### PR TITLE
added a resetSequence for oci

### DIFF
--- a/framework/db/schema/oci/COciSchema.php
+++ b/framework/db/schema/oci/COciSchema.php
@@ -359,12 +359,13 @@ EOD;
 	 */
 	public function resetSequence($table,$value=1)
 	{
+		$seq = $table->name."_SEQ";
 		if($table->sequenceName!==null)
 		{
-			$this->getDbConnection()->createCommand("DROP SEQUENCE ".$table->sequenceName)->execute();
+			$this->getDbConnection()->createCommand("DROP SEQUENCE ".$seq)->execute();
 
 			$createSequenceSql = <<< SQL
-create sequence {$table->sequenceName}
+create sequence $seq
 start with $value 
 increment by 1 
 nomaxvalue


### PR DESCRIPTION
This handles at least half of issue #315

The best way to reset a sequence is to remove it and re-add it.
