### PR TITLE
Proposed fix for Issue #1070

### DIFF
--- a/framework/db/ar/CActiveFinder.php
+++ b/framework/db/ar/CActiveFinder.php
@@ -234,12 +234,16 @@ class CActiveFinder extends CComponent
 
 			if(!empty($options['scopes']))
 				$scopes=array_merge($scopes,(array)$options['scopes']); // no need for complex merging
+			
+			$model->resetScope();
+			if(($scope=$model->defaultScope())!==array())
+				$relation->mergeWith($scope,true);
 
 			$criteria=$model->getDbCriteria();
 			$criteria->scopes=$scopes;
 			$model->applyScopes($criteria);
 			$relation->mergeWith($criteria,true);
-
+			
 			// dynamic options
 			if($options!==null)
 				$relation->mergeWith($options);

--- a/tests/framework/db/ar/CActiveRecordTest.php
+++ b/tests/framework/db/ar/CActiveRecordTest.php
@@ -1374,4 +1374,30 @@ class CActiveRecordTest extends CTestCase
 		$posts=PostWithBeforeFind::model()->findAll();
 		$this->assertEquals(count($posts),1);
 	}
+
+	/**
+	 * Self referencing many to many relationship in a data provider uses cached criteria with outdated table alias since 1.1.11.
+	 * @see github issue 1070
+	 * @link https://github.com/yiisoft/yii/issues/1070
+	**/
+	public function testIssue1070()
+	{
+		$dp = new CActiveDataProvider( 'UserWithDefaultScope' );
+		foreach ( $dp->getData() as $item )
+		{
+			$result = false;
+			try
+			{
+				$item->links[0]->from_user;
+				$result = true;
+			}
+			catch ( CDbException $e )
+			{
+				$result = false;
+			}
+			
+			$this->assertTrue( $result );
+			break;
+		}
+	}
 }

--- a/tests/framework/db/data/models.php
+++ b/tests/framework/db/data/models.php
@@ -748,3 +748,52 @@ class PostWithBeforeFind extends CActiveRecord
 		$criteria->limit=1;
 	}
 }
+
+class UserWithDefaultScope extends CActiveRecord
+{
+	public static function model($class=__CLASS__)
+	{
+		return parent::model($class);
+	}
+
+	public function tableName()
+	{
+		return 'UserWithDefaultScope';
+	}
+	
+	public function defaultScope()
+	{
+		$a = $this->getTableAlias( false, false );
+		return array(
+			'condition' => "{$a}.deleted IS NULL"
+		);
+	}
+	
+	public function relations()
+	{
+		return array(
+			'links'=>array(self::HAS_MANY,'UserWithDefaultScopeLink','from_id')
+		);
+	}
+}
+
+class UserWithDefaultScopeLink extends CActiveRecord
+{
+	public static function model($class=__CLASS__)
+	{
+		return parent::model($class);
+	}
+
+	public function tableName()
+	{
+		return 'UserWithDefaultScopeLink';
+	}
+	
+	public function relations()
+	{
+		return array(
+			'from_user'=>array(self::BELONGS_TO,'UserWithDefaultScope','from_id'),
+			'to_user'=>array(self::BELONGS_TO,'UserWithDefaultScope','to_id'),
+		);
+	}
+}

--- a/tests/framework/db/data/sqlite.sql
+++ b/tests/framework/db/data/sqlite.sql
@@ -259,3 +259,25 @@ CREATE TABLE Comment
 INSERT INTO Comment (id,authorID,body) VALUES (3,1,'content for comment 1');
 INSERT INTO Comment (id,authorID,body) VALUES (5,1,'content for comment 2');
 INSERT INTO Comment (id,authorID,body) VALUES (6,1,'content for comment 3');
+
+CREATE TABLE UserWithDefaultScope
+(
+	id INTEGER NOT NULL PRIMARY KEY,
+	deleted INTEGER DEFAULT NULL,
+	`name` VARCHAR(255) NOT NULL
+);
+
+INSERT INTO UserWithDefaultScope (id,deleted,`name`) VALUES (1,NULL,'Fred Bloggs');
+INSERT INTO UserWithDefaultScope (id,deleted,`name`) VALUES (2,NULL,'Joe Bloggs');
+INSERT INTO UserWithDefaultScope (id,deleted,`name`) VALUES (3,NULL,'Jane Bloggs');
+
+CREATE TABLE UserWithDefaultScopeLink
+(
+	id INTEGER NOT NULL PRIMARY KEY,
+	from_id INTEGER NOT NULL,
+	to_id INTEGER NOT NULL
+);
+
+INSERT INTO UserWithDefaultScopeLink (id,from_id,to_id) VALUES (1,1,2);
+INSERT INTO UserWithDefaultScopeLink (id,from_id,to_id) VALUES (2,2,3);
+INSERT INTO UserWithDefaultScopeLink (id,from_id,to_id) VALUES (3,3,1);


### PR DESCRIPTION
Self referencing many to many relationship in a data provider uses cached criteria with outdated table alias since 1.1.11.

Issue: #1070
