### PR TITLE
Fixes Gii to properly find the generator when CUrlManager.caseSensitive=false

### DIFF
--- a/framework/gii/GiiModule.php
+++ b/framework/gii/GiiModule.php
@@ -211,6 +211,9 @@ class GiiModule extends CWebModule
 			$names=scandir($path);
 			foreach($names as $name)
 			{
+				if(Yii::app()->getUrlManager()->caseSensitive===false)
+					$name=strtolower($name);
+
 				if($name[0]!=='.' && is_dir($path.'/'.$name))
 				{
 					$className=ucfirst($name).'Generator';


### PR DESCRIPTION
Fixes #229.

This fix makes the Gii Module to store the generator name according to the CUrlManager.caseSensitive configuration and to fill its controllerMap with the correct data.
