### PR TITLE
Added support to register the messages directory for extensions.

### DIFF
--- a/framework/i18n/CPhpMessageSource.php
+++ b/framework/i18n/CPhpMessageSource.php
@@ -61,6 +61,22 @@ class CPhpMessageSource extends CMessageSource
 	 * the "messages" subdirectory of the application directory (e.g. "protected/messages").
 	 */
 	public $basePath;
+	/**
+	 * @var array the messages path for extensions.
+	 * The format of the array should be:
+	 * <pre>
+	 * array(
+	 *     'ExtensionName' => 'ext.ExtensionName.messages',
+	 * )
+	 * </pre>
+	 * Where the key is the name of the extension and the value is the alias to the path
+	 * of the "messages" subdirectory of the extension.
+	 * When using Yii::t() to translate an extension message, the category name should be
+	 * set as 'ExtensionName.categoryName'.
+	 * Defaults to an empty array, meaning no extensions registered.
+	 * @since 1.1.11
+	 */
+	public $extensionBasePaths=array();
 
 	private $_files=array();
 
@@ -92,10 +108,17 @@ class CPhpMessageSource extends CMessageSource
 		{
 			if(($pos=strpos($category,'.'))!==false)
 			{
-				$moduleClass=substr($category,0,$pos);
-				$moduleCategory=substr($category,$pos+1);
-				$class=new ReflectionClass($moduleClass);
-				$this->_files[$category][$language]=dirname($class->getFileName()).DIRECTORY_SEPARATOR.'messages'.DIRECTORY_SEPARATOR.$language.DIRECTORY_SEPARATOR.$moduleCategory.'.php';
+				$extensionClass=substr($category,0,$pos);
+				$extensionCategory=substr($category,$pos+1);
+				// First check if there's an extension registered for this class.
+				if (isset($this->extensionBasePaths[$extensionClass]))
+					$this->_files[$category][$language]=Yii::getPathOfAlias($this->extensionBasePaths[$extensionClass]).DIRECTORY_SEPARATOR.$language.DIRECTORY_SEPARATOR.$extensionCategory.'.php';
+				else
+				{
+					// No extension registered, need to find it.
+					$class=new ReflectionClass($extensionClass);
+					$this->_files[$category][$language]=dirname($class->getFileName()).DIRECTORY_SEPARATOR.'messages'.DIRECTORY_SEPARATOR.$language.DIRECTORY_SEPARATOR.$extensionCategory.'.php';
+				}
 			}
 			else
 				$this->_files[$category][$language]=$this->basePath.DIRECTORY_SEPARATOR.$language.DIRECTORY_SEPARATOR.$category.'.php';


### PR DESCRIPTION
Fixes #117.

I'm providing a path for CPhpMessageSource with a property called "extensionBasePaths". It is used to register a messages directory for the extension.
See the example configuration for it:

``` php
'components' => array(
  'messages' => array (
    'extensionBasePaths' => array(
      'giix' => 'ext.giix.messages',
    ),
  ),
),
```
