### PR TITLE
Fixes issue 369 (Cache key prefixes and custom serializer)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Version 1.1.11 work in progress
 - Enh: Added full-featured behaviors and events CConsoleCommand::onBeforeAction & CConsoleCommand::onAfterAction (Yiivgeny)
 - Enh #171: Added support for PUT and DELETE request tunneled through POST via parameter named _method in POST body (musterknabe)
 - Enh #266: Add support for HTML5 url, email, number, range and date fields to CHtml (gregmolnar)
+- Enh #369: Added $hashKey and $autoSerialize properties as well as serializeValue() and unserializeValue() methods to CCache (kidol)
 - Bug #193: Changed datetime column type for postgresql from 'time' to 'timestamp' (cebe)
 - Enh: Added getIsFlashRequest(), proper handling of Flash/Flex request when using CWebLogRoute with FireBug (resurtm)
 - Enh: Added CBreadcrumbs::$activeLinkTemplate and CBreadcrumbs::$inactiveLinkTemplate properties which allows to change each item's template (resurtm)


### PR DESCRIPTION
@qiangxue I choose to drop inbuild support for "native serializers". Reason is that it's not reliable. Apc for example supports PHP structures as well but has problems with multidimensional arrays (that's what I've read at least). My Apache crashed when testing this with XCache + a dependency. I did not test Memcache. However, developers may override serializeValue() / unserializeValue() to simply return the $value.
