### PR TITLE
Fix for #224

### DIFF
--- a/framework/db/CDbCommand.php
+++ b/framework/db/CDbCommand.php
@@ -603,7 +603,7 @@ class CDbCommand extends CComponent
 				else if(strpos($column,'(')===false)
 				{
 					if(preg_match('/^(.*?)(?i:\s+as\s+|\s+)(.*)$/',$column,$matches))
-						$columns[$i]=$this->_connection->quoteColumnName($matches[1]).' AS '.$this->_connection->getSchema()->quoteSimpleTableName($matches[2]);
+						$columns[$i]=$this->_connection->quoteColumnName($matches[1]).' AS '.$this->_connection->quoteSimpleColumnName($matches[2]);
 					else
 						$columns[$i]=$this->_connection->quoteColumnName($column);
 				}

--- a/framework/db/CDbConnection.php
+++ b/framework/db/CDbConnection.php
@@ -574,6 +574,17 @@ class CDbConnection extends CApplicationComponent
 	{
 		return $this->getSchema()->quoteColumnName($name);
 	}
+	
+	/**
+	 * Quotes a column name for use in a query.
+	 * A simple column name does not contain prefix.
+	 * @param string $name column name
+	 * @return string the properly quoted column name
+	 */
+	public function quoteSimpleColumnName($name)
+	{
+		return $this->getSchema()->quoteSimpleColumnName($name);
+	}
 
 	/**
 	 * Determines the PDO type for the specified PHP type.


### PR DESCRIPTION
Attempt to fix #224

CDbCommand->select() : 'as' portion is quoted like a table

AS part of SELECT is quoted as if it were a table name. In some cases the '.' character is needed, so the quotes should be around the entire string.
