### PR TITLE
#1109: Fixed "js:" encoding BC-break in CHtml::ajax() and related methods introduced in 1.1.11, added tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ Version 1.1.12 work in progress
 - Bug #1087: Reverted changes to CCookieCollection::add() introduced in 1.1.11 as they were triggering E_STRICT on some old PHP-versions (suralc)
 - Bug #1088: Fixed usage of proper CActiveForm id property when it's supplied with htmlOptions (mdomba)
 - Bug #1094: CGridView with enabled history used to clear page title in case sorting or paging performed (Opera and Firefox only) (resurtm)
+- Bug #1109: Fixed "js:" encoding BC-break in CHtml::ajax() and related methods introduced in 1.1.11 (samdark)
 - Enh #243: CWebService is now able to deal with the customized WSDL generator classes, was hardcoded to the CWsdlGenerator before, added CWebService::$generatorConfig property (resurtm)
 - Enh #636: CManyManyRelation now parses foreign key for the junction table data internally, and provide public interface to access it (klimov-paul)
 

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -56,11 +56,11 @@ class CHtml
 	/**
 	 * Sets the default style for attaching jQuery event handlers.
 	 *
-	 * If set to true (default), event handlers are delegated. 
-	 * Event handlers are attached to the document body and can process events 
+	 * If set to true (default), event handlers are delegated.
+	 * Event handlers are attached to the document body and can process events
 	 * from descendant elements that are added to the document at a later time.
 	 *
-	 * If set to false, event handlers are directly bound. 
+	 * If set to false, event handlers are directly bound.
 	 * Event handlers are attached directly to the DOM element, that must already exist
 	 * on the page. Elements injected into the page at a later time will not be processed.
 	 *
@@ -1047,8 +1047,11 @@ EOD;
 			$options['data']=new CJavaScriptExpression('jQuery(this).parents("form").serialize()');
 		foreach(array('beforeSend','complete','error','success') as $name)
 		{
-			if(isset($options[$name]) && (!($options[$name] instanceof CJavaScriptExpression) || strpos($options[$name],'js:')!==0))
-				$options[$name]=new CJavaScriptExpression($options[$name]);
+			if(isset($options[$name]) && !($options[$name] instanceof CJavaScriptExpression))
+			{
+				if(!is_string($options[$name]) || strpos($options[$name],'js:')!==0)
+					$options[$name]=new CJavaScriptExpression($options[$name]);
+			}
 		}
 		if(isset($options['update']))
 		{

--- a/tests/framework/web/helpers/CHtmlTest.php
+++ b/tests/framework/web/helpers/CHtmlTest.php
@@ -885,6 +885,23 @@ class CHtmlTest extends CTestCase
 		$this->assertTrue(mb_strpos($output, $clientScriptOutput)!==false);
 	}
 
+	public function testAjaxCallbacks()
+	{
+		$out=CHtml::ajax(array(
+			'success'=>'js:function() { /* callback */ }',
+		));
+		$this->assertTrue(mb_strpos($out,"'success':function() { /* callback */ }", null, Yii::app()->charset)!==false, "Unexpected JavaScript: ".$out);
+
+		$out=CHtml::ajax(array(
+			'success'=>'function() { /* callback */ }',
+		));
+		$this->assertTrue(mb_strpos($out,"'success':function() { /* callback */ }", null, Yii::app()->charset)!==false, "Unexpected JavaScript: ".$out);
+
+		$out=CHtml::ajax(array(
+			'success'=>new CJavaScriptExpression('function() { /* callback */ }'),
+		));
+		$this->assertTrue(mb_strpos($out,"'success':function() { /* callback */ }", null, Yii::app()->charset)!==false, "Unexpected JavaScript: ".$out);
+	}
 }
 
 /* Helper classes */

--- a/tests/framework/web/helpers/CJavaScriptExpressionTest.php
+++ b/tests/framework/web/helpers/CJavaScriptExpressionTest.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * CJavaScriptExpressionTest
+ */
+class CJavaScriptExpressionTest extends CTestCase
+{
+	public function testToString()
+	{
+		$expression=new CJavaScriptExpression("function(){return \"Hello, world!\";}");
+		$this->assertEquals('function(){return "Hello, world!";}', $expression);
+	}
+}

--- a/tests/framework/web/helpers/CJavaScriptTest.php
+++ b/tests/framework/web/helpers/CJavaScriptTest.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * CJavaScriptTest
+ */
+class CJavaScriptTest extends CTestCase
+{
+	public function testLegacyEncode()
+	{
+		$expression=CJavaScript::encode("js:function() { /* callback */ }");
+		$this->assertEquals("function() { /* callback */ }",$expression);
+	}
+
+	public function testLegacyEncodeSafe()
+	{
+		$expression=CJavaScript::encode("js:function() { /* callback */ }",true);
+		$this->assertEquals("'js:function() { /* callback */ }'",$expression);
+	}
+
+	public function testEncode()
+	{
+		$expression=CJavaScript::encode(new CJavaScriptExpression("function() { /* callback */ }"));
+		$this->assertEquals("function() { /* callback */ }",$expression);
+	}
+}


### PR DESCRIPTION
#1109
