### PR TITLE
Added filterHtmlOptions property to the CGridColumn component

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@ Version 1.1.11 work in progress
 - Enh #599: Added case sensitivity check when autoloading classes (qiangxue)
 - Enh #601: added the method loginRequired() to the IWebUser interface (mdomba)
 - Enh #641: Added support for cache entry serialization through the igbinary serializer (DaSourcerer) 
+- Enh #648: Added filterHtmlOptions property to the CGridColumn component (juban)
 - Enh: Added default value to CConsoleCommand::confirm (musterknabe)
 - Enh: Added third parameter to CHttpCookie to configure the cookie by array (suralc)
 - Enh: Added getIsFlashRequest(), proper handling of Flash/Flex request when using CWebLogRoute with FireBug (resurtm)

--- a/framework/zii/widgets/grid/CGridColumn.php
+++ b/framework/zii/widgets/grid/CGridColumn.php
@@ -61,6 +61,10 @@ abstract class CGridColumn extends CComponent
 	 */
 	public $htmlOptions=array();
 	/**
+	 * @var array the HTML options for the filter cell tag.
+	 */
+	public $filterHtmlOptions=array();
+	/**
 	 * @var array the HTML options for the header cell tag.
 	 */
 	public $headerHtmlOptions=array();
@@ -102,7 +106,7 @@ abstract class CGridColumn extends CComponent
 	 */
 	public function renderFilterCell()
 	{
-		echo "<td>";
+		echo CHtml::openTag('td',$this->filterHtmlOptions);
 		$this->renderFilterCellContent();
 		echo "</td>";
 	}


### PR DESCRIPTION
Pull request for #648 enhancement request.
Add a filterHtmlOptions property to the CGridColumn component to be able to set html options for the td filter cell.
