### PR TITLE
[auth test] Handle case-sensitive db

### DIFF
--- a/tests/framework/web/auth/CDbAuthManagerTest.php
+++ b/tests/framework/web/auth/CDbAuthManagerTest.php
@@ -32,6 +32,9 @@ class CDbAuthManagerTest extends AuthManagerTestBase
 		$this->db->active=false;
 
 		$this->auth=new CDbAuthManager;
+		$this->auth->assignmentTable = 'authassignment';
+		$this->auth->itemChildTable = 'authitemchild';
+		$this->auth->itemTable = 'authitem';
 		$this->auth->db=$this->db;
 		$this->auth->init();
 		$this->prepareData();


### PR DESCRIPTION
By default CDbAuthManager uses upper camel case table names, on the contrary schema for test uses lowercase for table names, this fix will make auth test passes against case-sensitive db (pgsql).
