### PR TITLE
Setting `timestampAttribute` to null when CDateValidator allows empty values

### DIFF
--- a/framework/validators/CDateValidator.php
+++ b/framework/validators/CDateValidator.php
@@ -49,8 +49,11 @@ class CDateValidator extends CValidator
 	protected function validateAttribute($object,$attribute)
 	{
 		$value=$object->$attribute;
-		if($this->allowEmpty && $this->isEmpty($value))
-			return;
+		if($this->allowEmpty && $this->isEmpty($value)) {
+			if($this->timestampAttribute!==null)
+				$object->{$this->timestampAttribute}=null;
+			return;	
+		}
 
 		$formats=is_string($this->format) ? array($this->format) : $this->format;
 		$valid=false;


### PR DESCRIPTION
By the documentation, `timestampAttribute` should get set when the date is valid. If the validator is set to allow empty values, it's logical that timestampAttribute should be set to empty (i.e. null) when the original attribute is set to null / empty. 
