### PR TITLE
Fixing bug with url hash in CMenu::isItemActive()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ Version 1.1.11 work in progress
 - Bug #553: Criteria of related AR finders was affected after performing find with relational scopes (marcovtwout)
 - Bug #660: Fixed error when calling CDbCache::getValues (zilles)
 - Bug #681: Fixed detection of one-to-one relations in Gii (richardpeng)
+- Bug: Fixed CMenu::isItemActive() to work properly when there is a hash in the item's url (SlKelevro)
 - Enh #120: Added ability to set cookies in an object based style without specifying the cookie-name twice (suralc)
 - Enh #136: Added ability to select database connection in Gii model generator (samdark)
 - Enh #165: Allow CCacheDependency to be reusable across multiple cache calls (phpnode)

--- a/framework/zii/widgets/CMenu.php
+++ b/framework/zii/widgets/CMenu.php
@@ -302,8 +302,7 @@ class CMenu extends CWidget
 	{
 		if(isset($item['url']) && is_array($item['url']) && !strcasecmp(trim($item['url'][0],'/'),$route))
 		{
-			if(isset($item['url']['#']))
-				unset($item['url']['#']);
+			unset($item['url']['#']);
 			if(count($item['url'])>1)
 			{
 				foreach(array_splice($item['url'],1) as $name=>$value)


### PR DESCRIPTION
CMenu::isItemActive currently fails when there is a hash (# value) in the item's url. Such item will never be active, because this method obviously will never find $_GET['#']
