### PR TITLE
Fixes #110 (unit test)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 Version 1.1.13 work in progress
 -------------------------------
 - Bug #93: Criteria modification in CActiveRecord::beforeFind() did not apply when record was loaded in relational context. See UPGRADE instructions for details on behavior change. (cebe)
+- Bug #110: MSSQL: fixed empty $primaryKey value after saving CActiveRecord model (resurtm)
 - Bug #112: MSSQL: database abstraction layer now uses native transaction support of the SQLSRV driver (resurtm)
 - Bug #124: Added CMysqlCommandBuilder to handle JOIN directive on update commands correctly (cebe, DaSourcerer)
 - Bug #962: Fixed handling of negative timestamps in CDateFormatter::format() (johnmendonca)

--- a/tests/framework/db/schema/CMssqlTest.php
+++ b/tests/framework/db/schema/CMssqlTest.php
@@ -3,6 +3,16 @@
 Yii::import('system.db.CDbConnection');
 Yii::import('system.db.schema.mssql.CMssqlSchema');
 
+require_once(dirname(__FILE__).'/../data/models2.php');
+
+class MssqlUser2 extends User2
+{
+	public function tableName()
+	{
+		return '[dbo].[users]';
+	}
+}
+
 /**
  * @group mssql
  */
@@ -71,6 +81,8 @@ EOD;
 			if(trim($sql)!=='')
 				$this->db->createCommand($sql)->execute();
 		}
+
+		CActiveRecord::$db=$this->db;
 	}
 
 	public function tearDown()
@@ -342,5 +354,26 @@ EOD;
 		$this->assertEquals('Тест Юникода', $usersColumns['id']->comment);
 		$this->assertEquals('User\'s identifier', $usersColumns['user_id']->comment);
 		$this->assertEmpty($usersColumns['last_name']->comment);
+	}
+
+	public function testARLastInsertId()
+	{
+		$user=new MssqlUser2();
+
+		$user->username='testingUser';
+		$user->password='testingPassword';
+		$user->email='testing@email.com';
+
+		$this->assertTrue($user->isNewRecord);
+		$this->assertNull($user->primaryKey);
+		$this->assertNull($user->id);
+		$this->assertEquals(3, $this->db->createCommand('SELECT MAX(id) FROM [dbo].[users]')->queryScalar());
+
+		$user->save();
+
+		$this->assertFalse($user->isNewRecord);
+		$this->assertEquals(4, $user->primaryKey);
+		$this->assertEquals(4, $user->id);
+		$this->assertEquals(4, $this->db->createCommand('SELECT MAX(id) FROM [dbo].[users]')->queryScalar());
 	}
 }


### PR DESCRIPTION
Fixes #110.

Looks like #110 was fixed at the same time when fix for the #112 was merged into upstream. This PR provides unit test for #110 to be sure that it was fixed.

Running result (command is `phpunit --verbose --coverage-text framework/db/schema/CMssqlTest.php`):

```
PHPUnit 3.6.10 by Sebastian Bergmann.

Configuration read from C:\_work\jetbrains\yii\tests\phpunit.xml

.......

Time: 4 seconds, Memory: 6.75Mb

OK (7 tests, 251 assertions)

Generating textual code coverage report, this may take a moment.

Code Coverage Report 
  2012-09-05 19:55:15

 Summary: 
  Classes: 16.95% (10/59)
  Methods: 14.99% (112/747)
  Lines:   23.78% (1085/4562)

@system.base::CApplication
  Methods:   1.92% ( 1/52)   Lines:   0.34% (  1/290)
@system.base::CApplicationComponent
  Methods:  50.00% ( 1/ 2)   Lines:  75.00% (  3/  4)
@system.base::CComponent
  Methods:  25.00% ( 6/24)   Lines:   9.57% ( 18/188)
@system.base::CEvent
  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  3/  3)
@system.base::CModel
  Methods:  36.11% (13/36)   Lines:  34.33% ( 46/134)
@system.base::CModule
  Methods:   3.70% ( 1/27)   Lines:   8.76% ( 12/137)
@system.collections::CList
  Methods:  23.81% ( 5/21)   Lines:  16.85% ( 15/ 89)
@system.collections::CListIterator
  Methods:  83.33% ( 5/ 6)   Lines:  90.91% ( 10/ 11)
@system.db.ar::CActiveRecord
  Methods:  19.10% (17/89)   Lines:  15.05% ( 84/558)
@system.db.ar::CActiveRecordMetaData
  Methods:  50.00% ( 2/ 4)   Lines:  54.29% ( 19/ 35)
@system.db.ar::CBaseActiveRelation
  Methods:  50.00% ( 1/ 2)   Lines:  10.53% (  6/ 57)
@system.db.schema.mssql::CMssqlColumnSchema
  Methods: 100.00% ( 5/ 5)   Lines:  90.91% ( 20/ 22)
@system.db.schema.mssql::CMssqlCommandBuilder
  Methods: 100.00% (12/12)   Lines:  81.51% ( 97/119)
@system.db.schema.mssql::CMssqlSchema
  Methods:  62.50% (10/16)   Lines:  71.70% (114/159)
@system.db.schema.mssql::CMssqlSqlsrvPdoAdapter
  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  3/  3)
@system.db.schema::CDbColumnSchema
  Methods:  60.00% ( 3/ 5)   Lines:  51.43% ( 18/ 35)
@system.db.schema::CDbCommandBuilder
  Methods:  76.92% (20/26)   Lines:  64.55% (224/347)
@system.db.schema::CDbCriteria
  Methods:   9.09% ( 1/11)   Lines:   1.33% (  3/226)
@system.db.schema::CDbSchema
  Methods:  26.67% ( 8/30)   Lines:  26.67% ( 40/150)
@system.db.schema::CDbTableSchema
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  2/  2)
@system.db::CDbCommand
  Methods:  20.00% (15/75)   Lines:  22.17% ( 90/406)
@system.db::CDbConnection
  Methods:  35.71% (15/42)   Lines:  48.23% ( 68/141)
@system.db::CDbDataReader
  Methods:  11.11% ( 2/18)   Lines:  10.81% (  4/ 37)
@system.db::CDbException
  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  3/  3)
@system.db::CDbTransaction
  Methods:  50.00% ( 3/ 6)   Lines:  73.91% ( 17/ 23)
@system.i18n::CLocale
  Methods:   3.12% ( 1/32)   Lines:   0.97% (  1/103)
@system.i18n::CMessageSource
  Methods:  50.00% ( 3/ 6)   Lines:  38.10% (  8/ 21)
@system.i18n::CPhpMessageSource
  Methods:  33.33% ( 1/ 3)   Lines:  10.81% (  4/ 37)
@system.logging::CLogger
  Methods:   9.09% ( 1/11)   Lines:   5.32% (  5/ 94)
@system.validators::CEmailValidator
  Methods:  40.00% ( 2/ 5)   Lines:  31.71% ( 13/ 41)
@system.validators::CRegularExpressionValidator
  Methods:  50.00% ( 1/ 2)   Lines:  26.67% (  8/ 30)
@system.validators::CRequiredValidator
  Methods:  50.00% ( 1/ 2)   Lines:  17.14% (  6/ 35)
@system.validators::CStringValidator
  Methods:  50.00% ( 1/ 2)   Lines:  18.46% ( 12/ 65)
@system.validators::CValidator
  Methods:  57.14% ( 4/ 7)   Lines:  55.36% ( 31/ 56)
@system::YiiBase
  Methods:  33.33% ( 7/21)   Lines:  29.52% ( 62/210)
User2
  Methods:  50.00% ( 2/ 4)   Lines:  81.82% (  9/ 11)
```
