### PR TITLE
Fixes #1371: Captcha support for CForm

### DIFF
--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -810,6 +810,7 @@ class YiiBase
 		'CHttpCacheFilter' => '/web/filters/CHttpCacheFilter.php',
 		'CInlineFilter' => '/web/filters/CInlineFilter.php',
 		'CForm' => '/web/form/CForm.php',
+		'CFormCaptcha' => '/web/form/CFormCaptcha.php',
 		'CFormButtonElement' => '/web/form/CFormButtonElement.php',
 		'CFormElement' => '/web/form/CFormElement.php',
 		'CFormElementCollection' => '/web/form/CFormElementCollection.php',

--- a/framework/web/form/CFormCaptcha.php
+++ b/framework/web/form/CFormCaptcha.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ *
+ */
+class CFormCaptcha extends CCaptcha
+{
+	/**
+	 * @var CModel
+	 */
+	public $model;
+	/**
+	 * @var string
+	 */
+	public $attribute;
+	/**
+	 * @var string
+	 */
+	public $separator="<br/>\n";
+	/**
+	 * @var array
+	 */
+	public $inputOptions=array();
+
+	public function run()
+	{
+		if(self::checkRequirements())
+		{
+			$this->renderImage();
+			$this->registerClientScript();
+
+			echo $this->separator;
+			echo CHtml::activeTextField($this->model,$this->attribute,$this->inputOptions);
+		}
+		else
+			throw new CException(Yii::t('yii','GD and FreeType PHP extensions are required.'));
+	}
+}

--- a/framework/web/form/CFormInputElement.php
+++ b/framework/web/form/CFormInputElement.php
@@ -221,6 +221,13 @@ class CFormInputElement extends CFormElement
 		}
 		else
 		{
+			if($this->type=='captcha')
+			{
+				$this->type='system.web.form.CFormCaptcha';
+				if(!CFormCaptcha::checkRequirements())
+					return '';
+			}
+
 			$attributes=$this->attributes;
 			$attributes['model']=$this->getParent()->getModel();
 			$attributes['attribute']=$this->name;


### PR DESCRIPTION
Fixes #1371.

This is just a prototype. If you like this solution, then I'll add necessary things (changelog line, comments, docblocks, etc.).

Usage example:

``` php
$model=new LoginForm();

$form=new CForm(array(
    'title'=>'Please provide your login credential',
    'elements'=>array(
        'username'=>array(
            'type'=>'text',
            'maxlength'=>32,
        ),
        'password'=>array(
            'type'=>'password',
            'maxlength'=>32,
        ),
        'rememberMe'=>array(
            'type'=>'checkbox',
            'attributes'=>array('class'=>'test-class'),
        ),
        'verifyCode'=>array(
            'type'=>'captcha',
            'captchaAction'=>'captcha', // this
            'showRefreshButton'=>true, // is
            'clickableImage'=>true, // an
            'buttonType'=>'button', // optional
            'imageOptions'=>array('class'=>'imageOptions-class'), // parameters
            'buttonOptions'=>array('class'=>'buttonOptions-class'),
            'separator'=>"<br/>\n",
            'inputOptions'=>array('class'=>'inputOptions-class'),
        ),
    ),
    'buttons'=>array(
        'login'=>array(
            'type'=>'submit',
            'label'=>'Login',
        ),
    ),
),$model);

if($form->submitted('login') && $form->validate())
    $this->refresh();
else
    $this->render('index', array('form'=>$form));
```

Result:
![https://dl.dropbox.com/u/916366/github/cform-captcha.png](https://dl.dropbox.com/u/916366/github/cform-captcha.png)
