### PR TITLE
Sometimes CJSON::decode returns null because native json_encode has bugs and returns null

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 
 Version 1.1.11 work in progress
 -------------------------------
+- Bug #295: Sometimes CJSON::decode returns null because native json_encode has bugs and returns null. Workaround to continue decoding when result of json_decode is null (luislobo)
 - Bug #145: CGettextMoFile now can parse strings with no context (eagleoneraptor)
 - Enh: Added full-featured behaviors and events CConsoleCommand::onBeforeAction & CConsoleCommand::onAfterAction (Yiivgeny)
 - Enh #171: Added support for PUT and DELETE request tunneled through POST via parameter named _method in POST body (musterknabe)

--- a/framework/web/helpers/CJSON.php
+++ b/framework/web/helpers/CJSON.php
@@ -324,7 +324,13 @@ class CJSON
 	public static function decode($str, $useArray=true)
 	{
 		if(function_exists('json_decode'))
-			return json_decode($str,$useArray);
+			$json = json_decode($str,$useArray);
+
+		// based on investigation, native fails sometimes returning null.
+		// see: http://gggeek.altervista.org/sw/article_20070425.html
+		// As of PHP 5.3.6 it still fails on some valid JSON strings
+		if(!is_null($json))
+			return $json;
 
 		$str = self::reduceString($str);
 


### PR DESCRIPTION
Workaround to continue decoding when result of json_decode is null. Fixes #295
