### PR TITLE
#954 - adding interface: IModelErrorReport into interfaces.php and set CModel to use it.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 
 Version 1.1.11 work in progress
 -------------------------------
+- Enh #954: Using IModelErrorReport in CModel to implement error control methods in a clear way.(christiansalazar)
 - Bug #098: No correct identity value being returned when using Active Record and mssql (c-schmitz)
 - Bug #114: CUniqueValidator and CExistValidator now respect table alias while creating db query condition (klimov-paul)
 - Bug #145: CGettextMoFile now can parse strings with no context (eagleoneraptor)

--- a/framework/base/CModel.php
+++ b/framework/base/CModel.php
@@ -27,7 +27,7 @@
  * @package system.base
  * @since 1.0
  */
-abstract class CModel extends CComponent implements IteratorAggregate, ArrayAccess
+abstract class CModel extends CComponent implements IteratorAggregate, ArrayAccess, IModelErrorReport
 {
 	private $_errors=array();	// attribute name => array of errors
 	private $_validators;  		// validators

--- a/framework/base/interfaces.php
+++ b/framework/base/interfaces.php
@@ -644,3 +644,61 @@ interface ILogFilter
 	public function filter(&$logs);
 }
 
+/**
+ * IModelErrorReport is the interface that is implemented by CModel to provide error report methods.
+ *
+ *   When you create a new class that needs the error handling cappabilities of CModel 
+ * into it then implementing this interface ensure the same mechanism that CModel uses is used 
+ * too in your own class. 
+ *   If you have a class who detects a validation error (a validator component maybe ?)
+ * then unsing this interface you could copy the detected errors to CModel in a clear and well 
+ * known way. as an example:
+ *   foreach($this->getFields() as $f)           
+ *      if($f->validate() == false)				<- in this example all detected errors will be
+ *          $this->addErrors($f->getErrors());  <- passed to a CModel instance using this interface
+ *
+ * @author Christian Salazar <christiansalazarh@gmail.com>
+ * @version $Id$
+ * @package system.base
+ * @since 1.1.11
+ */
+interface IModelErrorReport
+{
+	/**
+	 * Returns a value indicating whether there is any validation error.
+	 * @param string $attribute attribute name. Use null to check all attributes.
+	 * @return boolean whether there is any error.
+	 */
+	public function hasErrors($attribute=null);
+	/**
+	 * Returns the errors for all attribute or a single attribute.
+	 * @param string $attribute attribute name. Use null to retrieve errors for all attributes.
+	 * @return array errors for all attributes or the specified attribute. Empty array is returned if no error.
+	 */
+	public function getErrors($attribute=null);
+	/**
+	 * Returns the first error of the specified attribute.
+	 * @param string $attribute attribute name.
+	 * @return string the error message. Null is returned if no error.
+	 */
+	public function getError($attribute);
+	/**
+	 * Adds a new error to the specified attribute.
+	 * @param string $attribute attribute name
+	 * @param string $error new error message
+	 */
+	public function addError($attribute,$error);
+	/**
+	 * Adds a list of errors.
+	 * @param array $errors a list of errors. The array keys must be attribute names.
+	 * The array values should be error messages. If an attribute has multiple errors,
+	 * these errors must be given in terms of an array.
+	 * You may use the result of {@link getErrors} as the value for this parameter.
+	 */
+	public function addErrors($errors);
+	/**
+	 * Removes errors for all attributes or a single attribute.
+	 * @param string $attribute attribute name. Use null to remove errors for all attribute.
+	 */
+	public function clearErrors($attribute=null);
+}


### PR DESCRIPTION
in some cases, if you need to validate a model using an external class created for this specific prupose then you need to implement this same methods (addError, hasErrors and so on..) to pass back the detected errors to a CModel parent class.

This interface is intended to separate this methods in a clear interface to be used in other components too, finally, the modification to CModel is ver small:  indicating the usage of this interface into it too.

this changes do not affects the core in any way, but will help on extensions related to CModel.

Issue: #954
