### PR TITLE
Fixes #1076: CJavaScript::encode() was not compatible with PHP 5.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 
 Version 1.1.12 work in progress
 -------------------------------
+- Bug #1076: CJavaScript::encode() was not compatible with PHP 5.1 (samdark)
 - Bug #1077: Fixed the problem with alias in CSort (creocoder)
 - Bug #1072: Fixed the problem with getTableAlias() in defaultScope() (creocoder)
 - Enh #636: CManyManyRelation now parses foreign key for the junction table data internally, and provide public interface to access it (klimov-paul)

--- a/framework/web/helpers/CJavaScript.php
+++ b/framework/web/helpers/CJavaScript.php
@@ -82,7 +82,7 @@ class CJavaScript
 				return rtrim(sprintf('%.16F',$value),'0');  // locale-independent representation
 		}
 		else if($value instanceof CJavaScriptExpression)
-			return (string)$value;
+			return $value->__toString();
 		else if(is_object($value))
 			return self::encode(get_object_vars($value));
 		else if(is_array($value))


### PR DESCRIPTION
This one fixes #1076. Fix is trivial.
