### PR TITLE
Support reading the RAW POST body

### DIFF
--- a/framework/web/CHttpRequest.php
+++ b/framework/web/CHttpRequest.php
@@ -186,6 +186,15 @@ class CHttpRequest extends CApplicationComponent
 	{
 		return isset($_POST[$name]) ? $_POST[$name] : $defaultValue;
 	}
+    
+    /**
+     * Returns the raw POST body content
+     * @return string the POST body content
+     */
+    public function getPostBody()
+    {
+        return file_get_contents("php://input");
+    }
 
 	/**
 	 * Returns the named DELETE parameter value.


### PR DESCRIPTION
Added method getPostBody() to CHttpRequest in order to support reading the entire POST body contents.

The method is using  file_get_contents("php://input") rather than $HTTP_RAW_POST_DATA for efficiency.
