### PR TITLE
Fix CHttpRequest->getIsSecureConnection() to return properly behind load balancer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -72,7 +72,8 @@ Version 1.1.11 work in progress
 - Chg #440: Upgraded JQuery UI to 1.8.20 (samdark)
 - Chg #497: Added log component and preloaded it in default console application config in order to properly log errors (samdark)
 - Chg: Upgraded jQuery to 1.7.2 (samdark)
-- Enh: added possibility to set the container for CHtml::radioButtonList and CHtml::checkBoxList() (pgaultier)
+- Enh: added possibility to set the container for CHtml::radioButtonList and CHtml::checkBoxList() (pgaultier)'
+- Enh: CHttpRequest->getIsSecureConnection() now responds properly when application server is behind an SSL Terminating proxy or load balancer (brentj84062)
 
 Version 1.1.10 February 12, 2012
 --------------------------------

--- a/framework/web/CHttpRequest.php
+++ b/framework/web/CHttpRequest.php
@@ -498,7 +498,9 @@ class CHttpRequest extends CApplicationComponent
 	 */
 	public function getIsSecureConnection()
 	{
-		return isset($_SERVER['HTTPS']) && !strcasecmp($_SERVER['HTTPS'],'on');
+		return isset($_SERVER['HTTPS']) && !strcasecmp($_SERVER['HTTPS'],'on')
+		/* The following may be necessary for servers behind an SSL terminating load balancer */
+                        || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && !strcasecmp($_SERVER['HTTP_X_FORWARDED_PROTO'],'https'));
 	}
 
 	/**
@@ -575,13 +577,20 @@ class CHttpRequest extends CApplicationComponent
 	}
 
 	/**
+
 	 * Returns whether this is an Adobe Flash or Adobe Flex request.
+
 	 * @return boolean whether this is an Adobe Flash or Adobe Flex request.
 	 * @since 1.1.11
+
 	 */
+
 	public function getIsFlashRequest()
+
 	{
+
 		return isset($_SERVER['HTTP_USER_AGENT']) && (stripos($_SERVER['HTTP_USER_AGENT'],'Shockwave')!==false || stripos($_SERVER['HTTP_USER_AGENT'],'Flash')!==false);
+
 	}
 
 	/**


### PR DESCRIPTION
Pretty simple patch - getIsSecureConnection() should respond affirmatively when the server is behind an SSL terminating load balancer or proxy. Updated to check $_SERVER["HTTP_X_FORWARDED_PROTO"] in addition to $_SERVER["HTTPS"] and added enhancement to Changelog.
