### PR TITLE
$attribute parameter for CFormInputElement

### DIFF
--- a/framework/web/form/CFormInputElement.php
+++ b/framework/web/form/CFormInputElement.php
@@ -83,6 +83,10 @@ class CFormInputElement extends CFormElement
 	 */
 	public $name;
 	/**
+	 * @var string attribute name for feeding list inputs with CHtml::active*List()
+	 */
+	public $attribute;
+	/**
 	 * @var string hint text of this input
 	 */
 	public $hint;
@@ -212,19 +216,23 @@ class CFormInputElement extends CFormElement
 	 */
 	public function renderInput()
 	{
+		// ability to substitute model attribute name, to use custom data getter
+		$attrName = ($this->attribute !== null) ? $this->attribute : $this->name;
 		if(isset(self::$coreTypes[$this->type]))
 		{
+			
 			$method=self::$coreTypes[$this->type];
-			if(strpos($method,'List')!==false)
-				return CHtml::$method($this->getParent()->getModel(), $this->name, $this->items, $this->attributes);
+			if(strpos($method,'List')!==false){
+				return CHtml::$method($this->getParent()->getModel(), $attrName, $this->items, $this->attributes);
+			}
 			else
-				return CHtml::$method($this->getParent()->getModel(), $this->name, $this->attributes);
+				return CHtml::$method($this->getParent()->getModel(), $attrName, $this->attributes);
 		}
 		else
 		{
 			$attributes=$this->attributes;
 			$attributes['model']=$this->getParent()->getModel();
-			$attributes['attribute']=$this->name;
+			$attributes['attribute']=$attrName;
 			ob_start();
 			$this->getParent()->getOwner()->widget($this->type, $attributes);
 			return ob_get_clean();


### PR DESCRIPTION
Easy-to-customize data sources for all core inputs and even custom input widgets.
It is not dangerous to use any custom fields and getters, because it will work for read-only.
And there is also possibility to re-assign model for input for same reasons.
