### PR TITLE
Value of the CHtml::activeTextArea() can now be set through $htmlOptions['value'].

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,7 @@ Version 1.1.13 work in progress
 - Enh: Requirements checker: added check for Oracle database (pdo_oci extension) and MSSQL (pdo_dblib, pdo_sqlsrv and pdo_mssql extensions) (resurtm)
 - Enh: Added CChainedLogFilter class to allow adding multiple filters to a logroute (cebe)
 - Enh: Allow CDataProvider to use custom pagination and sorter (creocoder)
+- Enh: Value of the CHtml::activeTextArea() can now be set through $htmlOptions['value'] (resurtm)
 - Chg: MSSQL unit tests updated and actualized, added SQLSRV driver support (resurtm)
 - Chg: Added Oracle unit tests (resurtm)
 - Chg: Updated CHttpCacheFilter to use dates as specified by RFC 1123 (bramp)

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -1367,7 +1367,13 @@ EOD;
 		self::clientChange('change',$htmlOptions);
 		if($model->hasErrors($attribute))
 			self::addErrorCss($htmlOptions);
-		$text=self::resolveValue($model,$attribute);
+		if(isset($htmlOptions['value']))
+		{
+			$text=$htmlOptions['value'];
+			unset($htmlOptions['value']);
+		}
+		else
+			$text=self::resolveValue($model,$attribute);
 		return self::tag('textarea',$htmlOptions,isset($htmlOptions['encode']) && !$htmlOptions['encode'] ? $text : self::encode($text));
 	}
 


### PR DESCRIPTION
Sample:

``` php
<?php $loginForm=new LoginForm(); ?>
<?php $loginForm->username='user1'; ?>
<?php echo CHtml::activeTextArea($loginForm,'username',array('value'=>'user2')); ?>
```

This enhancement is not needed for `CHtml::textArea()` because it's value already could be specified through second parameter.

Right now i have to do ugly things to pass this defect:

``` php
<!-- this is a view -->
<?php
$oldValue=$model->value2; // i want to keep $model->value2 untouched, but in a view, when shown to the user it should be altered
$model->value2=$model->value1;
echo CHtml::activeTextArea($model,'value2');
$model->value2=$oldValue;
?>
```

With this enhancement it would look much better:

``` php
<!-- this is a view -->
<?php echo CHtml::activeTextArea($model,'value2',array('value'=>$model->value1)); ?>
```
