### PR TITLE
Fix boolean empty validation

### DIFF
--- a/framework/validators/CValidator.php
+++ b/framework/validators/CValidator.php
@@ -273,7 +273,7 @@ abstract class CValidator extends CComponent
 	 */
 	protected function isEmpty($value,$trim=false)
 	{
-		return $value===null || $value===array() || $value==='' || $trim && is_scalar($value) && trim($value)==='';
+		return $value===null || $value===array() || $value==='' || $trim && is_scalar($value) && !is_bool($value) && trim($value)==='';
 	}
 }
 


### PR DESCRIPTION
Currently, when a field has the boolean value false it won't validate. This change fixes that problem by accepting the false value as a value.

This is necessary for example for the EActiveResource-plugin (https://github.com/Haensel/ActiveResource), which has boolean fields. Since the values are string-casted when using trim($value) and false is casted as an empty string, the validation will fail.
