### PR TITLE
travis-ci: Print coverage reports to stdout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_script:
   - mysql -u root -e 'CREATE SCHEMA `yii`; GRANT ALL ON `yii`.* TO test@localhost IDENTIFIED BY "test"; FLUSH PRIVILEGES;'
   - mysql -u root -D yii < framework/db/data/mysql.sql
 
-script: phpunit --verbose --coverage-html reports framework
+script: phpunit --verbose --coverage-text framework


### PR DESCRIPTION
We cannot access the generated html files, so let's use `--coverage-text` instead of `--coverage-html results`.
