### PR TITLE
Fix for total item count not providing alias to defaultScopes of a model

### DIFF
--- a/framework/web/CActiveDataProvider.php
+++ b/framework/web/CActiveDataProvider.php
@@ -172,6 +172,11 @@ class CActiveDataProvider extends CDataProvider
 	 */
 	protected function calculateTotalItemCount()
 	{
+		if($this->criteria->alias) {
+			$crit = new CDbCriteria;
+			$crit->alias = $this->criteria->alias;
+			$this->model->setDbCriteria($crit);
+		}
 		$baseCriteria=$this->model->getDbCriteria(false);
 		if($baseCriteria!==null)
 			$baseCriteria=clone $baseCriteria;


### PR DESCRIPTION
When the function calculateTotalItemCount of the CActiveDataProvider is called, it doesn't take into account that the criteria passed to CActiveDataProvider could change the "alias", and in the defaultScope of the target model also could be a call to the function "getTableAlias" and put the wrong alias to a condition.
