### PR TITLE
Model name improvement for Oracle and Postgresql in code generation

### DIFF
--- a/framework/gii/generators/model/ModelCode.php
+++ b/framework/gii/generators/model/ModelCode.php
@@ -359,7 +359,7 @@ class ModelCode extends CCodeModel
 		foreach(explode('_',$tableName) as $name)
 		{
 			if($name!=='')
-				$className.=ucfirst($name);
+				$className.=ucfirst(strtolower($name));
 		}
 		return $className;
 	}

--- a/framework/gii/generators/model/views/index.php
+++ b/framework/gii/generators/model/views/index.php
@@ -24,7 +24,7 @@ $('#{$class}_tableName').bind('keyup change', function(){
 		var modelClass='';
 		$.each(tableName.split('_'), function() {
 			if(this.length>0)
-				modelClass+=this.substring(0,1).toUpperCase()+this.substring(1);
+				modelClass+=this.substring(0,1).toUpperCase()+this.substring(1).toLowerCase();
 		});
 		model.val(modelClass);
 	}


### PR DESCRIPTION
Database objects in Oracle and Postgresql are always in uppercase, for that reason the table's name is set to lowercase first
