### PR TITLE
Fixes #1085: CTimestampBehavior tests sometimes failed due to mistake of time measurement

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,6 @@ Version 1.1.12 work in progress
 - Bug #1076: CJavaScript::encode() was not compatible with PHP 5.1 (samdark)
 - Bug #1077: Fixed the problem with alias in CSort (creocoder)
 - Bug #1072: Fixed the problem with getTableAlias() in defaultScope() (creocoder)
-- Bug #1085: CTimestampBehavior tests sometimes failed due to mistake of time measurement (resurtm)
 - Bug #1087: Reverted changes to CCookieCollection::add() introduced in 1.1.11 as they were triggering E_STRICT on some old PHP-versions(suralc)
 - Bug #1094: CGridView with enabled history used to clear page title in case sorting or paging performed (Opera and Firefox only) (resurtm)
 - Enh #636: CManyManyRelation now parses foreign key for the junction table data internally, and provide public interface to access it (klimov-paul)

--- a/tests/framework/zii/behaviors/CTimestampBehaviorTest.php
+++ b/tests/framework/zii/behaviors/CTimestampBehaviorTest.php
@@ -35,8 +35,9 @@ class CTimestampBehaviorTest extends CTestCase
 		));
 		$model1->title='testing-row-1';
 		$this->assertEquals(0,$model1->created_at);
+		$saveTime=time();
 		$model1->save();
-		$this->assertEquals(time(),$model1->created_at);
+		$this->assertEquals($saveTime,$model1->created_at);
 
 		// behavior changes created_at after inserting
 		$model2=new CTimestampBehaviorTestActiveRecord;
@@ -79,8 +80,9 @@ class CTimestampBehaviorTest extends CTestCase
 			'setUpdateOnCreate'=>false,
 		));
 		$this->assertEquals(1340529410,$model1->updated_at);
+		$saveTime=time();
 		$model1->save();
-		$this->assertEquals(time(),$model1->updated_at);
+		$this->assertEquals($saveTime,$model1->updated_at);
 
 		// behavior changes updated_at after updating
 		$model2=CTimestampBehaviorTestActiveRecord::model()->findByPk(2);
@@ -91,8 +93,9 @@ class CTimestampBehaviorTest extends CTestCase
 			'setUpdateOnCreate'=>true,
 		));
 		$this->assertEquals(1340529305,$model2->updated_at);
+		$saveTime=time();
 		$model2->save();
-		$this->assertEquals(time(),$model2->updated_at);
+		$this->assertEquals($saveTime,$model2->updated_at);
 
 		// behavior does not changes updated_at after updating
 		$model3=CTimestampBehaviorTestActiveRecord::model()->findByPk(3);
@@ -131,8 +134,9 @@ class CTimestampBehaviorTest extends CTestCase
 		$model5->title='testing-row-3';
 		$model5->updated_at=123123123;
 		$this->assertEquals(123123123,$model5->updated_at);
+		$saveTime=time();
 		$model5->save();
-		$this->assertEquals(time(),$model5->updated_at);
+		$this->assertEquals($saveTime,$model5->updated_at);
 	}
 }
 


### PR DESCRIPTION
Fixes #1085.

[![Build Status](https://secure.travis-ci.org/resurtm/yii.png?branch=1085-timestamp-behavior-test)](http://travis-ci.org/resurtm/yii)

Before making pull request i've executed tests hundred times to be sure.
