### PR TITLE
Separating by white space between date and time.

### DIFF
--- a/framework/i18n/data/ja.php
+++ b/framework/i18n/data/ja.php
@@ -172,7 +172,7 @@ return array (
     'medium' => 'H:mm:ss',
     'short' => 'H:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '午前',
   'pmName' => '午後',
   'orientation' => 'ltr',

--- a/framework/i18n/data/ja_jp.php
+++ b/framework/i18n/data/ja_jp.php
@@ -172,7 +172,7 @@ return array (
     'medium' => 'H:mm:ss',
     'short' => 'H:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '午前',
   'pmName' => '午後',
   'orientation' => 'ltr',

--- a/framework/i18n/data/zh.php
+++ b/framework/i18n/data/zh.php
@@ -247,7 +247,7 @@ return array (
     'medium' => 'ah:mm:ss',
     'short' => 'ah:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '上午',
   'pmName' => '下午',
   'orientation' => 'ltr',

--- a/framework/i18n/data/zh_cn.php
+++ b/framework/i18n/data/zh_cn.php
@@ -344,7 +344,7 @@ return array (
     'medium' => 'ah:mm:ss',
     'short' => 'ah:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '上午',
   'pmName' => '下午',
   'orientation' => 'ltr',

--- a/framework/i18n/data/zh_hans.php
+++ b/framework/i18n/data/zh_hans.php
@@ -247,7 +247,7 @@ return array (
     'medium' => 'ah:mm:ss',
     'short' => 'ah:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '上午',
   'pmName' => '下午',
   'orientation' => 'ltr',

--- a/framework/i18n/data/zh_hans_cn.php
+++ b/framework/i18n/data/zh_hans_cn.php
@@ -247,7 +247,7 @@ return array (
     'medium' => 'ah:mm:ss',
     'short' => 'ah:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '上午',
   'pmName' => '下午',
   'orientation' => 'ltr',

--- a/framework/i18n/data/zh_hans_hk.php
+++ b/framework/i18n/data/zh_hans_hk.php
@@ -247,7 +247,7 @@ return array (
     'medium' => 'ah:mm:ss',
     'short' => 'ah:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '上午',
   'pmName' => '下午',
   'orientation' => 'ltr',

--- a/framework/i18n/data/zh_hans_mo.php
+++ b/framework/i18n/data/zh_hans_mo.php
@@ -247,7 +247,7 @@ return array (
     'medium' => 'ah:mm:ss',
     'short' => 'ah:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '上午',
   'pmName' => '下午',
   'orientation' => 'ltr',

--- a/framework/i18n/data/zh_hans_sg.php
+++ b/framework/i18n/data/zh_hans_sg.php
@@ -247,7 +247,7 @@ return array (
     'medium' => 'ah:mm:ss',
     'short' => 'ahh:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '上午',
   'pmName' => '下午',
   'orientation' => 'ltr',

--- a/framework/i18n/data/zh_hant.php
+++ b/framework/i18n/data/zh_hant.php
@@ -247,7 +247,7 @@ return array (
     'medium' => 'ah:mm:ss',
     'short' => 'ah:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '上午',
   'pmName' => '下午',
   'orientation' => 'ltr',

--- a/framework/i18n/data/zh_hant_tw.php
+++ b/framework/i18n/data/zh_hant_tw.php
@@ -247,7 +247,7 @@ return array (
     'medium' => 'ah:mm:ss',
     'short' => 'ah:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '上午',
   'pmName' => '下午',
   'orientation' => 'ltr',

--- a/framework/i18n/data/zh_hk.php
+++ b/framework/i18n/data/zh_hk.php
@@ -344,7 +344,7 @@ return array (
     'medium' => 'ah:mm:ss',
     'short' => 'ah:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '上午',
   'pmName' => '下午',
   'orientation' => 'ltr',

--- a/framework/i18n/data/zh_mo.php
+++ b/framework/i18n/data/zh_mo.php
@@ -344,7 +344,7 @@ return array (
     'medium' => 'ah:mm:ss',
     'short' => 'ah:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '上午',
   'pmName' => '下午',
   'orientation' => 'ltr',

--- a/framework/i18n/data/zh_sg.php
+++ b/framework/i18n/data/zh_sg.php
@@ -344,7 +344,7 @@ return array (
     'medium' => 'ah:mm:ss',
     'short' => 'ah:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '上午',
   'pmName' => '下午',
   'orientation' => 'ltr',

--- a/framework/i18n/data/zh_tw.php
+++ b/framework/i18n/data/zh_tw.php
@@ -344,7 +344,7 @@ return array (
     'medium' => 'ah:mm:ss',
     'short' => 'ah:mm',
   ),
-  'dateTimeFormat' => '{1}{0}',
+  'dateTimeFormat' => '{1} {0}',
   'amName' => '上午',
   'pmName' => '下午',
   'orientation' => 'ltr',


### PR DESCRIPTION
In Japanese and Chinese locales, date and time are concatinated without any spaces. Then we got result such as `12/04/1716:00` from CDateFormatter::formatDateTime.

Though `2012年4月17日16時00分` is readable but the default option of formatDateTime is not long but medium. If `2012年4月17日 16時00分` would be presented to  some Asian users, there are no problem rather it's looking better.

And more, I mind the case creating a pattern from CDateFormatter::getDateTimeFormat() to use with CDateTimeParser::parse(). When re-parsing displayed text closely joined datetime is difficult to parse, isn't it? Additionally, most of JavaScript date time picking helpers are tested with white space separated datetime, I think.
