### PR TITLE
Some refinements to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ before_script:
   - cd tests
   - mysql -u root -e 'CREATE SCHEMA `yii` CHARACTER SET utf8 COLLATE utf8_general_ci; GRANT ALL ON `yii`.* TO test@localhost IDENTIFIED BY "test"; FLUSH PRIVILEGES;'
   - mysql -u root -D yii < framework/db/data/mysql.sql
-  - psql -c "CREATE ROLE test WITH PASSWORD 'test' LOGIN;" -U postgres
-  - psql -c 'CREATE DATABASE yii WITH OWNER = test;' -U postgres
-  - psql -c 'GRANT ALL PRIVILEGES ON DATABASE yii TO test;' -U postgres
-  - psql -d yii -f framework/db/data/postgres.sql -U test
-  - psql -d yii -f framework/web/auth/schema.sql -U test
+  - psql -q -c "CREATE ROLE test WITH PASSWORD 'test' LOGIN;" -U postgres
+  - psql -q -c 'CREATE DATABASE yii WITH OWNER = test;' -U postgres
+  - psql -q -c 'GRANT ALL PRIVILEGES ON DATABASE yii TO test;' -U postgres
+  - psql -q -d yii -f framework/db/data/postgres.sql -U test
+  - psql -q -d yii -f framework/web/auth/schema.sql -U test
   - echo "yes" | pecl install memcache
   - echo "extension=memcache.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
 
-script: phpunit --verbose --coverage-text framework
+script: phpunit --colors --coverage-text framework


### PR DESCRIPTION
I tried to improve the .travis.yml a bit further:
- psql has been silenced, so there will be less output to skim through
- the output of phpunit is no longer verbose (I think our setup is mature enough now to allow this)
- phpunit output is coloured now, which greatly improves readability of the code coverage report

I'd love to silence the memcache build as well. Unfortunately this turned out to be problematic: The pecl installer will print all output to stdout, so redirecting that to /dev/null will also silence all errors as well.
