### PR TITLE
Fix for issue #385

### DIFF
--- a/framework/web/CClientScript.php
+++ b/framework/web/CClientScript.php
@@ -205,6 +205,7 @@ class CClientScript extends CApplicationComponent
 			$this->renderBodyBegin($output);
 			$this->renderBodyEnd($output);
 		}
+		$this->scripts=array();
 	}
 
 	/**


### PR DESCRIPTION
Avoid duplicated scripts <no scriptFiles> when processing output using renderPartial function within a view that previously registers scripts.
