### PR TITLE
need to move beforeFindInternal() after adding scopes

### DIFF
--- a/framework/db/ar/CActiveFinder.php
+++ b/framework/db/ar/CActiveFinder.php
@@ -233,9 +233,9 @@ class CActiveFinder extends CComponent
 				$scopes=array_merge($scopes,(array)$options['scopes']); // no need for complex merging
 
 			$model->resetScope(false);
-			$model->beforeFindInternal();
 			$criteria=$model->getDbCriteria();
 			$criteria->scopes=$scopes;
+			$model->beforeFindInternal();
 			$model->applyScopes($criteria);
 			$relation->mergeWith($criteria,true);
 

--- a/tests/framework/db/data/models.php
+++ b/tests/framework/db/data/models.php
@@ -551,6 +551,7 @@ class UserWithWrappers extends CActiveRecord
 	{
 		return array(
 			'posts'=>array(self::HAS_MANY,'PostWithWrappers','author_id'),
+			'postsWithScope'=>array(self::HAS_MANY,'PostWithWrappers','author_id','scopes'=>array('replaceContent')),
 			'postCount'=>array(self::STAT,'PostWithWrappers','author_id'),
 			'comments'=>array(self::HAS_MANY,'CommentWithWrappers',array('id'=>'post_id'),'through'=>'posts')
 		);
@@ -656,6 +657,18 @@ class PostWithWrappers extends CActiveRecord
 	{
 		parent::afterFind();
 		$this->incrementCounter(__FUNCTION__);
+	}
+
+	public function scopes()
+	{
+		return array(
+			'rename'=>array(
+				'select'=>"'renamed post' AS title",
+			),
+			'replaceContent' => array(
+				'select'=>"'replaced content' AS content",
+			),
+		);
 	}
 
 	protected function incrementCounter($wrapper)


### PR DESCRIPTION
fix #1102 was not 100% correct as it was not possible to apply
additional scopes in relation definition and query criteria.
