### PR TITLE
Fixes #1088 use proper id in CActiveForm when it's supplied in htmloptions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ Version 1.1.12 work in progress
 - Bug #1072: Fixed the problem with getTableAlias() in defaultScope() (creocoder)
 - Bug #1066: CMemCache: expiration time higher than 60*60*24*30 (31536000) seconds led the value to expire right away after saving (resurtm)
 - Bug #1087: Reverted changes to CCookieCollection::add() introduced in 1.1.11 as they were triggering E_STRICT on some old PHP-versions(suralc)
+- Bug #1088: Fixed usage of proper CACtiveForm id property when it's supplied with htmlOptions (mdomba)
 - Bug #1094: CGridView with enabled history used to clear page title in case sorting or paging performed (Opera and Firefox only) (resurtm)
 - Enh #243: CWebService is now able to deal with the customized WSDL generator classes, was hardcoded to the CWsdlGenerator before, added CWebService::$generatorConfig property (resurtm)
 - Enh #636: CManyManyRelation now parses foreign key for the junction table data internally, and provide public interface to access it (klimov-paul)

--- a/framework/web/widgets/CActiveForm.php
+++ b/framework/web/widgets/CActiveForm.php
@@ -319,6 +319,9 @@ class CActiveForm extends CWidget
 	{
 		if(!isset($this->htmlOptions['id']))
 			$this->htmlOptions['id']=$this->id;
+		else
+			$this->id=$this->htmlOptions['id'];
+
 		if($this->stateful)
 			echo CHtml::statefulForm($this->action, $this->method, $this->htmlOptions);
 		else


### PR DESCRIPTION
Issue #1088
