### PR TITLE
Fix for issue #591 CActiveRecord::getRelated doesn't call afterFind() wi...

### DIFF
--- a/framework/db/ar/CActiveFinder.php
+++ b/framework/db/ar/CActiveFinder.php
@@ -167,8 +167,9 @@ class CActiveFinder extends CComponent
 		$this->_joinTree->lazyFind($baseRecord);
 		if(!empty($this->_joinTree->children))
 		{
-			$child=reset($this->_joinTree->children);
-			$child->afterFind();
+			foreach($this->_joinTree->children as $child) {
+			  $child->afterFind();
+      }
 		}
 		$this->destroyJoinTree();
 	}


### PR DESCRIPTION
...th `through` relation

Issue #591

It was only expecting joinTree only contain 1 child, if you use through relation, that might not be true. Therefore, use a loop to go though the children and call afterFind on them.
