### PR TITLE
travis-ci: Enable PostgreSQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,12 @@ before_script:
   - cd tests
   - mysql -u root -e 'CREATE SCHEMA `yii` CHARACTER SET utf8 COLLATE utf8_general_ci; GRANT ALL ON `yii`.* TO test@localhost IDENTIFIED BY "test"; FLUSH PRIVILEGES;'
   - mysql -u root -D yii < framework/db/data/mysql.sql
-  - printf "yes\n" | pecl install memcache
+  - psql -c "CREATE ROLE test WITH PASSWORD 'test' LOGIN;" -U postgres
+  - psql -c 'CREATE DATABASE yii WITH OWNER = test;' -U postgres
+  - psql -c 'GRANT ALL PRIVILEGES ON DATABASE yii TO test;' -U postgres
+  - psql -d yii -f framework/db/data/postgres.sql -U test
+  - psql -d yii -f framework/web/auth/schema.sql -U test
+  - echo "yes" | pecl install memcache
   - echo "extension=memcache.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
 
 script: phpunit --verbose --coverage-text framework


### PR DESCRIPTION
This will prepare the PostgreSQL installation in the travis VM for all pgsql-based tests.

Take note that it is pretty likely an [error](http://travis-ci.org/#!/DaSourcerer/yii/jobs/1783783/L288) will spawn, so we will no longer have a passing build. Somebody more proficient with postgres than me will have to take a look at that.
