### PR TITLE
(Fixes issue #203) optimized the AJAX validation of CActiveForm

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,6 +47,7 @@ Version 1.1.11 work in progress
 - Enh #673: Changed CClientScript::scripts to be public (mdomba)
 - Enh #675: CDateFormat::format() now returns null if the parameter $time is null (mdomba)
 - Enh #690: Added sender name and proper headers for UTF8 encoding when sending e-mail in SiteController->actionContact() (mdomba)
+- Enh #203: Minimzed unnecessary AJAX validation of CActiveForm, added field validation attributes (hightman)
 - Enh: Added default value to CConsoleCommand::confirm (musterknabe)
 - Enh: Allowed returning integer values as application exit code in CConsoleCommand actions (cebe)
 - Enh: Added third parameter to CHttpCookie to configure the cookie by array (suralc)

--- a/framework/web/js/source/jquery.yiiactiveform.js
+++ b/framework/web/js/source/jquery.yiiactiveform.js
@@ -308,6 +308,7 @@
 		var $form = $(form),
 			settings = $form.data('settings'),
 			needAjaxValidation = false,
+			attributesParam = '',
 			messages = {};
 		$.each(settings.attributes, function () {
 			var value,
@@ -321,6 +322,15 @@
 			}
 			if (this.enableAjaxValidation && !msg.length && (settings.submitting || this.status === 2 || this.status === 3)) {
 				needAjaxValidation = true;
+				if (this.status === 2 || this.status === 3) {
+					var pos1 = this.name.lastIndexOf('['), pos2 = this.name.lastIndexOf(']'), name = '';
+					if (pos2 == (this.name.length - 1))
+						name = this.name.substring(pos1 + 1, this.name.length);
+					else
+						name = this.name.substring(pos2 + 1);
+					attributesParam += '&' + encodeURIComponent(settings.attributesVar + '[' + this.model + '][]');
+					attributesParam += '=' + encodeURIComponent(name);
+				}
 			}
 		});
 
@@ -338,6 +348,7 @@
 
 		var $button = $form.data('submitObject'),
 			extData = '&' + settings.ajaxVar + '=' + $form.attr('id');
+		extData += attributesParam;
 		if ($button && $button.length) {
 			extData += '&' + $button.attr('name') + '=' + $button.attr('value');
 		}
@@ -379,6 +390,7 @@
 
 	$.fn.yiiactiveform.defaults = {
 		ajaxVar: 'ajax',
+		attributesVar: 'attributes',
 		validationUrl: undefined,
 		validationDelay: 200,
 		validateOnSubmit : false,


### PR DESCRIPTION
Issue #203

Two improvements to CActiveForm:
1. When validators of one field can be completely converted to Javascript validator, It will not cause AJAX request to server-side on changing this field.
2. When the AJAX validation request caused by some of fields, It will also send all these attribute names to sever. Therefore, server-side can only validate these fields.

The new ajax validation code will be:

``` php
protected function performAjaxValidation($model)
{
    if(isset($_POST['ajax']) && $_POST['ajax']==='user-form')
    {
        $class=get_class($model);
        if (isset($_POST['attributes']) && is_array($_POST['attributes'][$class]))
            $attributes=$_POST['attributes'][$class];
        else
            $attributes=null;
        echo CActiveForm::validate($model, $attributes);
        Yii::app()->end();
    }
}
```
