### PR TITLE
CHttpSessionTest used non portable temporary directory path.

### DIFF
--- a/tests/framework/web/CHttpSessionTest.php
+++ b/tests/framework/web/CHttpSessionTest.php
@@ -19,7 +19,7 @@ class CHttpSessionTest extends CTestCase {
 		Yii::app()->setComponents(array('session' => array(
 			'class' => 'CHttpSession',
 			'cookieMode' => 'none',
-			'savePath' => '/tmp',
+			'savePath' => sys_get_temp_dir(),
 			'sessionName' => 'CHttpSessionTest',
 			'timeout' => 5,
 		)));


### PR DESCRIPTION
Thus there was problem with running this test case under MS Windows.
