### PR TITLE
Removed extra tabs in COciCommandBuilder::applyLimit().

### DIFF
--- a/framework/db/schema/oci/COciCommandBuilder.php
+++ b/framework/db/schema/oci/COciCommandBuilder.php
@@ -62,11 +62,11 @@ class COciCommandBuilder extends CDbCommandBuilder
 
 
 		$sql = <<<EOD
-				WITH USER_SQL AS ({$sql}),
-				   PAGINATION AS (SELECT USER_SQL.*, rownum as rowNumId FROM USER_SQL)
-				SELECT *
-				FROM PAGINATION
-				{$filter}
+WITH USER_SQL AS ({$sql}),
+	PAGINATION AS (SELECT USER_SQL.*, rownum as rowNumId FROM USER_SQL)
+SELECT *
+FROM PAGINATION
+{$filter}
 EOD;
 
 		return $sql;


### PR DESCRIPTION
I'm working on Oracle unit tests. These tabs a bit annoying when asserting SQL containing them. I'm sure they're definitely shouldn't be there.
