### PR TITLE
yiic message changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ Version 1.1.11 work in progress
 - Enh #369: Added $hashKey and $autoSerialize properties as well as serializeValue() and unserializeValue() methods to CCache (kidol)
 - Enh #237: The tabs of CTabView now support the property 'visible' (DaSourcerer)
 - Enh #356: Improved extendability of CDetailView by adding method renderItem() (cebe)
+- Enh #414: Added sort parameter to yiic message command that sorts messages by key when merging (ranvis)
 - Enh: Added getIsFlashRequest(), proper handling of Flash/Flex request when using CWebLogRoute with FireBug (resurtm)
 - Enh: Added CBreadcrumbs::$activeLinkTemplate and CBreadcrumbs::$inactiveLinkTemplate properties which allows to change each item's template (resurtm)
 - Enh: Added full-featured behaviors and events CConsoleCommand::onBeforeAction & CConsoleCommand::onAfterAction (Yiivgeny)

--- a/framework/cli/commands/MessageCommand.php
+++ b/framework/cli/commands/MessageCommand.php
@@ -59,6 +59,8 @@ PARAMETERS
    - overwrite: if message file must be overwritten with the merged messages.
    - removeOld: if message no longer needs translation it will be removed,
      instead of being enclosed between a pair of '@@' marks.
+   - sort: sort messages by key when merging, regardless of their translation
+     state (new, obsolete, translated.)
 
 EOD;
 	}
@@ -92,6 +94,9 @@ EOD;
 
 		if(!isset($removeOld))
 			$removeOld = false;
+
+		if(!isset($sort))
+			$sort = false;
 		
 		$options=array();
 		if(isset($fileTypes))
@@ -112,7 +117,7 @@ EOD;
 			foreach($messages as $category=>$msgs)
 			{
 				$msgs=array_values(array_unique($msgs));
-				$this->generateMessageFile($msgs,$dir.DIRECTORY_SEPARATOR.$category.'.php',$overwrite,$removeOld);
+				$this->generateMessageFile($msgs,$dir.DIRECTORY_SEPARATOR.$category.'.php',$overwrite,$removeOld,$sort);
 			}
 		}
 	}
@@ -135,7 +140,7 @@ EOD;
 		return $messages;
 	}
 
-	protected function generateMessageFile($messages,$fileName,$overwrite,$removeOld)
+	protected function generateMessageFile($messages,$fileName,$overwrite,$removeOld,$sort)
 	{
 		echo "Saving messages to $fileName...";
 		if(is_file($fileName))
@@ -174,6 +179,8 @@ EOD;
 				}
 			}
 			$merged=array_merge($todo,$merged);
+			if($sort)
+				ksort($merged);
 			if($overwrite === false)
 				$fileName.='.merged';
 			echo "translation merged.\n";


### PR DESCRIPTION
Two changes to yiic message command:
- Avoid piling up obsolete marks of MessageCommand.
  Make @@ marks not to pile up when yiic message command is executed.
- Add sort parameter to MessageCommand that sort messages when merging.
  Usually untranslated string is merged on top of messages.
  By setting 'sort'=>true everything is sorted by key and diff output will be smaller across updates.
