### PR TITLE
fixed PHPUnit autoloading

### DIFF
--- a/build/build
+++ b/build/build
@@ -13,10 +13,6 @@
  * @version $Id$
  */
 
-require_once('PHPUnit/Runner/Version.php');
-if(version_compare(PHPUnit_Runner_Version::id(), '3.5.0RC1')>=0)
-    require_once('PHPUnit/Autoload.php');
-
 $root=dirname(__FILE__);
 $config=array('basePath'=>$root);
 require_once($root.'/../framework/yiic.php');

--- a/framework/test/CTestCase.php
+++ b/framework/test/CTestCase.php
@@ -8,8 +8,10 @@
  * @license http://www.yiiframework.com/license/
  */
 
-require_once('PHPUnit/Runner/Version.php');
+require_once('PHPUnit/Util/Filesystem.php'); // workaround for PHPUnit <= 3.6.11
 require_once('PHPUnit/Autoload.php');
+spl_autoload_unregister('phpunit_autoload');
+Yii::registerAutoloader('phpunit_autoload');
 
 /**
  * CTestCase is the base class for all test case classes.

--- a/framework/test/CWebTestCase.php
+++ b/framework/test/CWebTestCase.php
@@ -8,6 +8,7 @@
  * @license http://www.yiiframework.com/license/
  */
 
+Yii::import('system.test.CTestCase');
 require_once('PHPUnit/Extensions/SeleniumTestCase.php');
 
 /**


### PR DESCRIPTION
- removed requirement for PHPUnit from build command #963
- fixed PHPUnit autoloading in CTestCase
  register phpunit autoloader before Yii autoloader to handle phpunit
  autoloads correctly.
  Also require PHPUnit/Util/Filesystem.php to avoid Yii autoloader to
  crash initializing of PHPUnit autoloader, see also:
  sebastianbergmann/phpunit#605
- imported CTestCase in CWebTestCase to ensure PHPUnit autoloader is
  initialized correctly
