### PR TITLE
fixes issue #618 caching of CWebUser::checkAccess()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ Version 1.1.11 work in progress
 - Bug #517: Rule parameter sub-patterns are not checked correctly (ranvis)
 - Bug #539: Fixed CUrlRule::createUrl() to treat sub-patterns as Unicode as parseUrl() does (ranvis)
 - Bug #553: Criteria of related AR finders was affected after performing find with relational scopes (marcovtwout)
+- Bug #618: Fixed caching of CWebUser::checkAccess() when it is called first time with and second time without $params (cebe)
 - Bug #660: Fixed error when calling CDbCache::getValues (zilles)
 - Bug: Fixed CMenu::isItemActive() to work properly when there is a hash in the item's url (SlKelevro)
 - Bug: Added missing return statement to CAuthItem->revoke() (mdomba)

--- a/framework/web/auth/CWebUser.php
+++ b/framework/web/auth/CWebUser.php
@@ -785,14 +785,18 @@ class CWebUser extends CApplicationComponent implements IWebUser
 	 * its result will be directly returned when calling this method to check the same operation.
 	 * If this parameter is false, this method will always call {@link CAuthManager::checkAccess}
 	 * to obtain the up-to-date access result. Note that this caching is effective
-	 * only within the same request.
+	 * only within the same request and only works when <code>$params=array()</code>.
 	 * @return boolean whether the operations can be performed by this user.
 	 */
 	public function checkAccess($operation,$params=array(),$allowCaching=true)
 	{
 		if($allowCaching && $params===array() && isset($this->_access[$operation]))
 			return $this->_access[$operation];
-		else
-			return $this->_access[$operation]=Yii::app()->getAuthManager()->checkAccess($operation,$this->getId(),$params);
+
+		$access=Yii::app()->getAuthManager()->checkAccess($operation,$this->getId(),$params);
+		if($allowCaching && $params===array())
+			$this->_access[$operation]=$access;
+
+		return $access;
 	}
 }


### PR DESCRIPTION
fixes issue #618

Fixed caching of CWebUser::checkAccess() when it is called first time
with and second time without $params
