### PR TITLE
Issue #124 

### DIFF
--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -699,6 +699,7 @@ class YiiBase
 		'CMssqlSchema' => '/db/schema/mssql/CMssqlSchema.php',
 		'CMssqlTableSchema' => '/db/schema/mssql/CMssqlTableSchema.php',
 		'CMysqlColumnSchema' => '/db/schema/mysql/CMysqlColumnSchema.php',
+		'CMysqlCommandBuilder' => '/db/schema/mysql/CMysqlCommandBuilder.php',
 		'CMysqlSchema' => '/db/schema/mysql/CMysqlSchema.php',
 		'CMysqlTableSchema' => '/db/schema/mysql/CMysqlTableSchema.php',
 		'COciColumnSchema' => '/db/schema/oci/COciColumnSchema.php',

--- a/framework/db/schema/mysql/CMysqlCommandBuilder.php
+++ b/framework/db/schema/mysql/CMysqlCommandBuilder.php
@@ -1,0 +1,96 @@
+<?php
+class CMysqlCommandBuilder extends CDbCommandBuilder
+{
+	/**
+	 * Creates an UPDATE command.
+	 * @param mixed $table the table schema ({@link CDbTableSchema}) or the table name (string).
+	 * @param array $data list of columns to be updated (name=>value)
+	 * @param CDbCriteria $criteria the query criteria
+	 * @return CDbCommand update command.
+	 */
+	public function createUpdateCommand($table,$data,$criteria)
+	{
+		$this->ensureTable($table);
+		$fields=array();
+		$values=array();
+		$bindByPosition=isset($criteria->params[0]);
+		$i=0;
+		foreach($data as $name=>$value)
+		{
+			if(($column=$table->getColumn($name))!==null)
+			{
+				if($value instanceof CDbExpression)
+				{
+					$fields[]=$column->rawName.'='.$value->expression;
+					foreach($value->params as $n=>$v)
+						$values[$n]=$v;
+				}
+				else if($bindByPosition)
+				{
+					$fields[]=$column->rawName.'=?';
+					$values[]=$column->typecast($value);
+				}
+				else
+				{
+					$fields[]=$column->rawName.'='.self::PARAM_PREFIX.$i;
+					$values[self::PARAM_PREFIX.$i]=$column->typecast($value);
+					$i++;
+				}
+			}
+		}
+		if($fields===array())
+			throw new CDbException(Yii::t('yii','No columns are being updated for table "{table}".',
+				array('{table}'=>$table->name)));
+		$sql="UPDATE {$table->rawName}";
+		$sql=$this->applyJoin($sql,$criteria->join);
+		$sql.=" SET ".implode(', ',$fields);
+		$sql=$this->applyCondition($sql,$criteria->condition);
+		$sql=$this->applyOrder($sql,$criteria->order);
+		$sql=$this->applyLimit($sql,$criteria->limit,$criteria->offset);
+
+		$command=$this->getDbConnection()->createCommand($sql);
+		$this->bindValues($command,array_merge($values,$criteria->params));
+
+		return $command;
+	}
+	
+	/**
+	 * Creates an UPDATE command that increments/decrements certain columns.
+	 * @param mixed $table the table schema ({@link CDbTableSchema}) or the table name (string).
+	 * @param array $counters counters to be updated (counter increments/decrements indexed by column names.)
+	 * @param CDbCriteria $criteria the query criteria
+	 * @return CDbCommand the created command
+	 * @throws CException if no counter is specified
+	 */
+	public function createUpdateCounterCommand($table,$counters,$criteria)
+	{
+		$this->ensureTable($table);
+		$fields=array();
+		foreach($counters as $name=>$value)
+		{
+			if(($column=$table->getColumn($name))!==null)
+			{
+				$value=(int)$value;
+				if($value<0)
+					$fields[]="{$column->rawName}={$column->rawName}-".(-$value);
+				else
+					$fields[]="{$column->rawName}={$column->rawName}+".$value;
+			}
+		}
+		if($fields!==array())
+		{
+			$sql="UPDATE {$table->rawName}";
+			$sql=$this->applyJoin($sql,$criteria->join);
+			$sql.=" SET ".implode(', ',$fields);
+			$sql=$this->applyCondition($sql,$criteria->condition);
+			$sql=$this->applyOrder($sql,$criteria->order);
+			$sql=$this->applyLimit($sql,$criteria->limit,$criteria->offset);
+			$command=$this->getDbConnection()->createCommand($sql);
+			$this->bindValues($command,$criteria->params);
+			return $command;
+		}
+		else
+			throw new CDbException(Yii::t('yii','No counter columns are being updated for table "{table}".',
+				array('{table}'=>$table->name)));
+	}
+}

--- a/framework/db/schema/mysql/CMysqlSchema.php
+++ b/framework/db/schema/mysql/CMysqlSchema.php
@@ -254,7 +254,17 @@ class CMysqlSchema extends CDbSchema
 			$name=$schema.'.'.$name;
 		return $names;
 	}
-
+	
+	/**
+	 * Creates a command builder for the database.
+	 * This method overrides parent implementation in order to create a MySQL specific command builder
+	 * @return CDbCommandBuilder command builder instance
+	 */
+	protected function createCommandBuilder()
+	{
+		return new CMysqlCommandBuilder($this);
+	}
+	
 	/**
 	 * Builds a SQL statement for renaming a column.
 	 * @param string $table the table whose column is to be renamed. The name will be properly quoted by the method.


### PR DESCRIPTION
New attempt: The Command builder will construct update queries that do not take MySQLs needs into account when joins are being involved.

An example from the blog demo:

<pre>Post::model()->updateAll(array(
    'content'=>'m00',
), array(
    'join'=>'JOIN {{user}} u ON `author_id`=u.`id`',
    'condition'=>'u.`username`="demo"',
));
</pre>


This will produce a query like this:
UPDATE table SET column='value' JOIN table2 ON id=id2
`UPDATE `tbl_post` SET `content`=:yp0 JOIN tbl_user u ON `author_id`=u.`id` WHERE u.`username`="demo";`
But MySQL expects the query to be like this:
`UPDATE `tbl_post` JOIN tbl_user u ON `author_id` = u.`id` SET `content`=:yp0 WHERE u.`username`="demo";`

See:
- http://dev.mysql.com/doc/refman/5.1/en/update.html
- http://dev.mysql.com/doc/refman/5.1/en/join.html
