### PR TITLE
fix ehn #291

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ Version 1.1.12 work in progress
 - Bug #1120: Fixed duplicate events processing in CGridView when ENTER was pressed for filtering (mdomba)
 - Enh #243: CWebService is now able to deal with the customized WSDL generator classes, was hardcoded to the CWsdlGenerator before, added CWebService::$generatorConfig property (resurtm)
 - Enh #636: CManyManyRelation now parses foreign key for the junction table data internally, and provide public interface to access it (klimov-paul)
+- Enh #291: CFormatter::formatDate and formatDateTime are also accept strings in strtotime() format now (francis_tm)
 
 Version 1.1.11 July 29, 2012
 ----------------------------

--- a/framework/utils/CFormatter.php
+++ b/framework/utils/CFormatter.php
@@ -165,7 +165,9 @@ class CFormatter extends CApplicationComponent
 	 */
 	public function formatDate($value)
 	{
-		return date($this->dateFormat,$value);
+		$value = is_numeric($value) ? $value : strtotime($value);
+
+		return date($this->dateFormat, $value);
 	}
 
 	/**
@@ -176,7 +178,9 @@ class CFormatter extends CApplicationComponent
 	 */
 	public function formatTime($value)
 	{
-		return date($this->timeFormat,$value);
+		$value = is_numeric($value) ? $value : strtotime($value);
+
+		return date($this->timeFormat, $value);
 	}
 
 	/**
@@ -187,7 +191,8 @@ class CFormatter extends CApplicationComponent
 	 */
 	public function formatDatetime($value)
 	{
-		return date($this->datetimeFormat,$value);
+		$value = is_numeric($value) ? $value : strtotime($value);
+		return date($this->datetimeFormat, $value);
 	}
 
 	/**


### PR DESCRIPTION
`CFormatter::formatDate` and `formatDateTime` are also accept strings in strtotime() for ehn #291, now.
