### PR TITLE
changed CDbCommand::queryInternal from private to protected 

### DIFF
--- a/framework/db/CDbCommand.php
+++ b/framework/db/CDbCommand.php
@@ -456,7 +456,7 @@ class CDbCommand extends CComponent
 	 * binding methods and  the input parameters this way can improve the performance.
 	 * @return mixed the method execution result
 	 */
-	private function queryInternal($method,$mode,$params=array())
+	protected function queryInternal($method,$mode,$params=array())
 	{
 		$params=array_merge($this->params,$params);
 


### PR DESCRIPTION
Much easier to extend functionality of CDbCommand so you can override queryInternal instead of the 5 query functions (query, queryAll, queryRow, queryColumn, queryScalar) that call it
