### PR TITLE
mention the CChoiceFormat param name in Yii::t doc

### DIFF
--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -557,6 +557,7 @@ class YiiBase
 	 * an appropriate message translation.
 	 * Starting from version 1.1.6 you can pass parameter for {@link CChoiceFormat::format}
 	 * or plural forms format without wrapping it with array.
+	 * This parameter is then available as <code>{n}</code> in the message translation string.
 	 * @param string $source which message source application component to use.
 	 * Defaults to null, meaning using 'coreMessages' for messages belonging to
 	 * the 'yii' category and using 'messages' for the rest messages.


### PR DESCRIPTION
added doc line to $params parameter of Yii::t that mentions the name of
the CChoiceFormat parameter in translation message strings. {n}

took me some time to figure that out, should be directly there where I put it now.
