### PR TITLE
Html Buttons for ajaxSubmit methods in CHtml class

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -1009,6 +1009,38 @@ EOD;
 	}
 
 	/**
+	 * Generates a push Html button that can initiate AJAX requests.
+	 * @param string $label the button label
+	 * @param mixed $url the URL for the AJAX request. If empty, it is assumed to be the current URL. See {@link normalizeUrl} for more details.
+	 * @param array $ajaxOptions AJAX options (see {@link ajax})
+	 * @param array $htmlOptions additional HTML attributes. Besides normal HTML attributes, a few special
+	 * attributes are also recognized (see {@link clientChange} and {@link tag} for more details.)
+	 * @return string the generated button
+	 */
+	public static function ajaxHtmlButton($label,$url,$ajaxOptions=array(),$htmlOptions=array())
+	{
+		$ajaxOptions['url']=$url;
+		$htmlOptions['ajax']=$ajaxOptions;
+		return self::htmlButton($label,$htmlOptions);
+	}
+
+	/**
+	 * Generates a push Html button that can submit the current form in POST method.
+	 * @param string $label the button label
+	 * @param mixed $url the URL for the AJAX request. If empty, it is assumed to be the current URL. See {@link normalizeUrl} for more details.
+	 * @param array $ajaxOptions AJAX options (see {@link ajax})
+	 * @param array $htmlOptions additional HTML attributes. Besides normal HTML attributes, a few special
+	 * attributes are also recognized (see {@link clientChange} and {@link tag} for more details.)
+	 * @return string the generated button
+	 */
+	public static function ajaxSubmitHtmlButton($label,$url,$ajaxOptions=array(),$htmlOptions=array())
+	{
+		$ajaxOptions['type']='POST';
+		$htmlOptions['type']='submit';
+		return self::ajaxHtmlButton($label,$url,$ajaxOptions,$htmlOptions);
+	}
+
+	/**
 	 * Generates the JavaScript that initiates an AJAX request.
 	 * @param array $options AJAX options. The valid options are specified in the jQuery ajax documentation.
 	 * The following special options are added for convenience:


### PR DESCRIPTION
CHtml class has a method to create a INPUT called "button"
Also it has a method to create a BUTTON called "htmlButton"

On the other hand, there's a method called "ajaxSubmitButton" to create
buttons with ajax calls. This method refers to "ajaxButton" and this
one refers to "button".

My request is to have this feature also in (what you call) htmlButton's.

So there could be a method called "ajaxSubmitHtmlButton" that refers to
"ajaxHtmlButton" and this one to "htmlButton".
