### PR TITLE
AR: Restore criteria on related model after find when using 'with' and 'scopes'.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ Version 1.1.11 work in progress
 - Bug #454: Removed translation on CDbConnection exception as it was creating an endless loop if the application used CDbCache (mdomba)
 - Bug #517: Rule parameter sub-patterns are not checked correctly (ranvis)
 - Bug #539: Fixed CUrlRule::createUrl() to treat sub-patterns as Unicode as parseUrl() does (ranvis)
+- Bug #553: Restore dbCriteria on related record after doing an AR-find with related scopes (marcovtwout)
 - Enh #136: Added ability to select database connection in Gii model generator (samdark)
 - Enh #165: Allow CCacheDependency to be reusable across multiple cache calls (phpnode)
 - Enh #171: Added support for PUT and DELETE request tunneled through POST via parameter named _method in POST body (musterknabe)

--- a/framework/db/ar/CActiveFinder.php
+++ b/framework/db/ar/CActiveFinder.php
@@ -217,6 +217,9 @@ class CActiveFinder extends CComponent
 
 			$relation=clone $relation;
 			$model=CActiveRecord::model($relation->className);
+
+			$oldDbCriteria = $model->getDbCriteria(false);
+
 			if($relation instanceof CActiveRelation)
 			{
 				$oldAlias=$model->getTableAlias(false,false);
@@ -271,6 +274,8 @@ class CActiveFinder extends CComponent
 					$relation->mergeWith($model->getDbCriteria(),true);
 				}
 			}
+
+			$model->setDbCriteria($oldDbCriteria);
 
 			// dynamic options
 			if($options!==null)


### PR DESCRIPTION
More information in: Issue #553

I already submitted a patch file in the issue page, but I figured to have a go at my first GIT-based contribution :)
