### PR TITLE
Fix for issue #1192

### DIFF
--- a/framework/web/filters/CHttpCacheFilter.php
+++ b/framework/web/filters/CHttpCacheFilter.php
@@ -41,7 +41,8 @@ class CHttpCacheFilter extends CFilter
 	 */
 	public $etagSeedExpression;
 	/**
-	 * Http cache control headers
+	 * Http cache control headers. Set this to an empty string in order to keep this
+	 * header from being sent entirely.
 	 * @var string
 	 */
 	public $cacheControl = 'max-age=3600, public';


### PR DESCRIPTION
This PR should fix the issue described in #1192: The custom `Cache-Control` header values are now being sent among 304 responses. There's also a small phpdoc update.
