### PR TITLE
Fixed session-restore failure for symlinked Yii apps (like Capistrano deployments)

### DIFF
--- a/framework/base/CApplication.php
+++ b/framework/base/CApplication.php
@@ -211,7 +211,7 @@ abstract class CApplication extends CModule
 		if($this->_id!==null)
 			return $this->_id;
 		else
-			return $this->_id=sprintf('%x',crc32($this->getBasePath().$this->name));
+			return $this->_id=sprintf('%x',crc32(php_uname().$this->name));
 	}
 
 	/**


### PR DESCRIPTION
In its current state, Yii is **not compatible** with apps that are deployed via changing symlinks; for example,  Capistrano maintains a `releases/` folder with each deployed version of your app, and a `current/` symlink that points to your current version of the app, so you can revert quickly if there is a problem, and maintain a history of the deployed version of the app.  When you change the absolute location of your protected folder, Yii's session prefix changes, and no pre-existing sessions will be resolved, so all users will be logged out and auto-logins will fail.

Prior to this commit, the config param `basePath` would pass through `realpath()` and symlinks are resolved (actually nearly impossible to get the un-symlink-resolved location of the current file in PHP), then this path would be used in `CApplication::getId()` to generate a unique ID for the application.  When a user visits your Yii app, `CWebUser::getStateKeyPrefix()` is used to generate a session key prefix - this function uses the aforementioned `CApplication::getId()` function, which is filesystem location-dependent.  If you change the absolute path of your `protected/` folder (aka basePath) by syminking or otherwise, `getId()` is changed, so `getStateKeyPrefix()` is changed, so your session variables cannot be restored.  **This means that 1) all your users are logged out; and 2) the auto-login feature will not work since the key prefix is different.**

This commit changes the `CApplication::getId()` method to use `php_uname()` (works on all platforms) instead of the `getBasePath()` to keep similar uniqueness, while removing the need for the absolute filesystem location of `protected/` to remain the same.
