### PR TITLE
Update autoload function in compliance with psr-0 standard

### DIFF
--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -420,11 +420,19 @@ class YiiBase
 					}
 				}
 				else
-					include($className.'.php');
+				{
+					@include($className.'.php');
+					if(!(class_exists($className,false) || interface_exists($className,false)) && strpos($className,'_')!==false)
+					{
+						// Try namespaced version of class name
+						$namespacedClassName=str_replace('_',DIRECTORY_SEPARATOR,$className);
+						include($namespacedClassName.'.php');
+					}
+				}
 			}
 			else  // class name with namespace in PHP 5.3
 			{
-				$namespace=str_replace('\\','.',ltrim($className,'\\'));
+				$namespace=str_replace(array('\\','_'),'.',ltrim($className,'\\'));
 				if(($path=self::getPathOfAlias($namespace))!==false)
 					include($path.'.php');
 				else


### PR DESCRIPTION
From the [psr-0 specification](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md):

> # Mandatory
> 
> ...
> - Each "_" character in the CLASS NAME is converted to a 
>   `DIRECTORY_SEPARATOR`. The "_" character has no special meaning in the 
>   namespace.

Currently, Yii's autoloading functionality only recognizes class names as being namespaced when a backslash character is present. This breaks autoloading for older-style namespaced libraries, such as the Zend Framework v1.x. The only workaround is to then manually include the files, as seen in [this Yii docs guide](http://www.yiiframework.com/doc/guide/1.1/en/extension.integration).

This commit modifies the non-namespaced autoloader code to first attempt loading the bare class name from the include path. If that fails, and the class name has underscores present, the autoloader replaces those underscores with directory separators and tries again. Additionally, the namespace autoloader code is modified to replace underscores in the base class name with directory separators, in compliance with the psr-0 standard.
