### PR TITLE
Allow the cruds generation for tables with composite primary keys

### DIFF
--- a/framework/cli/views/webapp/protected/components/GeneralModel.php
+++ b/framework/cli/views/webapp/protected/components/GeneralModel.php
@@ -1,0 +1,150 @@
+<?php
+class GeneralModel extends CActiveRecord
+{	
+	// This method allows you assign next values to table's primary key without worry for if 
+	// is it a compound key or a simple key. This happends before insert data into table
+	// This benefit was made for the most popular databases and saves you create code for that purpose,
+	// The only thing you have to do for use it is extend your model's class from this class (GeneralModel).
+	// If you have to do something different in "beforeSave" method, you can rewrite this method in your model's class for do what you want.
+	public function beforeSave(){
+		
+		if ($this->getIsNewRecord()){
+			$table = $this->getMetaData()->tableSchema;
+			$arrayDBConnection = explode(':',Yii::app()->db->connectionString);
+			// $dbType variable stores the database type, its value can be... 
+			// oci => it means Oracle database
+			// pgsql => it means PostgreSQL database
+			// mysql => it means MySQL database
+			// mssql => it means SQL Server database
+			// sqlite => it means SQLite database
+			$dbType = strtolower($arrayDBConnection[0]);
+						
+			// If the primary key is a simple key
+			if(is_string($table->primaryKey)){
+								
+				//if the property has a value, we do nothing
+				if ($this->{$table->primaryKey})
+					return true;
+				
+				// The switch statement is used for compatibility with most popular database engines
+				switch ($dbType) {
+					case 'oci':
+						$sqlSentence = 'select nvl(max('.$table->primaryKey.'),0)+1 from '.$this->tableName();
+						break;
+					
+					case 'mysql':
+						$sqlSentence = 'select IFNULL(MAX('.$table->primaryKey.'),0)+1 from '.$this->tableName();
+						break;
+
+					case 'pgsql':
+						$sqlSentence = 'select coalesce(max('.$table->primaryKey.'),0)+1 from '.$this->tableName();
+						break;
+						
+					case 'mssql':
+						$sqlSentence = 'select ISNULL(MAX('.$table->primaryKey.'),0)+1 from '.$this->tableName();
+						break;
+						
+					case 'sqlite':
+						$sqlSentence = 'select ifnull(max('.$table->primaryKey.'),0)+1 from '.$this->tableName();
+						break;
+						
+					default:
+						$sqlSentence = '';
+						break;
+				}
+				
+				$command = Yii::app()->db->createCommand($sqlSentence);
+				// The next line returns the value of the first column in the first row of data.
+				$result = $command->queryScalar();
+				// If we got a result from the query 
+				if ($result)
+					$this->{$table->primaryKey} = $result;
+			}
+			// If the primary key is a compound key	
+			else if(is_array($table->primaryKey)){
+				// Every item of the compound key is evaluated to know if is a foreign key, if not,  
+				// the query returns data with the next value for assign it to the field, when this is numeric.
+				$select = 'select';
+				$where = '1 = 1';
+				foreach($table->primaryKey as $nameField){
+					//if is it a foreign key
+					if ($table->getColumn($nameField)->isForeignKey){
+						//if the field is not null
+						if ($this->{$nameField}){
+							$where .= ' AND '.$nameField.' = '.$this->{$nameField};
+						}else{
+							$this->addError($nameField,'Por favor ingrese un valor para el campo '.$nameField);
+							return false;
+						}
+					//If is it a numeric field (integer or float)
+					}else if(strcmp($table->getColumn($nameField)->type, 'integer') == 0 || strcmp($table->getColumn($nameField)->type, 'float') == 0){
+						
+						// The switch statement is used for compatibility with most popular database engines
+						switch ($dbType) {
+							case 'oci':
+								$select .= ' nvl(max('.$nameField.'),0)+1 as '.$nameField.', ';
+								break;
+									
+							case 'mysql':
+								$select .= ' IFNULL(MAX('.$nameField.'),0)+1 as '.$nameField.', ';
+								break;
+						
+							case 'pgsql':
+								$select .= ' coalesce(max('.$nameField.'),0)+1 as '.$nameField.', ';
+								break;
+						
+							case 'mssql':
+								$select .= ' ISNULL(MAX('.$nameField.'),0)+1 as '.$nameField.', ';
+								break;
+						
+							case 'sqlite':
+								$select .= ' ifnull(max('.$nameField.'),0)+1 as '.$nameField.', ';
+								break;
+						
+							default:
+								$sqlSentence = '';
+								break;
+						}						
+						
+					//If is it a string field and the value is null, we not sugguest the next value, i mean, we request to user fill the field
+					}else if(strcmp($table->getColumn($nameField)->type, 'string') == 0 && $this->{$nameField} == null){
+						$this->addError($nameField,'Please insert a value for field'.$nameField);
+						return false;
+					}
+				}
+			
+				// If the query was builded
+				if (strcmp($select, 'select') != 0){
+					
+					$select = substr($select, 0, -2);
+					$sqlSentence = $select.' from '.$this->tableName().' where '.$where;
+					$command = Yii::app()->db->createCommand($sqlSentence);
+					// The next line returns the value of the first row of data
+					$result = $command->queryRow();
+					// If we got a result from the query 
+					if (is_array($result)){
+						// we get the associative indexes from the first row of data returned
+						$arrayQueryKeys = array_keys($result);
+						// we assign the values for each property of the object to be inserted in database
+						foreach ($arrayQueryKeys as $column){
+							$this->{$column} = $result[$column];
+						}
+					}
+				}
+			}
+		}
+		return true;
+	}
+	
+	
+	// This method allows you list data from a model in order to create a HMTL select item (drop down list) in the form file.
+	// This means helpers when you want to create or update a row in a transactional table who has fields that depends from other tables.
+	// You can call this method from your _form file and deliver it the model's name, the id and description fields who you want get for
+	// list in the html select item  
+	// for Example: echo CHtml::activeDropDownList($model,'BANK_ID', $model->getListDataForeingModel('BANKS', 'BANK_ID', 'BANK_NAME'),array('prompt' => '(Select an option)')); 
+	public function getListDataForeingModel($modelName, $idName, $descriptionName){
+		// CHtml::listData method returns the data list from the model, id and description's names send by parameter 
+		return CHtml::listData($modelName::model()->findAll(), $idName, $descriptionName);
+	}
+	
+}

--- a/framework/db/schema/pgsql/CPgsqlColumnSchema.php
+++ b/framework/db/schema/pgsql/CPgsqlColumnSchema.php
@@ -28,7 +28,7 @@ class CPgsqlColumnSchema extends CDbColumnSchema
 			$this->type='string';
 		else if(strpos($dbType,'bool')!==false)
 			$this->type='boolean';
-		else if(preg_match('/(real|float|double)/',$dbType))
+		else if(preg_match('/(real|float|double|numeric)/',$dbType)) //you forgot the numeric database type
 			$this->type='double';
 		else if(preg_match('/(integer|oid|serial|smallint)/',$dbType))
 			$this->type='integer';

--- a/framework/gii/generators/crud/templates/default/_form.php
+++ b/framework/gii/generators/crud/templates/default/_form.php
@@ -24,10 +24,11 @@
 <?php
 foreach($this->tableSchema->columns as $column)
 {
-	if($column->autoIncrement)
+	//If column is autoIncrement or ( if is integer, float or double primary key and is not a ForeignKey ) 
+	if($column->autoIncrement || ($column->isPrimaryKey && preg_match('/(integer|float|double)/',$column->type) && !$column->isForeignKey))
 		continue;
 ?>
-	<div class="row">
+	<div class="row"<?php if ($column->isPrimaryKey) echo " <?php if (!\$model->isNewRecord) echo \"style='display: none;'\"; ?>"; ?>>
 		<?php echo "<?php echo ".$this->generateActiveLabel($this->modelClass,$column)."; ?>\n"; ?>
 		<?php echo "<?php echo ".$this->generateActiveField($this->modelClass,$column)."; ?>\n"; ?>
 		<?php echo "<?php echo \$form->error(\$model,'{$column->name}'); ?>\n"; ?>

--- a/framework/gii/generators/crud/templates/default/_view.php
+++ b/framework/gii/generators/crud/templates/default/_view.php
@@ -12,8 +12,23 @@
 <div class="view">
 
 <?php
-echo "\t<b><?php echo CHtml::encode(\$data->getAttributeLabel('{$this->tableSchema->primaryKey}')); ?>:</b>\n";
-echo "\t<?php echo CHtml::link(CHtml::encode(\$data->{$this->tableSchema->primaryKey}), array('view', 'id'=>\$data->{$this->tableSchema->primaryKey})); ?>\n\t<br />\n\n";
+if(is_string($this->tableSchema->primaryKey)){
+	echo "\t<b><?php echo CHtml::encode(\$data->getAttributeLabel('{$this->tableSchema->primaryKey}')); ?>:</b>\n";
+	echo "\t<?php echo CHtml::link(CHtml::encode(\$data->{$this->tableSchema->primaryKey}), array('view', 'id'=>\$data->{$this->tableSchema->primaryKey})); ?>\n\t<br />\n\n";
+}
+else if(is_array($this->tableSchema->primaryKey)){
+	//for composite primary keys, id is separated by the "|" character
+	$strPrimaryKeys = $strHtmlFields = '';
+	
+	foreach($this->tableSchema->primaryKey as $name){
+		$strHtmlFields .= "\t<b><?php echo CHtml::encode(\$data->getAttributeLabel('{$name}')); ?>:</b>\n";
+		$strHtmlFields .= "\t<?php echo CHtml::link(CHtml::encode(\$data->{$name}), array('view', 'id'=>idStringToReplaceLink)); ?>\n\t<br />\n\n";
+		$strPrimaryKeys .= "\$data->{$name}.'|'.";
+	}
+	$strPrimaryKeys = substr($strPrimaryKeys, 0, -5);
+	echo str_replace('idStringToReplaceLink', $strPrimaryKeys, $strHtmlFields);
+}
+
 $count=0;
 foreach($this->tableSchema->columns as $column)
 {

--- a/framework/gii/generators/crud/templates/default/controller.php
+++ b/framework/gii/generators/crud/templates/default/controller.php
@@ -4,6 +4,24 @@
  * The following variables are available in this template:
  * - $this: the CrudCode object
  */
+if (is_array($this->tableSchema->primaryKey)){
+	//for composite primary keys, id is separated by the "|" character
+	$i=0; $strFields = $strModel = '';
+	foreach($this->tableSchema->primaryKey as $nameField){
+		$strFields .= '\''.$nameField.'\' => $arrayId['.$i.'], ';
+		$strModel .= '$model->'.$nameField.'.\'|\'.';
+		$i++;
+	}
+	if ($strFields){
+		$strPkIds = '$arrayId = explode(\'|\',$id);'."\n\t\t";
+		$strFields = substr($strFields, 0, -2);
+		$strPkIds .= '$id = array('.$strFields.');'."\n";
+		$strModel = substr($strModel, 0, -5);
+	}
+}else{
+	$strPkIds = "\n";
+	$strModel = '$model->'.$this->tableSchema->primaryKey;
+}
 ?>
 <?php echo "<?php\n"; ?>
 
@@ -78,7 +96,7 @@ class <?php echo $this->controllerClass; ?> extends <?php echo $this->baseContro
 		{
 			$model->attributes=$_POST['<?php echo $this->modelClass; ?>'];
 			if($model->save())
-				$this->redirect(array('view','id'=>$model-><?php echo $this->tableSchema->primaryKey; ?>));
+				$this->redirect(array('view','id'=><?php echo $strModel; ?>));
 		}
 
 		$this->render('create',array(
@@ -102,7 +120,7 @@ class <?php echo $this->controllerClass; ?> extends <?php echo $this->baseContro
 		{
 			$model->attributes=$_POST['<?php echo $this->modelClass; ?>'];
 			if($model->save())
-				$this->redirect(array('view','id'=>$model-><?php echo $this->tableSchema->primaryKey; ?>));
+				$this->redirect(array('view','id'=><?php echo $strModel; ?>));
 		}
 
 		$this->render('update',array(
@@ -157,6 +175,7 @@ class <?php echo $this->controllerClass; ?> extends <?php echo $this->baseContro
 	 */
 	public function loadModel($id)
 	{
+		<?php echo $strPkIds; ?>
 		$model=<?php echo $this->modelClass; ?>::model()->findByPk($id);
 		if($model===null)
 			throw new CHttpException(404,'The requested page does not exist.');

--- a/framework/gii/generators/crud/templates/default/update.php
+++ b/framework/gii/generators/crud/templates/default/update.php
@@ -3,6 +3,18 @@
  * The following variables are available in this template:
  * - $this: the CrudCode object
  */
+if (is_array($this->tableSchema->primaryKey)){
+	//for composite primary keys, id is separated by the "|" character
+	$strFields = '';
+	foreach($this->tableSchema->primaryKey as $nameField){
+		$strFields .= '$model->'.$nameField.'.\'|\'.';
+	}
+	if ($strFields){
+		$strFields = substr($strFields, 0, -5);
+	}
+}else{
+	$strFields = '$model->'.$this->tableSchema->primaryKey;
+}
 ?>
 <?php echo "<?php\n"; ?>
 /* @var $this <?php echo $this->getControllerClass(); ?> */
@@ -13,7 +25,7 @@ $nameColumn=$this->guessNameColumn($this->tableSchema->columns);
 $label=$this->pluralize($this->class2name($this->modelClass));
 echo "\$this->breadcrumbs=array(
 	'$label'=>array('index'),
-	\$model->{$nameColumn}=>array('view','id'=>\$model->{$this->tableSchema->primaryKey}),
+	\$model->{$nameColumn}=>array('view','id'=>$strFields),
 	'Update',
 );\n";
 ?>
@@ -21,11 +33,11 @@ echo "\$this->breadcrumbs=array(
 $this->menu=array(
 	array('label'=>'List <?php echo $this->modelClass; ?>', 'url'=>array('index')),
 	array('label'=>'Create <?php echo $this->modelClass; ?>', 'url'=>array('create')),
-	array('label'=>'View <?php echo $this->modelClass; ?>', 'url'=>array('view', 'id'=>$model-><?php echo $this->tableSchema->primaryKey; ?>)),
+	array('label'=>'View <?php echo $this->modelClass; ?>', 'url'=>array('view', 'id'=><?php echo $strFields; ?>)),
 	array('label'=>'Manage <?php echo $this->modelClass; ?>', 'url'=>array('admin')),
 );
 ?>
 
-<h1>Update <?php echo $this->modelClass." <?php echo \$model->{$this->tableSchema->primaryKey}; ?>"; ?></h1>
+<h1>Update <?php echo $this->modelClass." <?php echo $strFields; ?>"; ?></h1>
 
 <?php echo "<?php echo \$this->renderPartial('_form', array('model'=>\$model)); ?>"; ?>

--- a/framework/gii/generators/crud/templates/default/view.php
+++ b/framework/gii/generators/crud/templates/default/view.php
@@ -3,6 +3,18 @@
  * The following variables are available in this template:
  * - $this: the CrudCode object
  */
+if (is_array($this->tableSchema->primaryKey)){
+	//for composite primary keys, id is separated by the "|" character
+	$strFields = '';
+	foreach($this->tableSchema->primaryKey as $nameField){
+		$strFields .= '$model->'.$nameField.'.\'|\'.';
+	}
+	if ($strFields){
+		$strFields = substr($strFields, 0, -5);
+	}
+}else{
+	$strFields = '$model->'.$this->tableSchema->primaryKey;
+}
 ?>
 <?php echo "<?php\n"; ?>
 /* @var $this <?php echo $this->getControllerClass(); ?> */
@@ -20,13 +32,13 @@ echo "\$this->breadcrumbs=array(
 $this->menu=array(
 	array('label'=>'List <?php echo $this->modelClass; ?>', 'url'=>array('index')),
 	array('label'=>'Create <?php echo $this->modelClass; ?>', 'url'=>array('create')),
-	array('label'=>'Update <?php echo $this->modelClass; ?>', 'url'=>array('update', 'id'=>$model-><?php echo $this->tableSchema->primaryKey; ?>)),
-	array('label'=>'Delete <?php echo $this->modelClass; ?>', 'url'=>'#', 'linkOptions'=>array('submit'=>array('delete','id'=>$model-><?php echo $this->tableSchema->primaryKey; ?>),'confirm'=>'Are you sure you want to delete this item?')),
+	array('label'=>'Update <?php echo $this->modelClass; ?>', 'url'=>array('update', 'id'=><?php echo $strFields; ?>)),
+	array('label'=>'Delete <?php echo $this->modelClass; ?>', 'url'=>'#', 'linkOptions'=>array('submit'=>array('delete','id'=><?php echo $strFields; ?>),'confirm'=>'Are you sure you want to delete this item?')),
 	array('label'=>'Manage <?php echo $this->modelClass; ?>', 'url'=>array('admin')),
 );
 ?>
 
-<h1>View <?php echo $this->modelClass." #<?php echo \$model->{$this->tableSchema->primaryKey}; ?>"; ?></h1>
+<h1>View <?php echo $this->modelClass." # <?php echo $strFields; ?>"; ?></h1>
 
 <?php echo "<?php"; ?> $this->widget('zii.widgets.CDetailView', array(
 	'data'=>$model,

--- a/framework/gii/generators/model/ModelCode.php
+++ b/framework/gii/generators/model/ModelCode.php
@@ -211,17 +211,34 @@ class ModelCode extends CCodeModel
 		$numerical=array();
 		$length=array();
 		$safe=array();
+		$float=array(); //support for float type for create rule with regular expression for length control
 		foreach($table->columns as $column)
 		{
-			if($column->autoIncrement)
+			//If column is autoIncrement or ( if is integer, float or double primary key and is not a ForeignKey ) 
+			if($column->autoIncrement || ($column->isPrimaryKey && preg_match('/(integer|float|double)/',$column->type) && !$column->isForeignKey))
 				continue;
 			$r=!$column->allowNull && $column->defaultValue===null;
 			if($r)
 				$required[]=$column->name;
-			if($column->type==='integer')
+			if($column->type==='integer'){
 				$integers[]=$column->name;
-			else if($column->type==='double')
+				//support for length control in form input for integer type
+				if ($column->precision>0)
+					$length[$column->precision][]=$column->name;
+			}
+			else if($column->type==='double'){
 				$numerical[]=$column->name;
+				//support for length control in form input for double type
+				if ($column->precision>0){
+					if ($column->scale>0){
+						$precisionLength=$column->precision+1;
+						$float[$column->precision-$column->scale.'-'.$column->scale][]=$column->name;
+					}else{
+						$precisionLength=$column->precision;
+					}
+					$length[$precisionLength][]=$column->name;
+				}
+			}
 			else if($column->type==='string' && $column->size>0)
 				$length[$column->size][]=$column->name;
 			else if(!$column->isPrimaryKey && !$r)
@@ -238,6 +255,15 @@ class ModelCode extends CCodeModel
 			foreach($length as $len=>$cols)
 				$rules[]="array('".implode(', ',$cols)."', 'length', 'max'=>$len)";
 		}
+		if ($float!==array())
+		{
+			//support for length control in form input for double type with regular expression
+			foreach($float as $len=>$cols){
+				$aux = explode('-',$len);
+				$rules[]="array('".implode(', ',$cols)."', 'match', 'pattern'=>'/^\d{1,$aux[0]}(\.\d{1,$aux[1]})?$/')";
+			}
+		}
+		
 		if($safe!==array())
 			$rules[]="array('".implode(', ',$safe)."', 'safe')";
 
@@ -358,8 +384,9 @@ class ModelCode extends CCodeModel
 		$className='';
 		foreach(explode('_',$tableName) as $name)
 		{
+			// Database objects in Oracle and Postgresql are always in uppercase, for that reason content of variable $name is set to lowercase first
 			if($name!=='')
-				$className.=ucfirst($name);
+				$className.=ucfirst(strtolower($name));
 		}
 		return $className;
 	}

--- a/framework/gii/generators/model/templates/default/model.php
+++ b/framework/gii/generators/model/templates/default/model.php
@@ -50,7 +50,12 @@
 <?php endforeach; ?>
 <?php endif; ?>
  */
-class <?php echo $modelClass; ?> extends <?php echo $this->baseClass."\n"; ?>
+// The commented "extends <?php echo $this->baseClass;?>" is necesary if you don't want to work with GeneralModel component,
+// by default, this line is commented for use GeneralModel class who extends from CActiveRecord
+// and delivers general methods who make easy view, update and insert data in database tables with composite primary keys.
+// The GeneralModel class also makes easy to implement drop down lists for parameter tables
+// class <?php echo $modelClass; ?> extends <?php echo $this->baseClass."\n"; ?>
+class <?php echo $modelClass; ?> extends GeneralModel
 {
 	/**
 	 * Returns the static model of the specified AR class.

--- a/framework/gii/generators/model/views/index.php
+++ b/framework/gii/generators/model/views/index.php
@@ -24,7 +24,7 @@ $('#{$class}_tableName').bind('keyup change', function(){
 		var modelClass='';
 		$.each(tableName.split('_'), function() {
 			if(this.length>0)
-				modelClass+=this.substring(0,1).toUpperCase()+this.substring(1);
+				modelClass+=this.substring(0,1).toUpperCase()+this.substring(1).toLowerCase();
 		});
 		model.val(modelClass);
 	}


### PR DESCRIPTION
Modifications to allow the cruds generation for tables with composite primary keys. It adds functionality (new feature) to allow the creation of cruds of all tables with models created using the \* character as well as in the model builder. Creation of GeneralModel class who extends from CActiveRecord and delivers general methods who make easy view, update and insert data in database tables with composite primary keys. The GeneralModel class also makes easy to implement drop down lists for parameter tables. Finally i did improvement for CPgsqlColumnSchema class for recognize numeric database type
