### PR TITLE
CCache improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 
 Version 1.1.13 work in progress
 -------------------------------
+- Enh: Added CCache::contains() to check if a value exists in cache. Query caching will now cache empty results. See http://www.yiiframework.com/forum/index.php/topic/31583-query-cache-and-ar (pavlepredic)
 - Bug #93: Criteria modification in CActiveRecord::beforeFind() did not apply when record was loaded in relational context. See UPGRADE instructions for details on behavior change. (cebe)
 - Bug #110: MSSQL: fixed empty $primaryKey value after saving CActiveRecord model (resurtm)
 - Bug #112: MSSQL: database abstraction layer now uses native transaction support of the SQLSRV driver (resurtm)

--- a/framework/base/interfaces.php
+++ b/framework/base/interfaces.php
@@ -93,6 +93,12 @@ interface ICache
 	 * @return boolean whether the flush operation was successful.
 	 */
 	public function flush();
+	/**
+	 * Checks if a value with a specified key exists in cache.
+	 * @param string $id a key identifying the cached value.
+	 * @return boolean whether the key exists in cache.
+	 */
+	public function contains($id);
 }
 
 /**

--- a/framework/caching/CApcCache.php
+++ b/framework/caching/CApcCache.php
@@ -45,6 +45,17 @@ class CApcCache extends CCache
 	{
 		return apc_fetch($key);
 	}
+	
+	/**
+	 * Checks if the specifed key exists in cache and has not expired.
+	 * This is the implementation of the method declared in the parent class.
+	 * @param string $key a unique key identifying the cached value.
+	 * @return boolean whether the specified key exists in cache and has not expired.
+	 */
+	protected function keyExists($key)
+	{
+		return apc_exists($key);
+	}
 
 	/**
 	 * Retrieves multiple values from cache with the specified keys.

--- a/framework/caching/CDbCache.php
+++ b/framework/caching/CDbCache.php
@@ -194,6 +194,31 @@ EOD;
 		else
 			return $db->createCommand($sql)->queryScalar();
 	}
+	
+	/**
+	 * Checks if the specifed key exists in cache and has not expired.
+	 * This is the implementation of the method declared in the parent class.
+	 * @param string $key a unique key identifying the cached value.
+	 * @return boolean whether the specified key exists in cache and has not expired.
+	 */
+	protected function keyExists($key)
+	{
+		$time=time();
+		$sql="SELECT 1 FROM {$this->cacheTableName} WHERE id='$key' AND (expire=0 OR expire>$time)";
+		$db=$this->getDbConnection();
+		if($db->queryCachingDuration>0)
+		{
+			$duration=$db->queryCachingDuration;
+			$db->queryCachingDuration=0;
+			$result=$db->createCommand($sql)->queryRow();
+			
+			$db->queryCachingDuration=$duration;
+		}
+		else
+			$result = $db->createCommand($sql)->queryRow();
+		
+		return $result !== false;
+	}
 
 	/**
 	 * Retrieves multiple values from cache with the specified keys.

--- a/framework/caching/CDummyCache.php
+++ b/framework/caching/CDummyCache.php
@@ -47,7 +47,17 @@ class CDummyCache extends CApplicationComponent implements ICache, ArrayAccess
 	{
 		return false;
 	}
-
+	
+	/**
+	 * Checks if a value with a specified key exists in cache.
+	 * @param string $id a key identifying the cached value.
+	 * @return boolean whether the key exists in cache.
+	 */
+	public function contains($id)
+	{
+		return false;
+	}
+	
 	/**
 	 * Retrieves multiple values from cache with the specified keys.
 	 * Some caches (such as memcache, apc) allow retrieving multiple cached values at one time,

--- a/framework/caching/CFileCache.php
+++ b/framework/caching/CFileCache.php
@@ -109,6 +109,18 @@ class CFileCache extends CCache
 			@unlink($cacheFile);
 		return false;
 	}
+	
+	/**
+	 * Checks if the specifed key exists in cache and has not expired.
+	 * This is the implementation of the method declared in the parent class.
+	 * @param string $key a unique key identifying the cached value.
+	 * @return boolean whether the specified key exists in cache and has not expired.
+	 */
+	protected function keyExists($key)
+	{
+		$cacheFile=$this->getCacheFile($key);
+		return file_exists($cacheFile) and @filemtime($cacheFile) > time();
+	}
 
 	/**
 	 * Stores a value identified by a key in cache.

--- a/framework/caching/CWinCache.php
+++ b/framework/caching/CWinCache.php
@@ -45,7 +45,18 @@ class CWinCache extends CCache {
 	{
 		return wincache_ucache_get($key);
 	}
-
+	
+	/**
+	 * Checks if the specifed key exists in cache and has not expired.
+	 * This is the implementation of the method declared in the parent class.
+	 * @param string $key a unique key identifying the cached value.
+	 * @return boolean whether the specified key exists in cache and has not expired.
+	 */
+	protected function keyExists($key)
+	{
+		return wincache_ucache_exists($key);
+	}
+	
 	/**
 	 * Retrieves multiple values from cache with the specified keys.
 	 * @param array $keys a list of keys identifying the cached values

--- a/framework/caching/CXCache.php
+++ b/framework/caching/CXCache.php
@@ -46,6 +46,17 @@ class CXCache extends CCache
 	}
 
 	/**
+	 * Checks if the specifed key exists in cache and has not expired.
+	 * This is the implementation of the method declared in the parent class.
+	 * @param string $key a unique key identifying the cached value.
+	 * @return boolean whether the specified key exists in cache and has not expired.
+	 */
+	protected function keyExists($key)
+	{
+		return xcache_isset($key);
+	}
+	
+	/**
 	 * Stores a value identified by a key in cache.
 	 * This is the implementation of the method declared in the parent class.
 	 *

--- a/framework/db/CDbCommand.php
+++ b/framework/db/CDbCommand.php
@@ -479,10 +479,10 @@ class CDbCommand extends CComponent
 			$this->_connection->queryCachingCount--;
 			$cacheKey='yii:dbquery'.$this->_connection->connectionString.':'.$this->_connection->username;
 			$cacheKey.=':'.$this->getText().':'.serialize(array_merge($this->_paramLog,$params));
-			if(($result=$cache->get($cacheKey))!==false)
+			if($cache->contains($cacheKey))
 			{
 				Yii::trace('Query result found in cache','system.db.CDbCommand');
-				return $result;
+				return $cache->get($cacheKey);
 			}
 		}
 


### PR DESCRIPTION
Added CCache::contains() method for checking if key exists in cache. Also modified child classes accordingly. Modified CDbCommand::queryInternal() to check if cached key exists using the new contains() method. This way, empty resultsets will also be cached.

See this post for more info:
http://www.yiiframework.com/forum/index.php/topic/31583-query-cache-and-ar
