### PR TITLE
Suppressed a possible E_WARNING PHP error in CDbConnection::createPdoIns...

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 
 Version 1.1.11 work in progress
 -------------------------------
+- Bug: Suppressed a possible E_WARNING PHP error in CDbConnection::createPdoInstance() which might occured when the mysqlnd PDO driver was in use (kidol)
 - Bug #145: CGettextMoFile now can parse strings with no context (eagleoneraptor)
 - Bug #193: Changed datetime column type for postgresql from 'time' to 'timestamp' (cebe)
 - Bug #295: Sometimes CJSON::decode returns null because native json_encode has bugs and returns null. Workaround to continue decoding when result of json_decode is null (luislobo)

--- a/framework/db/CDbConnection.php
+++ b/framework/db/CDbConnection.php
@@ -418,7 +418,7 @@ class CDbConnection extends CApplicationComponent
 			if($driver==='mssql' || $driver==='dblib' || $driver==='sqlsrv')
 				$pdoClass='CMssqlPdoAdapter';
 		}
-		return new $pdoClass($this->connectionString,$this->username,
+		return @new $pdoClass($this->connectionString,$this->username,
 									$this->password,$this->_attributes);
 	}
 


### PR DESCRIPTION
...tance() which might occured when the mysqlnd PDO driver was in use

Summary: The native mysql PDO driver may trigger a E_WARNING which will just abort the script and is unlike a proper CDbException not catchable.

Before fix:

```
PHP warning
PDO::__construct() [<a href='pdo.--construct'>pdo.--construct</a>]: [2002] Es konnte keine Verbindung hergestellt werden, da der Zielcomputer die Verbindung verweigerte. (trying to connect via tcp://localhost:3306)
```

After fix:

```
CDbException
CDbConnection failed to open the DB connection: SQLSTATE[HY000] [2002] Es konnte keine Verbindung hergestellt werden, da der Zielcomputer die Verbindung verweigerte.
```

Related links:

https://bugs.php.net/bug.php?id=53185
http://www.yiiframework.com/forum/index.php/topic/31268-handle-stopped-database/
