### PR TITLE
Corrected #578 extension checking. Old solution breaks 'yiic message'.

### DIFF
--- a/framework/caching/CMemCache.php
+++ b/framework/caching/CMemCache.php
@@ -114,7 +114,8 @@ class CMemCache extends CCache
 		{
 			$extension=$this->useMemcached ? 'memcached' : 'memcache';
 			if(!extension_loaded($extension))
-				throw new CException(Yii::t('yii',"CMemCache requires PHP $extension extension to be loaded."));
+				throw new CException(Yii::t('yii',"CMemCache requires PHP {extension} extension to be loaded.",
+                    array('{extension}'=>$extension)));
 			return $this->_cache=$this->useMemcached ? new Memcached : new Memcache;
 		}
 	}


### PR DESCRIPTION
issue #578
