### PR TITLE
Enh #1396: Add mime-type for CSV

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,7 @@ Version 1.1.13 work in progress
 - Enh #1289: Added support for column comments for MSSQL (CDbColumnSchema::$comment property) (resurtm)
 - Enh #1299: Added CSRF token validation for PUT and DELETE (miraage, samdark)
 - Enh #1369: Added CCheckBoxColumn::disabled that accepts PHP expression or anonymous function determining if checkbox for the row should be disabled (sucotronic)
+- Enh #1396: Added 'text/csv' mime-type for the 'csv' file extension in utils/mimeTypes.php (effectively used by e.g. CHttpRequest::sendFile()) (rawtaz)
 - Enh: Fixed the check for ajaxUpdate false value in jquery.yiilistview.js as that never happens (mdomba)
 - Enh: Requirements checker: added check for Oracle database (pdo_oci extension) and MSSQL (pdo_dblib, pdo_sqlsrv and pdo_mssql extensions) (resurtm)
 - Enh: Added CChainedLogFilter class to allow adding multiple filters to a logroute (cebe)

--- a/framework/utils/mimeTypes.php
+++ b/framework/utils/mimeTypes.php
@@ -34,6 +34,7 @@ return array(
 	'cpt'=>'application/mac-compactpro',
 	'csh'=>'application/x-csh',
 	'css'=>'text/css',
+	'csv'=>'text/csv',
 	'dcr'=>'application/x-director',
 	'dir'=>'application/x-director',
 	'dms'=>'application/octet-stream',


### PR DESCRIPTION
Add 'text/csv' mime-type for the 'csv' file extension in utils/mimeTypes.php, in accordance with RFC4180.

Fix #1396
