### PR TITLE
#451 Fix CUrlRule::createUrl() error when $params contains an array.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Version 1.1.11 work in progress
 - Bug #381: Fixed the bug that Gii model name input could get misspelled when autocomplete is used (mdomba)
 - Bug #417: CAttributeCollections::mergeWith() does not take into account the caseSensitive (dmtrs)
 - Bug #433: Fixed the bug that Gii model name input autocomplete was not working sometimes (mdomba)
+- Bug #451: Fixed CUrlRule::createUrl() error when $params contains an array (ranvis)
 - Bug #454: Removed translation on CDbConnection exception as it was creating an endless loop if the application used CDbCache (mdomba)
 - Bug #517: Rule parameter sub-patterns are not checked correctly (ranvis)
 - Bug #539: Fixed CUrlRule::createUrl() to treat sub-patterns as Unicode as parseUrl() does (ranvis)

--- a/framework/web/CUrlManager.php
+++ b/framework/web/CUrlManager.php
@@ -743,8 +743,12 @@ class CUrlRule extends CBaseUrlRule
 		}
 
 		foreach($this->params as $key=>$value)
+		{
 			if(!isset($params[$key]))
 				return false;
+			if(is_array($params[$key]))
+				return false;
+		}
 
 		if($manager->matchValue && $this->matchValue===null || $this->matchValue)
 		{

--- a/tests/framework/web/CUrlManagerTest.php
+++ b/tests/framework/web/CUrlManagerTest.php
@@ -18,6 +18,7 @@ class CUrlManagerTest extends CTestCase
 			'<c:(post|comment)>s/*'=>'<c>/list',
 			'http://<user:\w+>.example.com/<lang:\w+>/profile'=>'user/profile',
 			'currency/<c:\p{Sc}>'=>'currency/info',
+			'edit/<model>/<a:(update|delete)>/<id>' => 'crud/<a>',
 		);
 		$entries=array(
 			array(
@@ -120,6 +121,21 @@ class CUrlManagerTest extends CTestCase
 				'route'=>'currency/info',
 				'params'=>array('c'=>'＄'),
 			),
+			array(
+				'pathInfo'=>'edit/user/update/123',
+				'route'=>'crud/update',
+				'params'=>array('model'=>'user','id'=>123),
+			),
+			array(
+				'pathInfo'=>'crud/update/model/company/id%5Ba%5D/123/id%5Bb%5D/abc',
+				'route'=>'crud/update/model/company/id%5Ba%5D/123/id%5Bb%5D/abc',
+				'params'=>array(),
+			),
+			array(
+				'pathInfo'=>'crud/update/model/company/id%5Ba%5D/123/id%5Bb%5D/abc',
+				'route'=>'crud/update/model/company/id%5Ba%5D/123/id%5Bb%5D/abc',
+				'params'=>array(),
+			),
 		);
 		$config=array(
 			'basePath'=>dirname(__FILE__),
@@ -168,6 +184,7 @@ class CUrlManagerTest extends CTestCase
 			'<c:(post|comment)>s/*'=>'<c>/list',
 			'http://<user:\w+>.example.com/<lang:\w+>/profile'=>'user/profile',
 			'currency/<c:\p{Sc}>'=>'currency/info',
+			'edit/<model>/<a:(update|delete)>/<id>' => 'crud/<a>',
 		);
 		$config=array(
 			'basePath'=>dirname(__FILE__),
@@ -299,6 +316,28 @@ class CUrlManagerTest extends CTestCase
 				'route'=>'currency/info',
 				'params'=>array(
 					'c'=>'＄',
+				),
+			),
+			array(
+				'scriptUrl'=>'/index.php',
+				'url'=>'/index.php/edit/user/update/123',
+				'url2'=>'/edit/user/update/123',
+				'url3'=>'/edit/user/update/123.html',
+				'route'=>'crud/update',
+				'params'=>array(
+					'model'=>'user',
+					'id'=>123,
+				),
+			),
+			array(
+				'scriptUrl'=>'/index.php',
+				'url'=>'/index.php/crud/update/model/company/id%5Ba%5D/123/id%5Bb%5D/abc',
+				'url2'=>'/crud/update/model/company/id%5Ba%5D/123/id%5Bb%5D/abc',
+				'url3'=>'/crud/update/model/company/id%5Ba%5D/123/id%5Bb%5D/abc.html',
+				'route'=>'crud/update',
+				'params'=>array(
+					'model'=>'company',
+					'id'=>array('a'=>'123','b'=>'abc'),
 				),
 			),
 		);


### PR DESCRIPTION
Fix for `CUrlManager->createUrl()` with array values in `$param`.

For instance, `CUrlManager->createUrl("a",array("id"=>array("b"=>"c","d"=>"e")))` fails with error "urlencode() expects parameter 1 to be string, array given" at `CUrlRule->createUrl()`.

I first tried supporting array rule parameter like `<ids[]>`, which ended up just bringing complex to URL path.
This fix avoids error just by not applying the specific rule, and lets the caller use the default URL constructor.

Related: pull #506, issue #451
