### PR TITLE
Fixed xSendFile Content-Disposition bug #979

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@ Version 1.1.11 work in progress
 - Bug #697: Fixed WSDLGenerator now generating proper namespace for certain complexTypes (BBoom)
 - Bug #749: CActiveRecord::refresh() did not work in afterSave() for new records, will now always refresh, when db entry exists (cebe)
 - Bug #769: Fixed the bug that $.fn.yiiGridView.getSelection was not working always if a custom CGridView::template was used (mdomba)
+- Bug #979: Fixed the bug in CHttpRequest xSendFile that kept you from being able to specify Content-Disposition: inline (acorncom)
 - Bug: Fixed CMenu::isItemActive() to work properly when there is a hash in the item's url (SlKelevro)
 - Bug: Added missing return statement to CAuthItem->revoke() (mdomba)
 - Bug: CHtml::resolveValue() ignoring of array elements accessor at the beginning of the $attribute argument now works properly (resurtm)

--- a/framework/web/CHttpRequest.php
+++ b/framework/web/CHttpRequest.php
@@ -878,7 +878,7 @@ class CHttpRequest extends CApplicationComponent
 	 */
 	public function xSendFile($filePath, $options=array())
 	{
-		if(!isset($options['forceDownload']) || $options['forceDownload'])
+		if(!isset($options['forceDownload']) || $options['forceDownload'] == 'attachment')
 			$disposition='attachment';
 		else
 			$disposition='inline';


### PR DESCRIPTION
Content-Disposition is supposed to be able to be set to inline, but the code that was in there wouldn't allow you to do that.
