### PR TITLE
Use base64 instead of hex encoding for asset hashes

### DIFF
--- a/framework/web/CAssetManager.php
+++ b/framework/web/CAssetManager.php
@@ -315,6 +315,6 @@ class CAssetManager extends CApplicationComponent
 	 */
 	protected function hash($path)
 	{
-		return rtrim(strtr(base64_encode(pack('I',crc32($path.Yii::getVersion()))),'+/','-_'),'=');
+		return base_convert(crc32($path.Yii::getVersion()),10,36);
 	}
 }


### PR DESCRIPTION
Not an actual pull request but rather a request for comments: This change will use a url'ified base64 encoding for asset hashes instead of the hex notation resulting into even shorter hashes. This will be mostly interesting if the future asset system will rely on a real hashing algorithm (such as sha1). As is, this will already save two characters on the resulting hashes. Speed hasn't changed notably for me.
