### PR TITLE
282 allow c check box column header to behave like normal datacolumn

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,8 +4,8 @@
 
 Version 1.1.11 work in progress
 -------------------------------
-- Enh #282: Added visible option for the CheckBox placed in the header cell by CCheckBoxColumn (pentium10)
 - Bug #145: CGettextMoFile now can parse strings with no context (eagleoneraptor)
+- Enh #282: Added template and htmlOptions for the CheckBox placed in the header cell by CCheckBoxColumn (pentium10)
 - Enh: Added full-featured behaviors and events CConsoleCommand::onBeforeAction & CConsoleCommand::onAfterAction (Yiivgeny)
 - Enh #171: Added support for PUT and DELETE request tunneled through POST via parameter named _method in POST body (musterknabe)
 - Enh #266: Add support for HTML5 url, email, number, range and date fields to CHtml (gregmolnar)

--- a/framework/zii/widgets/grid/CCheckBoxColumn.php
+++ b/framework/zii/widgets/grid/CCheckBoxColumn.php
@@ -16,7 +16,7 @@ Yii::import('zii.widgets.grid.CGridColumn');
  * CCheckBoxColumn supports no selection (read-only), single selection and multiple selection.
  * The mode is determined according to {@link selectableRows}. When in multiple selection mode, the header cell will display
  * an additional checkbox, clicking on which will check or uncheck all of the checkboxes in the data cells.
- * This additional checkbox in the header cell can be made hidden by {@link $headerCheckBoxVisible} default true (visible).
+ * The header cell can be customized by {@link headerTemplate}.
  *
  * Additionally selecting a checkbox can select a grid view row (depending on {@link CGridView::selectableRows} value) if
  * {@link selectableRows} is null (default).
@@ -62,6 +62,10 @@ class CCheckBoxColumn extends CGridColumn
 	 */
 	public $headerHtmlOptions=array('class'=>'checkbox-column');
 	/**
+	 * @var array the HTML options for the header cell checkbox tag.
+	 */
+	public $headerItemHtmlOptions=array();
+	/**
 	 * @var array the HTML options for the footer cell tag.
 	 */
 	public $footerHtmlOptions=array('class'=>'checkbox-column');
@@ -84,11 +88,15 @@ class CCheckBoxColumn extends CGridColumn
 	 * @since 1.1.6
 	 */
 	public $selectableRows=null;
-        /**
-         * @var boolean whether the CheckBox in header ccolumn is visible. Defaults to true.
-         * @since 1.1.11
-         */
-        public $headerCheckBoxVisible=true;
+	 /**
+	 * @var string the template used to render the header cell. Defaults to a checkbox when {@link selectableRows} is greater than 1
+	 * or in case {@link selectableRows} is null when {@link CGridView::selectableRows} is greater than 1.
+	 *
+	 * The token recognized: "{item}". It will be replaced with the checkbox.
+	 *
+	 * @see selectableRows
+	 */
+	public $headerTemplate='{item}';
 
 	/**
 	 * Initializes the column.
@@ -127,9 +135,9 @@ class CCheckBoxColumn extends CGridColumn
 			//.. only one can be checked, uncheck all other
 			$cbcode="$(\"input:not(#\"+this.id+\")[name='$name']\").prop('checked',false);";
 		}
-		else
+		elseif(!empty($this->headerTemplate) && strpos($this->headerTemplate,'{item}')!==false)
 		{
-			//.. process check/uncheck all
+			//.. process check/uncheck all only when there is an item requested
 			$cball=<<<CBALL
 $('#{$this->id}_all').live('click',function() {
 	var checked=this.checked;
@@ -141,12 +149,16 @@ CBALL;
 		}
 
 		$js=$cball;
-		$js.=<<<EOD
+		if($cbcode)
+		{
+			
+			$js.=<<<EOD
 $("input[name='$name']").live('click', function() {
 	$cbcode
 });
 EOD;
-		Yii::app()->getClientScript()->registerScript(__CLASS__.'#'.$this->id,$js);
+			Yii::app()->getClientScript()->registerScript(__CLASS__.'#'.$this->id,$js);
+		}
 	}
 
 	/**
@@ -155,13 +167,19 @@ EOD;
 	 * or in case {@link selectableRows} is null when {@link CGridView::selectableRows} is greater than 1.
 	 */
 	protected function renderHeaderCellContent()
-	{                
-		if($this->headerCheckBoxVisible!==false && $this->selectableRows===null && $this->grid->selectableRows>1)
-			echo CHtml::checkBox($this->id.'_all',false,array('class'=>'select-on-check-all'));
-		else if($this->headerCheckBoxVisible!==false && $this->selectableRows>1)
-			echo CHtml::checkBox($this->id.'_all',false);
+	{
+		if(empty($this->headerTemplate)) return '';
+		if($this->selectableRows===null && $this->grid->selectableRows>1)
+                {
+                    $this->headerItemHtmlOptions['class']=trim('select-on-check-all'.' '.$this->headerItemHtmlOptions['class']);
+			$tr['{item}']=CHtml::checkBox($this->id.'_all',false,$this->headerItemHtmlOptions);
+                }
+		else if($this->selectableRows>1)
+			$tr['{item}']=CHtml::checkBox($this->id.'_all',false,$this->headerItemHtmlOptions);
 		else
-			parent::renderHeaderCellContent();
+			$tr['{item}']=parent::renderHeaderCellContent();
+		
+		echo strtr($this->headerTemplate,$tr);
 	}
 
 	/**


### PR DESCRIPTION
We resolved this by adding a $headerCheckBoxVisible property to CCheckBoxColumn. When that is set to false, the header cell will act as a normal one, so for example you can set a header even if $selectableRows is 2.

Issue #282
