### PR TITLE
added CCombinedLogFilter

### DIFF
--- a/framework/logging/CCombinedLogFilter.php
+++ b/framework/logging/CCombinedLogFilter.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * CCombinedLogFilter class file
+ *
+ * @author Carsten Brandt <mail@cebe.cc>
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright &copy; 2008-2012 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+/**
+ * CCombinedLogFilter allows you to attach multiple log filters to a log route (See {@link CLogRoute::$filter} for details).
+ *
+ * @author Carsten Brandt <mail@cebe.cc>
+ * @version $Id$
+ * @package system.logging
+ * @since 1.1.11
+ */
+class CCombinedLogFilter extends CComponent implements ILogFilter
+{
+	/**
+	 * @var array list of filters to apply to the logs.
+	 * The value of each array element will be passed to {@link Yii::createComponent} to create
+	 * a log filter object. As a result, this can be either a string representing the
+	 * filter class name or an array representing the filter configuration.
+	 * In general, the log filter classes should implement {@link ILogFilter} interface.
+	 * Filters will be applied in the order they are defined.
+	 */
+	public $filters=array();
+
+
+	/**
+	 * Filters the given log messages by applying all filters configured by {@link filters}.
+	 * @param array $logs the log messages
+	 */
+	public function filter(&$logs)
+	{
+		foreach($this->filters as $filter)
+			Yii::createComponent($filter)->filter($logs);
+	}
+}

--- a/framework/logging/CLogRoute.php
+++ b/framework/logging/CLogRoute.php
@@ -49,6 +49,7 @@ abstract class CLogRoute extends CComponent
 	 * a log filter object. As a result, this can be either a string representing the
 	 * filter class name or an array representing the filter configuration.
 	 * In general, the log filter class should be {@link CLogFilter} or a child class of it.
+	 * If you want to apply multiple filters you can use {@link CCombinedLogFilter} to do so.
 	 * Defaults to null, meaning no filter will be used.
 	 */
 	public $filter;


### PR DESCRIPTION
CCombinedLogFilter allows you to attach multiple log filters to a log
route. Solves the 3rd problem described in issue #684 and first of #721.

Main reason for not changing filter property to filters is backwards
compatibility. yii 2 should allow multiple filters by design.
