### PR TITLE
fixed typo rollBack -> rollback

### DIFF
--- a/docs/guide/database.dao.txt
+++ b/docs/guide/database.dao.txt
@@ -175,7 +175,7 @@ try
 }
 catch(Exception $e) // an exception is raised if a query fails
 {
-	$transaction->rollBack();
+	$transaction->rollback();
 }
 ~~~
 

--- a/docs/guide/database.migration.txt
+++ b/docs/guide/database.migration.txt
@@ -131,7 +131,7 @@ class m101129_185401_create_news_table extends CDbMigration
 		catch(Exception $e)
 		{
 			echo "Exception: ".$e->getMessage()."\n";
-			$transaction->rollBack();
+			$transaction->rollback();
 			return false;
 		}
 	}

--- a/framework/db/CDbConnection.php
+++ b/framework/db/CDbConnection.php
@@ -57,7 +57,7 @@
  * }
  * catch(Exception $e)
  * {
- *    $transaction->rollBack();
+ *    $transaction->rollback();
  * }
  * </pre>
  *

--- a/framework/db/CDbMigration.php
+++ b/framework/db/CDbMigration.php
@@ -50,7 +50,7 @@ abstract class CDbMigration extends CComponent
 		{
 			if($this->safeUp()===false)
 			{
-				$transaction->rollBack();
+				$transaction->rollback();
 				return false;
 			}
 			$transaction->commit();
@@ -59,7 +59,7 @@ abstract class CDbMigration extends CComponent
 		{
 			echo "Exception: ".$e->getMessage().' ('.$e->getFile().':'.$e->getLine().")\n";
 			echo $e->getTraceAsString()."\n";
-			$transaction->rollBack();
+			$transaction->rollback();
 			return false;
 		}
 	}
@@ -77,7 +77,7 @@ abstract class CDbMigration extends CComponent
 		{
 			if($this->safeDown()===false)
 			{
-				$transaction->rollBack();
+				$transaction->rollback();
 				return false;
 			}
 			$transaction->commit();
@@ -86,7 +86,7 @@ abstract class CDbMigration extends CComponent
 		{
 			echo "Exception: ".$e->getMessage().' ('.$e->getFile().':'.$e->getLine().")\n";
 			echo $e->getTraceAsString()."\n";
-			$transaction->rollBack();
+			$transaction->rollback();
 			return false;
 		}
 	}

--- a/framework/db/CDbTransaction.php
+++ b/framework/db/CDbTransaction.php
@@ -25,7 +25,7 @@
  * }
  * catch(Exception $e)
  * {
- *    $transaction->rollBack();
+ *    $transaction->rollback();
  * }
  * </pre>
  *

--- a/tests/framework/db/CDbTransactionTest.php
+++ b/tests/framework/db/CDbTransactionTest.php
@@ -34,7 +34,7 @@ class CDbTransactionTest extends CTestCase
 		}
 		catch(Exception $e)
 		{
-			$transaction->rollBack();
+			$transaction->rollback();
 			$reader=$this->_connection->createCommand('SELECT * FROM posts WHERE id=10')->query();
 			$this->assertFalse($reader->read());
 		}
@@ -53,7 +53,7 @@ class CDbTransactionTest extends CTestCase
 		}
 		catch(Exception $e)
 		{
-			$transaction->rollBack();
+			$transaction->rollback();
 			$this->fail('Unexpected exception');
 		}
 		$n=$this->_connection->createCommand('SELECT COUNT(*) FROM posts WHERE id=10')->queryScalar();

--- a/tests/framework/db/schema/CMssqlTest.php
+++ b/tests/framework/db/schema/CMssqlTest.php
@@ -285,7 +285,7 @@ EOD;
 		}
 		catch (Exception $e)
 		{
-			$transaction->rollBack();
+			$transaction->rollback();
 		}
 		$n=$builder->createCountCommand($table, new CDbCriteria(array('condition' => "title LIKE 'working transaction%'")))->queryScalar();
 		$this->assertEquals(2, $n);
@@ -301,7 +301,7 @@ EOD;
 		}
 		catch (Exception $e)
 		{
-			$transaction->rollBack();
+			$transaction->rollback();
 		}
 		$n=$builder->createCountCommand($table, new CDbCriteria(array('condition' => "title LIKE 'failed transaction%'")))->queryScalar();
 		$this->assertEquals(0, $n);


### PR DESCRIPTION
as mentioned in #977 used case setting of methods implementation in CDbTransaction as
reference and changed rollBack to rollback.

Left translation files untouched to not mark them up to date.
