### PR TITLE
Enable MySQL in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@ php:
 
 before_script:
   - cd tests
+  - mysql -e 'CREATE SCHEMA `yii`; GRANT ALL ON `yii`.* TO "test@localhost" IDENTIFIED BY "test"; FLUSH PRIVILIGES;'
+  - mysql -D yii < framework/db/data/mysql.sql
 
 script: phpunit --verbose --coverage-html reports framework


### PR DESCRIPTION
This should enable MySQL-based testcases. Validates with [travis-lint](http://lint.travis-ci.org/), so I assume all is fine.
