### PR TITLE
Added https support for CGoogleApi

### DIFF
--- a/framework/web/helpers/CGoogleApi.php
+++ b/framework/web/helpers/CGoogleApi.php
@@ -18,7 +18,7 @@
 class CGoogleApi
 {
 	public static function getBootstrapUrl(){
-		return (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != "off" ? 'https://' : 'http://') . 'www.google.com/jsapi';
+		return (Yii::app()->getRequest()->isSecureConnection ? 'https://' : 'http://') . 'www.google.com/jsapi';
 	}
 	
 	/**


### PR DESCRIPTION
this improvement checks if the current connection is running over https, if so the google api lib is also loaded over https. This prevents browser warnings.
