### PR TITLE
Patch to support named parameter as array value in CUrlRule

### DIFF
--- a/framework/web/CUrlManager.php
+++ b/framework/web/CUrlManager.php
@@ -757,7 +757,7 @@ class CUrlRule extends CBaseUrlRule
 
 		foreach($this->params as $key=>$value)
 		{
-			$tr["<$key>"]=urlencode($params[$key]);
+			$tr["<$key>"] = is_array($params[$key]) ? $manager->createPathInfo(array($key => $params[$key]), '/', '/') : urlencode($params[$key]);
 			unset($params[$key]);
 		}
 


### PR DESCRIPTION
Patch to support named parameter as array value. Currently if you specify a route such as 'controller/<id>', and $id is an array, CUrlRule will toss an error while attempting to urlencode the array. This fixes the issue, and routes still function properly in my tests.
