### PR TITLE
improved extendability of CDetailView

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ Version 1.1.11 work in progress
 -------------------------------
 - Enh #171: Added support for PUT and DELETE request tunneled through POST via parameter named _method in POST body (musterknabe)
 - Enh #266: Add support for HTML5 url, email, number, range and date fields to CHtml (gregmolnar)
-- Enh #356: Improved extendability of CDetailView by adding method renderItemRow() (cebe)
+- Enh #356: Improved extendability of CDetailView by adding method renderItem() (cebe)
 
 Version 1.1.10 February 12, 2012
 --------------------------------

--- a/framework/zii/widgets/CDetailView.php
+++ b/framework/zii/widgets/CDetailView.php
@@ -215,7 +215,7 @@ class CDetailView extends CWidget
 
 			$tr['{value}']=$value===null ? $this->nullDisplay : $formatter->format($value,$attribute['type']);
 
-			$this->renderItemRow($attribute, $tr);
+			$this->renderItem($attribute, $tr);
 
 			$i++;
 		}
@@ -227,13 +227,13 @@ class CDetailView extends CWidget
 	/**
 	 * This method is used by run() to render item row
 	 *
-	 * @param array $rowAttributes config attributes for this row from {@link attributes}
+	 * @param array $options config options for this item/attribute from {@link attributes}
 	 * @param string $templateData data that will be inserted into {@link itemTemplate}
 	 * @since 1.1.11
 	 */
-	protected function renderItemRow($rowAttributes,$templateData)
+	protected function renderItem($options,$templateData)
 	{
-		echo strtr(isset($rowAttributes['template']) ? $rowAttributes['template'] : $this->itemTemplate,$templateData);
+		echo strtr(isset($options['template']) ? $options['template'] : $this->itemTemplate,$templateData);
 	}
 
 	/**


### PR DESCRIPTION
makes it possible to change the way rows are rendered
by overwriting method renderItemRow()
before you had to copy the whole run() method to make
some changes to the row rendering.

also added the possibility to set tagName to null so
no tag will be rendered then.

this fixes issue #251

My use case for this is that I want to use CDetailView in plain text email template and need to exted it to properly render the content like this:

```
Label1:     Value1
LongLabel2: Value2
short:      Value3
```
