### PR TITLE
Fixes #392: There was no way to get and modify criteria in CActiveRecord::beforeFind

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Version 1.1.11 work in progress
 - Bug #193: Changed datetime column type for postgresql from 'time' to 'timestamp' (cebe)
 - Bug #295: Sometimes CJSON::decode returns null because native json_encode has bugs and returns null. Workaround to continue decoding when result of json_decode is null (luislobo)
 - Bug #381: Fixed the bug that Gii model name input could get misspelled when autocomplete is used (mdomba)
+- Bug #392: There was no way to get and modify criteria in CActiveRecord::beforeFind (samdark)
 - Bug #417: CAttributeCollections::mergeWith() does not take into account the caseSensitive (dmtrs)
 - Bug #433: Fixed the bug that Gii model name input autocomplete was not working sometimes (mdomba)
 - Bug #454: Removed translation on CDbConnection exception as it was creating an endless loop if the application used CDbCache (mdomba)

--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -1281,8 +1281,9 @@ abstract class CActiveRecord extends CModel
 	 */
 	protected function query($criteria,$all=false)
 	{
-        $this->beforeFind();
 		$this->applyScopes($criteria);
+		$this->beforeFind($criteria);
+
 		if(empty($criteria->with))
 		{
 			if(!$all)


### PR DESCRIPTION
This one fixes issue #392 so one can get criteria in beforeFind by passing it as a parameter and modify it.
