### PR TITLE
Enh #486: Minimal $gCProbability value has been changed to the 0.001%, was 1% before, default value left unchanged (1%).

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
 
 Version 1.1.13 work in progress
 -------------------------------
-- Enh #486: CHttpSession::$gCProbability and CDbHttpSession::$gCProbability are floats now. Minimal $gCProbability value has been changed to the 0.001%, was 1% before, default value left unchanged (1%) (resurtm)
+- Enh #486: CHttpSession::$gCProbability and CDbHttpSession::$gCProbability are floats now. Minimal possible $gCProbability value has been changed to the ≈0.00000005% (1/2147483647), was integer 1% before, default value left unchanged (1%) (resurtm)
 - Enh #556: CDbColumnSchema::$comment property has been added. It stores comment for the table column, comment retrieving is working for MySQL, PgSQL and Oracle (resurtm)
 - Enh: Fixed the check for ajaxUpdate false value in jquery.yiilistview.js as that never happens (mdomba)
 

--- a/framework/web/CHttpSession.php
+++ b/framework/web/CHttpSession.php
@@ -77,7 +77,6 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 	 */
 	public $autoStart=true;
 
-
 	/**
 	 * Initializes the application component.
 	 * This method is required by IApplicationComponent and is invoked by application.
@@ -86,9 +85,9 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 	{
 		parent::init();
 
-		// default session gc probability is 1%: 1000/100000 = 0.01 = 1%
-		ini_set('session.gc_probability','1000');
-		ini_set('session.gc_divisor','100000');
+		// default session gc probability is 1%: 21474837/2147483647 ≈ 0.01 ≈ 1%
+		ini_set('session.gc_probability',21474837);
+		ini_set('session.gc_divisor',2147483647);
 
 		if($this->autoStart)
 			$this->open();
@@ -293,7 +292,7 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 	 */
 	public function getGCProbability()
 	{
-		return (float)(ini_get('session.gc_probability'))/1000;
+		return ini_get('session.gc_probability')/ini_get('session.gc_divisor')*100;
 	}
 
 	/**
@@ -302,14 +301,14 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 	 */
 	public function setGCProbability($value)
 	{
-		$value=(float)$value;
-		if($value>=0.001 && $value<=99.999)
+		if($value>=0 && $value<=100)
 		{
-			ini_set('session.gc_probability',$value*1000);
-			ini_set('session.gc_divisor','100000');
+			// percent * 21474837 / 2147483647 ≈ percent * 0.01
+			ini_set('session.gc_probability',$value*21474837);
+			ini_set('session.gc_divisor',2147483647);
 		}
 		else
-			throw new CException(Yii::t('yii','CHttpSession.gcProbability "{value}" is invalid. It must be a float between 0.001 and 99.999.',
+			throw new CException(Yii::t('yii','CHttpSession.gcProbability "{value}" is invalid. It must be a float between 0 and 100.',
 				array('{value}'=>$value)));
 	}
 


### PR DESCRIPTION
Enh #486: Minimal $gCProbability value has been changed to the 0.001%, was 1% before, default value left unchanged (1%).
