### PR TITLE
Fix detection of one-to-one db relationships

### DIFF
--- a/framework/gii/generators/model/ModelCode.php
+++ b/framework/gii/generators/model/ModelCode.php
@@ -321,7 +321,7 @@ class ModelCode extends CCodeModel
 					$relations[$className][$relationName]="array(self::BELONGS_TO, '$refClassName', '$fkName')";
 
 					// Add relation for the referenced table
-					$relationType=$table->primaryKey === $fkName ? 'HAS_ONE' : 'HAS_MANY';
+					$relationType=$table->primaryKey === $refKey ? 'HAS_ONE' : 'HAS_MANY';
 					$relationName=$this->generateRelationName($refTable, $this->removePrefix($tableName,false), $relationType==='HAS_MANY');
 					$i=1;
 					$rawName=$relationName;


### PR DESCRIPTION
Previously, one-to-one relationships weren't properly detected because the wrong variables were being compared.
