### PR TITLE
.travis.yml: Let unit tests set the test databases up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,9 @@ php:
 before_script:
   - cd tests
   - mysql -u root -e 'CREATE SCHEMA `yii` CHARACTER SET utf8 COLLATE utf8_general_ci; GRANT ALL ON `yii`.* TO test@localhost IDENTIFIED BY "test"; FLUSH PRIVILEGES;'
-  - mysql -u root -D yii < framework/db/data/mysql.sql
   - psql -q -c "CREATE ROLE test WITH PASSWORD 'test' LOGIN;" -U postgres
   - psql -q -c 'CREATE DATABASE yii WITH OWNER = test;' -U postgres
   - psql -q -c 'GRANT ALL PRIVILEGES ON DATABASE yii TO test;' -U postgres
-  - psql -q -d yii -f framework/db/data/postgres.sql -U test
-  - psql -q -d yii -f framework/web/auth/schema.sql -U test
   - echo 'y' | pecl install memcache > ~/memcache.log || ( echo "=== MEMCACHE BUILD FAILED ==="; cat ~/memcache.log )
   - echo "extension=memcache.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
 


### PR DESCRIPTION
I'm a bit surprised nobody spotted this before: The relevant test cases are all capable of tearing up the test dbs. There is no need to populate them before.

This patch will shorten the build output a bit, make the build script less complicated and even speeds up things a bit.

While we're at it: Is there any use for `tests/framework/db/schema/sqlite.sql`? I can't see any test touching this file.
