### PR TITLE
Fix wrong offset in SQL Server when not using ORDER BY

### DIFF
--- a/framework/db/schema/mssql/CMssqlCommandBuilder.php
+++ b/framework/db/schema/mssql/CMssqlCommandBuilder.php
@@ -199,18 +199,13 @@ class CMssqlCommandBuilder extends CDbCommandBuilder
 	 */
 	protected function rewriteLimitOffsetSql($sql, $limit, $offset)
 	{
-	    $fetch = $limit+$offset;
-	    $sql = "
-		SELECT * FROM (
-		SELECT
-		    ROW_NUMBER() OVER(ORDER BY (SELECT 1)) AS [__RowNumber__],
-		    *
-		    FROM (
-		        $sql
-		    ) as [__inner__]
-		) as [__outer__]
-		WHERE [__RowNumber__] BETWEEN $limit AND $fetch";
-	    return $sql;
+		$end = $limit+$offset;
+		$start = ($limit-1) * ($offset+1);
+		$ordering = $this->findOrdering($sql);
+		$orginalOrdering = $this->joinOrdering($ordering, '[__outer__]');
+		$sql = preg_replace('/( ORDER BY)[\s"\[](.*)(ASC|DESC)?(?:[\s"\[]|$|COMPUTE|FOR)/i','',$sql);
+		$sql = "SELECT * FROM (SELECT ROW_NUMBER() OVER(ORDER BY (SELECT 1)) AS [__RowNumber__], * FROM ({$sql}) as [__inner__]) as [__outer__] WHERE [__RowNumber__] BETWEEN {$start} AND {$end} {$orginalOrdering}";
+		return $sql;
 	}
 
 	/**

--- a/framework/db/schema/mssql/CMssqlCommandBuilder.php
+++ b/framework/db/schema/mssql/CMssqlCommandBuilder.php
@@ -203,7 +203,7 @@ class CMssqlCommandBuilder extends CDbCommandBuilder
 		$start = ($limit-1) * ($offset+1);
 		$ordering = $this->findOrdering($sql);
 		$orginalOrdering = $this->joinOrdering($ordering, '[__outer__]');
-		$sql = preg_replace('/( ORDER BY)[\s"\[](.*)(ASC|DESC)?(?:[\s"\[]|$|COMPUTE|FOR)/i','',$sql);
+		$sql = preg_replace('/([ ]ORDER BY)[\s"\[](.*)(ASC|DESC)?(?:[\s"\[]|$|COMPUTE|FOR)/i','',$sql);
 		$sql = "SELECT * FROM (SELECT ROW_NUMBER() OVER(ORDER BY (SELECT 1)) AS [__RowNumber__], * FROM ({$sql}) as [__inner__]) as [__outer__] WHERE [__RowNumber__] BETWEEN {$start} AND {$end} {$orginalOrdering}";
 		return $sql;
 	}

--- a/framework/db/schema/mssql/CMssqlCommandBuilder.php
+++ b/framework/db/schema/mssql/CMssqlCommandBuilder.php
@@ -199,12 +199,13 @@ class CMssqlCommandBuilder extends CDbCommandBuilder
 	 */
 	protected function rewriteLimitOffsetSql($sql, $limit, $offset)
 	{
-		$end = $limit+$offset;
-		$start = ($limit-1) * ($offset+1);
+		$end = $limit + $offset;
+		$start = $end - $limit + 1;
 		$ordering = $this->findOrdering($sql);
 		$orginalOrdering = $this->joinOrdering($ordering, '[__outer__]');
-		$sql = preg_replace('/([ ]ORDER BY)[\s"\[](.*)(ASC|DESC)?(?:[\s"\[]|$|COMPUTE|FOR)/i','',$sql);
-		$sql = "SELECT * FROM (SELECT ROW_NUMBER() OVER(ORDER BY (SELECT 1)) AS [__RowNumber__], * FROM ({$sql}) as [__inner__]) as [__outer__] WHERE [__RowNumber__] BETWEEN {$start} AND {$end} {$orginalOrdering}";
+                $rowNumberOrdering = !empty($orginalOrdering) ? $orginalOrdering : 'ORDER BY (SELECT 1)';
+		$sqlWithoutOrder = preg_replace('/([ ]ORDER BY)[\s"\[](.*)(ASC|DESC)?(?:[\s"\[]|$|COMPUTE|FOR)/i','',$sql);
+		$sql = "SELECT * FROM (SELECT ROW_NUMBER() OVER({$rowNumberOrdering}) AS [__RowNumber__], * FROM ({$sqlWithoutOrder}) as [__inner__]) as [__outer__] WHERE [__RowNumber__] BETWEEN {$start} AND {$end}";
 		return $sql;
 	}
 

--- a/framework/db/schema/mssql/CMssqlCommandBuilder.php
+++ b/framework/db/schema/mssql/CMssqlCommandBuilder.php
@@ -190,23 +190,27 @@ class CMssqlCommandBuilder extends CDbCommandBuilder
 
 	/**
 	 * Rewrite sql to apply $limit > and $offset > 0 for MSSQL database.
-	 * See http://troels.arvin.dk/db/rdbms/#select-limit-offset
 	 * @param string $sql sql query
 	 * @param integer $limit $limit > 0
 	 * @param integer $offset $offset > 0
 	 * @return string modified sql query applied with limit and offset.
 	 *
-	 * @author Wei Zhuo <weizhuo[at]gmail[dot]com>
+	 * @author Diego Rocha <diego[dot]rocha[dot]br[at]gmail[dot]com>
 	 */
 	protected function rewriteLimitOffsetSql($sql, $limit, $offset)
 	{
-		$fetch = $limit+$offset;
-		$sql = preg_replace('/^([\s(])*SELECT( DISTINCT)?(?!\s*TOP\s*\()/i',"\\1SELECT\\2 TOP $fetch", $sql);
-		$ordering = $this->findOrdering($sql);
-		$orginalOrdering = $this->joinOrdering($ordering, '[__outer__]');
-		$reverseOrdering = $this->joinOrdering($this->reverseDirection($ordering), '[__inner__]');
-		$sql = "SELECT * FROM (SELECT TOP {$limit} * FROM ($sql) as [__inner__] {$reverseOrdering}) as [__outer__] {$orginalOrdering}";
-		return $sql;
+	    $fetch = $limit+$offset;
+	    $sql = "
+		SELECT * FROM (
+		SELECT
+		    ROW_NUMBER() OVER(ORDER BY (SELECT 1)) AS [__RowNumber__],
+		    *
+		    FROM (
+		        $sql
+		    ) as [__inner__]
+		) as [__outer__]
+		WHERE [__RowNumber__] BETWEEN $limit AND $fetch";
+	    return $sql;
 	}
 
 	/**

--- a/tests/framework/db/schema/CMssqlTest.php
+++ b/tests/framework/db/schema/CMssqlTest.php
@@ -212,7 +212,8 @@ EOD;
 			'order'=>'title',
 			'limit'=>2,
 			'offset'=>3)));
-		$this->assertEquals('SELECT * FROM (SELECT TOP 2 * FROM (SELECT TOP 5 id, title FROM [dbo].[posts] [t] ORDER BY title) as [__inner__] ORDER BY title DESC) as [__outer__] ORDER BY title ASC',$c->text);
+		$expectedSql = 'SELECT * FROM (SELECT ROW_NUMBER() OVER(ORDER BY (SELECT 1)) AS [__RowNumber__], * FROM (SELECT id, title FROM [dbo].[posts] [t]) as [__inner__]) as [__outer__] WHERE [__RowNumber__] BETWEEN 4 AND 5 ORDER BY title ASC';
+		$this->assertEquals($expectedSql,$c->text);
 		$rows=$c->query()->readAll();
 		$this->assertEquals(2,count($rows));
 		$this->assertEquals('post 4',$rows[0]['title']);


### PR DESCRIPTION
fix issue #166

Simple SQL test script:

--test table
CREATE TABLE [test_offset]([id] INTEGER);
--test data
INSERT INTO [test_offset]([id]) VALUES(2);
INSERT INTO [test_offset]([id]) VALUES(4);
INSERT INTO [test_offset]([id]) VALUES(6);
INSERT INTO [test_offset]([id]) VALUES(8);
INSERT INTO [test_offset]([id]) VALUES(10);
INSERT INTO [test_offset]([id]) VALUES(12);
INSERT INTO [test_offset]([id]) VALUES(14);

--which LIMIT = 3
--and OFFSET = 2
--expected values are: 6,8,10

--current implementation
SELECT * FROM (
	SELECT TOP 3 * FROM (
		SELECT TOP 5 [id] FROM [test_offset]
	) as [__inner__]
) as [__outer__];
--returned values: 2,4,6
--issue: wrong range of values

--proposed implementation
SELECT * FROM (
	SELECT
		ROW_NUMBER() OVER(ORDER BY (SELECT 1)) AS [__RowNumber__],
		*
	FROM (
		SELECT [id] FROM [test_offset]
	) as [__inner__]
) as [__outer__]
WHERE [__RowNumber__] BETWEEN 3 AND 5;
--returned values: 6,8,10
--issue: the column "__RowNumber__" is added to result