### PR TITLE
417 CAttributeCollection mergeWith does not take into account $caseSensitive

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@ Version 1.1.11 work in progress
 - Enh: Added getIsFlashRequest(), proper handling of Flash/Flex request when using CWebLogRoute with FireBug (resurtm)
 - Enh: Added CBreadcrumbs::$activeLinkTemplate and CBreadcrumbs::$inactiveLinkTemplate properties which allows to change each item's template (resurtm)
 - Enh: Added full-featured behaviors and events CConsoleCommand::onBeforeAction & CConsoleCommand::onAfterAction (Yiivgeny)
+- Bug #417: CAttributeCollections::mergeWith() does not take into account the caseSensitive (dmtrs)
 
 Version 1.1.10 February 12, 2012
 --------------------------------

--- a/framework/collections/CAttributeCollection.php
+++ b/framework/collections/CAttributeCollection.php
@@ -182,4 +182,33 @@ class CAttributeCollection extends CMap
 	{
 		return true;
 	}
+
+	/**
+	 * Merges iterable data into the map.
+	 *
+	 * Existing elements in the map will be overwritten if their keys are the same as those in the source.
+	 * If the merge is recursive, the following algorithm is performed:
+	 * <ul>
+	 * <li>the map data is saved as $a, and the source data is saved as $b;</li>
+	 * <li>if $a and $b both have an array indexed at the same string key, the arrays will be merged using this algorithm;</li>
+	 * <li>any integer-indexed elements in $b will be appended to $a and reindexed accordingly;</li>
+	 * <li>any string-indexed elements in $b will overwrite elements in $a with the same index;</li>
+	 * </ul>
+	 *
+	 * @param mixed $data the data to be merged with, must be an array or object implementing Traversable
+	 * @param boolean $recursive whether the merging should be recursive.
+	 *
+	 * @throws CException If data is neither an array nor an iterator.
+	 */
+	public function mergeWith($data,$recursive=true)
+	{
+		if(!$this->caseSensitive && (is_array($data) || $data instanceof Traversable))
+		{
+            $d=array();
+            foreach($data as $key=>$value)
+                $d[strtolower($key)]=$value;
+            return parent::mergeWith($d,$recursive);
+		}
+    parent::mergeWith($data,$recursive);
+	}
 }

--- a/tests/framework/collections/CAttributeCollectionTest.php
+++ b/tests/framework/collections/CAttributeCollectionTest.php
@@ -103,4 +103,24 @@ class CAttributeCollectionTest extends CTestCase
 		$collection->Property = 'value';
 		$this->assertEquals(true, $collection->hasProperty('Property'));
 	}
+
+  public function testMergeWithCaseSensitive()
+  {
+    $collection = new CAttributeCollection();
+    $item = array('Test'=>'Uppercase');
+    $collection->mergeWith($item);
+    $this->assertEquals('Uppercase', $collection->itemAt('test'));
+  }
+
+  public function testMergeWithCaseInSensitive()
+  {
+    $collection = new CAttributeCollection();
+    $collection->caseSensitive = true;
+    $collection->add('k1','item');
+
+    $item = array('K1'=>'ITEM');
+    $collection->mergeWith($item);
+    $this->assertEquals('item', $collection->itemAt('k1'));
+    $this->assertEquals('ITEM', $collection->itemAt('K1'));
+  }
 }


### PR DESCRIPTION
As discussed in the ticket [#417](https://github.com/yiisoft/yii/issues/417) when merging in an attribute collection the caseSensitive property does not work.
I don't think this fix is the better provided due to some issue I had resolving the issue.
The <code>CAttributeCollection</code> does not have access to <code>private CMap::_d</code>, this means I could not use <code>parent::mergeArray</code> with first argument the actual collection. So, I had to call the <code>CMap::mergeWith()</code> which do same checks.
