### PR TITLE
Fixing migrate command

### DIFF
--- a/framework/cli/commands/MigrateCommand.php
+++ b/framework/cli/commands/MigrateCommand.php
@@ -368,11 +368,11 @@ class MigrateCommand extends CConsoleCommand
 		}
 	}
 
-	public function confirm($message)
+	public function confirm($message,$default=false)
 	{
 		if(!$this->interactive)
 			return true;
-		return parent::confirm($message);
+		return parent::confirm($message,$default);
 	}
 
 	protected function migrateUp($class)


### PR DESCRIPTION
Since 63dd38dcaea1917b2b289f6dbceecdfc0713ed71 the migrate command was broken.
The migrate command overrides the confirm method which had its signature changed by the aforementioned commit.
This pull request updates the signature of the migrate command to match the parent class.
