### PR TITLE
CHtml::$closeSingleTags added

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,7 @@ Version 1.1.13 work in progress
 - Enh #1289: Added support for column comments for MSSQL (CDbColumnSchema::$comment property) (resurtm)
 - Enh #1299: Added CSRF token validation for PUT and DELETE (miraage, samdark)
 - Enh #1345: CButtonColumn's default buttons(view, update, delete) have visible option now (gregmolnar)
+- Enh: Allow to configure CHtml::$closeSingleTags. Useful for HTML5 code (creocoder)
 - Enh: Fixed the check for ajaxUpdate false value in jquery.yiilistview.js as that never happens (mdomba)
 - Enh: Requirements checker: added check for Oracle database (pdo_oci extension) and MSSQL (pdo_dblib, pdo_sqlsrv and pdo_mssql extensions) (resurtm)
 - Enh: Added CChainedLogFilter class to allow adding multiple filters to a logroute (cebe)

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -52,7 +52,6 @@ class CHtml
 	 * @var integer the counter for generating automatic input field names.
 	 */
 	public static $count=0;
-
 	/**
 	 * Sets the default style for attaching jQuery event handlers.
 	 *
@@ -72,6 +71,11 @@ class CHtml
 	 * @see clientChange
 	 */
 	public static $liveEvents = true;
+	/**
+	 * @var boolean whether to close single tags. Defaults to true. Can be setted to false for HTML5.
+	 * @since 1.1.13
+	 */
+	public static $closeSingleTags=true;
 
 	/**
 	 * Encodes special characters into HTML entities.
@@ -139,7 +143,7 @@ class CHtml
 	{
 		$html='<' . $tag . self::renderAttributes($htmlOptions);
 		if($content===false)
-			return $closeTag ? $html.' />' : $html.'>';
+			return self::$closeSingleTags && $closeTag ? $html.' />' : $html.'>';
 		else
 			return $closeTag ? $html.'>'.$content.'</'.$tag.'>' : $html.'>'.$content;
 	}


### PR DESCRIPTION
Allow using short single tags without close it. Very useful for HTML5.

For example:

```
<img src="..." alt="">
```

VS

```
<img src="..." alt="" />
```
