### PR TITLE
[WIP] Allow to customize and preconfigure CGridView columns via map

### DIFF
--- a/framework/zii/widgets/grid/CGridView.php
+++ b/framework/zii/widgets/grid/CGridView.php
@@ -289,30 +289,6 @@ class CGridView extends CBaseListView
 	/**
 	 * @var mixed
 	 */
-	public $dataColumn=array(
-		'class'=>'CDataColumn',
-	);
-	/**
-	 * @var mixed
-	 */
-	public $linkColumn=array(
-		'class'=>'CLinkColumn',
-	);
-	/**
-	 * @var mixed
-	 */
-	public $checkBoxColumn=array(
-		'class'=>'CCheckBoxColumn',
-	);
-	/**
-	 * @var mixed
-	 */
-	public $buttonColumn=array(
-		'class'=>'CButtonColumn',
-	);
-	/**
-	 * @var mixed
-	 */
 	public $columnMap=array();
 
 	/**
@@ -348,12 +324,18 @@ class CGridView extends CBaseListView
 	 */
 	protected function initDefaultColumns()
 	{
-		foreach(array('data','link','checkBox','button') as $id)
+		//TODO: add support for 'ColumnClassName'=>array(...),
+		foreach(array(
+			'data'=>array('class'=>'CDataColumn'),
+			'link'=>array('class'=>'CLinkColumn'),
+			'checkBox'=>array('class'=>'CCheckBoxColumn'),
+			'button'=>array('class'=>'CButtonColumn'),
+		) as $id=>$config)
 		{
 			if(isset($this->columnMap[$id]))
-				$this->columnMap[$id]=array_merge($this->{$id.'Column'},$this->columnMap[$id]);
+				$this->columnMap[$id]=array_merge($config,$this->columnMap[$id]);
 			else
-				$this->columnMap[$id]=$this->{$id.'Column'};
+				$this->columnMap[$id]=$config;
 		}
 	}
 


### PR DESCRIPTION
Features example inside widget:

``` php
$this->widget('zii.widgets.grid.CGridView',array(
    'columnMap'=>array(
        'data'=>array(
            // now data column class for this CGridView instance will be 'MyDataColumn',
            'class'=>'MyDataColumn',
            //now data column type for this CGridView instance will be 'raw',
            'type'=>'raw',
        ),
        'button'=>array(
            //now view button icon for this CGridView instance will be folder_explore.png 
            'viewButtonImageUrl'=>Yii::app()->assetUrl.'/admin/img/icons/folder_explore.png',
        ),
    ),
```

Features example for `widgetFactory`:

``` php
'widgetFactory'=>array(
    'widgets'=>array(
        'CGridView'=>array(
            'columnMap'=>array(
                'data'=>array(
                    // now default data column class for all CGridView instances
                    // will be 'MyDataColumn',
                    'class'=>'MyDataColumn',
                    // now default data column type for all CGridView instances will be 'raw',
                    'type'=>'raw',
                ),
                'button'=>array(
                    // now default view button icon for all CGridView instances
                    // will be folder_explore.png
                    'viewButtonImageUrl'=>'http://static.example.com/icons/folder_explore.png',
                ),
            ),
        ),
    ),
),
```
