### PR TITLE
Allow correct handling of negative timestamps in CDateFormatter.format()

### DIFF
--- a/framework/i18n/CDateFormatter.php
+++ b/framework/i18n/CDateFormatter.php
@@ -91,7 +91,7 @@ class CDateFormatter extends CComponent
 
 		if(is_string($time))
 		{
-			if(ctype_digit($time))
+			if(ctype_digit($time) || (substr($time, 0, 1)=='-' && ctype_digit(substr($time, 1))))
 				$time=(int)$time;
 			else
 				$time=strtotime($time);


### PR DESCRIPTION
CDateFormatter.format() uses a ctype_digit call to check if a string parameter is a timestamp, but this method fails for strings like "-3453453535" because of the negative sign.  I've added an additional check for negative numbers that allows dates before 1970 to be properly formatted.
