### PR TITLE
#517 Fix rule parameter sub-pattern check.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ Version 1.1.11 work in progress
 - Bug #417: CAttributeCollections::mergeWith() does not take into account the caseSensitive (dmtrs)
 - Bug #433: Fixed the bug that Gii model name input autocomplete was not working sometimes (mdomba)
 - Bug #454: Removed translation on CDbConnection exception as it was creating an endless loop if the application used CDbCache (mdomba)
+- Bug #517: Rule parameter sub-patterns are not checked correctly (ranvis)
 - Enh #136: Added ability to select database connection in Gii model generator (samdark)
 - Enh #165: Allow CCacheDependency to be reusable across multiple cache calls (phpnode)
 - Enh #171: Added support for PUT and DELETE request tunneled through POST via parameter named _method in POST body (musterknabe)

--- a/framework/web/CUrlManager.php
+++ b/framework/web/CUrlManager.php
@@ -750,7 +750,7 @@ class CUrlRule extends CBaseUrlRule
 		{
 			foreach($this->params as $key=>$value)
 			{
-				if(!preg_match('/'.$value.'/'.$case,$params[$key]))
+				if(!preg_match('/\A'.$value.'\z/'.$case,$params[$key]))
 					return false;
 			}
 		}

--- a/tests/TestHttpRequest.php
+++ b/tests/TestHttpRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+Yii::import('system.web.CHttpRequest');
+
+class TestHttpRequest extends CHttpRequest
+{
+	private $myPathInfo;
+	private $myScriptUrl;
+
+	public function getScriptUrl()
+	{
+		return $this->myScriptUrl;
+	}
+
+	public function setScriptUrl($value)
+	{
+		$this->myScriptUrl=$value;
+	}
+
+	public function getPathInfo()
+	{
+		return $this->myPathInfo;
+	}
+
+	public function setPathInfo($value)
+	{
+		$this->myPathInfo=$value;
+	}
+}

--- a/tests/framework/web/CUrlManagerTest.php
+++ b/tests/framework/web/CUrlManagerTest.php
@@ -1,34 +1,6 @@
 <?php
 
 Yii::import('system.web.CUrlManager');
-Yii::import('system.web.CHttpRequest');
-
-class TestHttpRequest extends CHttpRequest
-{
-	private $myPathInfo;
-	private $myScriptUrl;
-
-	public function getScriptUrl()
-	{
-		return $this->myScriptUrl;
-	}
-
-	public function setScriptUrl($value)
-	{
-		$this->myScriptUrl=$value;
-	}
-
-	public function getPathInfo()
-	{
-		return $this->myPathInfo;
-	}
-
-	public function setPathInfo($value)
-	{
-		$this->myPathInfo=$value;
-	}
-}
-
 
 class CUrlManagerTest extends CTestCase
 {

--- a/tests/framework/web/CUrlRuleTest.php
+++ b/tests/framework/web/CUrlRuleTest.php
@@ -1,0 +1,80 @@
+<?php
+
+Yii::import('system.web.CUrlManager');
+
+class CUrlRuleTest extends CTestCase
+{
+	private $app;
+
+	public function setUp()
+	{
+		$config=array(
+			'basePath'=>dirname(__FILE__),
+			'components'=>array(
+				'request'=>array(
+					'class'=>'TestHttpRequest',
+				),
+			),
+		);
+		$_SERVER['HTTP_HOST']='user.example.com';
+		$this->app=new TestApplication($config);
+	}
+
+	public function testParseUrlMatchValue()
+	{
+		$rules=array(
+			array(
+				'route'=>'article/read',
+				'pattern'=>'article/<id:\d+>',
+				'scriptUrl'=>'/apps/index.php',
+				'entries'=>array(
+					array(
+						'route'=>'article/read',
+						'params'=>array(
+							'id'=>'123',
+							'name1'=>'value1',
+						),
+						'url'=>'article/123?name1=value1',
+					),
+					array(
+						'route'=>'article/read',
+						'params'=>array(
+							'id'=>'abc',
+							'name1'=>'value1',
+						),
+						'url'=>false,
+					),
+					array(
+						'route'=>'article/read',
+						'params'=>array(
+							'id'=>"123\n",
+							'name1'=>'value1',
+						),
+						'url'=>false,
+					),
+					array(
+						'route'=>'article/read',
+						'params'=>array(
+							'id'=>'0x1',
+							'name1'=>'value1',
+						),
+						'url'=>false,
+					),
+				),
+			),
+		);
+		$um=new CUrlManager;
+		foreach($rules as $rule)
+		{
+			$this->app->request->baseUrl=null; // reset so that it can be determined based on scriptUrl
+			$this->app->request->scriptUrl=$rule['scriptUrl'];
+			$ur=new CUrlRule($rule['route'],$rule['pattern']);
+			$ur->matchValue=true;
+			foreach($rule['entries'] as $entry)
+			{
+				$url=$ur->createUrl($um,$entry['route'],$entry['params'],'&');
+				$this->assertEquals($entry['url'],$url);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Issue #517

In tests sub-patterns like `123\n`, `0x1` should be an error.
