### PR TITLE
Doc update: added info about AR lazy-loading relationship scoping syntax

### DIFF
--- a/docs/guide/database.arr.txt
+++ b/docs/guide/database.arr.txt
@@ -547,6 +547,14 @@ $posts=Post::model()->findAll(array(
 
 The above query will bring back all posts together with their approved comments. Note that `comments` refers to the relation name, while `recently` and `approved` refer to two named scopes declared in the `Comment` model class. The relation name and the named scopes should be separated by colons.
 
+Occasionally you may need to retrieve a scoped relationship using a lazy-loading approach, instead of the normal eager loading method shown above.  In that case, the following syntax will do what you need:
+
+~~
+[php]
+// note the repetition of the relationship name, which is necessary
+$approvedComments = $post->comments('comments:approved');
+~~
+
 Named scopes can also be specified in the `with` option of the relational rules declared in [CActiveRecord::relations()]. In the following example, if we access `$user->posts`, it would bring back all *approved* comments of the posts.
 
 ~~~


### PR DESCRIPTION
Ran across a need for this the other day and ended up finding syntax for it in a bug report.  But I haven't ever seen this mentioned anywhere else.  I posted on the forum about it:
http://www.yiiframework.com/forum/index.php/topic/32978-apply-criteria-on-lazy-loading/

but thought it'd be better to add it to the docs.
