### PR TITLE
fix bug if checkbox name does not end with []

### DIFF
--- a/framework/zii/widgets/grid/CCheckBoxColumn.php
+++ b/framework/zii/widgets/grid/CCheckBoxColumn.php
@@ -100,8 +100,11 @@ class CCheckBoxColumn extends CGridColumn
 	 */
 	public function init()
 	{
-		if(isset($this->checkBoxHtmlOptions['name']))
+		if(isset($this->checkBoxHtmlOptions['name'])) {
 			$name=$this->checkBoxHtmlOptions['name'];
+			if(substr($name,-2)!=='[]')
+				$name.='[]';
+		}
 		else
 		{
 			$name=$this->id;


### PR DESCRIPTION
it's a bug appears when user enters checkbox name without '[]' at the end of the name. like: 'checkBoxHtmlOptions'=>array('name'=>"Catalogs"),
in this case, only one checkbox value appears after form submission.
