### PR TITLE
updated upgrade instructions, minor code style upgrade

### DIFF
--- a/UPGRADE
+++ b/UPGRADE
@@ -21,7 +21,17 @@ General upgrade intructions
 
 Upgrading from v1.1.10
 ----------------------
-- API of protected method CConsoleCommand::afterAction() changed, if you are overiding this method make sure to update your code.
+- API of public method CConsoleCommand::confirm() changed. If you are overriding this method make sure to update your code.
+  The method now has a 2nd parameter for the default value which will be used if no selection is made, so you have to
+  adjust the signature to fit
+  
+      public function confirm($message,$default=false)
+  
+  and the parent call to
+  
+      parent::confirm($message,$default);
+
+- API of protected method CConsoleCommand::afterAction() changed, if you are overriding this method make sure to update your code.
   method now has a 3rd parameter for application exit code, so you have to adjust the signature to fit
   
       protected function afterAction($action,$params,$exitCode=0)

--- a/framework/console/CConsoleCommand.php
+++ b/framework/console/CConsoleCommand.php
@@ -557,7 +557,7 @@ abstract class CConsoleCommand extends CComponent
 	 *
 	 * @since 1.1.9
 	 */
-	public function confirm($message, $default = false)
+	public function confirm($message,$default=false)
 	{
 		echo $message.' (yes|no) [' . ($default ? 'yes' : 'no') . ']:';
 


### PR DESCRIPTION
Just found out, that the signature update of CConsoleCommand::confirm() wasn't reflected in the UPGRADE instructions.

Here are the corresponding instructions.

Also changed confirms signature code style to match the "no spaces" style used in the majority of Yii code.
