### PR TITLE
add selector option to htmlOptions

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2066,11 +2066,16 @@ EOD;
 				$handler="return $confirm;";
 		}
 
-		if($live)
-			$cs->registerScript('Yii.CHtml.#' . $id, "$('body').on('$event','#$id',function(){{$handler}});");
+		if(isset($htmlOptions['selector']))
+			$selector=$htmlOptions['selector'];
 		else
-			$cs->registerScript('Yii.CHtml.#' . $id, "$('#$id').on('$event', function(){{$handler}});");
-		unset($htmlOptions['params'],$htmlOptions['submit'],$htmlOptions['ajax'],$htmlOptions['confirm'],$htmlOptions['return'],$htmlOptions['csrf']);
+			$selector="#$id";
+
+		if($live)
+			$cs->registerScript('Yii.CHtml.#' . $selector, "$('body').on('$event','$selector',function(event){{$handler}});");
+		else
+			$cs->registerScript('Yii.CHtml.#' . $selector, "$('$selector').on('$event', function(event){{$handler}});");
+		unset($htmlOptions['params'],$htmlOptions['submit'],$htmlOptions['ajax'],$htmlOptions['confirm'],$htmlOptions['return'],$htmlOptions['csrf'],$htmlOptions['selector']);
 	}
 
 	/**


### PR DESCRIPTION
Here is a patch to allow using a 'selector' option to an ajax-enabled widget.

The reason is that in some cases we need to select by class rather than ID in order to work with elements added by ajax calls.

It could be also in other situations also, which is why I used a free-form selector field rather than a 'class' field ...

Here is an example use:

echo CHtml::ajaxButton('label', 'http://example.com',
        array('beforeSend' => 'js:function(){alert("hello");}'),
        array(
            'class' => 'btn-delete-event',
            'selector' => '.btn-delete-event'
            )
        );

... and the JS generated (made pretty for legibility):

$('body').on('click','.btn-delete-event',function(event){
    jQuery.ajax({
        'beforeSend':function(){
            alert("hello");
        },
        'url':'http://example.com',
        'cache':false
    });
    return false;
});
