### PR TITLE
Added support for tunneled PUT and DELETE requests through POST (Issue #171)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 
 Version 1.1.11 work in progress
 -------------------------------
+- Enh #171: Added support for PUT and DELETE request tunneled through POST via parameter named _method in POST body (musterknabe)
 
 
 Version 1.1.10 February 12, 2012


### PR DESCRIPTION
If the parameter _method=PUT|DELETE is present in the POST body the request is treated like a real PUT or DELETE request and routed accordingly.
