### PR TITLE
fixed doc comment on ModelEvent

### DIFF
--- a/framework/base/CModelEvent.php
+++ b/framework/base/CModelEvent.php
@@ -35,7 +35,7 @@ class CModelEvent extends CEvent
 	 * You can access criteria in {@link CActiveRecord::beforeFind} via <code>$this->getDbCriteria()</code>
 	 * and in a behavior via <code>$this->owner->getDbCriteria()</code>.
 	 * @since 1.1.5
-	 * @deprecated
+	 * @deprecated since 1.1.7
 	 */
 	public $criteria;
 }


### PR DESCRIPTION
Deprecating CModelEvent::$criteria since it is not used anymore since yii 1.1.7 so its
comment should not confuse people like here:
http://www.yiiframework.com/forum/index.php/topic/33601-access-query-criteria-from-beforefind/page__view__findpost__p__161694

See #392 for more details.
