### PR TITLE
Change $_rules property of CUrlManager from private to protected

### DIFF
--- a/framework/web/CUrlManager.php
+++ b/framework/web/CUrlManager.php
@@ -193,7 +193,7 @@ class CUrlManager extends CApplicationComponent
 	public $urlRuleClass='CUrlRule';
 
 	private $_urlFormat=self::GET_FORMAT;
-	private $_rules=array();
+	protected $_rules=array();
 	private $_baseUrl;
 
 


### PR DESCRIPTION
I'm trying to extend CUrlManager and need access to $_rules property but it's private, so I change the property from private to protected.
