### PR TITLE
CErrorHandler only set headers if not sent

### DIFF
--- a/framework/base/CErrorHandler.php
+++ b/framework/base/CErrorHandler.php
@@ -102,7 +102,8 @@ class CErrorHandler extends CApplicationComponent
 			{
 				@ob_end_clean();
 			}
-			header("Content-Encoding: ", true);
+			if(!headers_sent())
+				header('Content-Encoding:', true);
 		}
 
 		if($event instanceof CExceptionEvent)


### PR DESCRIPTION
this has been missed in commit f68fef2fe2cc21859e2bd490f63eaf1a6c5e5973 and causes php warning if headers where sent.
related to #901
