### PR TITLE
Adding JS/CSS to the bottom of the <head>, instead before <title>

### DIFF
--- a/framework/web/CClientScript.php
+++ b/framework/web/CClientScript.php
@@ -348,35 +348,51 @@ class CClientScript extends CApplicationComponent
 	 */
 	public function renderHead(&$output)
 	{
-		$html='';
+		$html='';$mtags='';
 		foreach($this->metaTags as $meta)
-			$html.=CHtml::metaTag($meta['content'],null,null,$meta)."\n";
+		    $mtags.=CHtml::metaTag($meta['content'],null,null,$meta)."\n";
 		foreach($this->linkTags as $link)
-			$html.=CHtml::linkTag(null,null,null,null,$link)."\n";
+		    $html.=CHtml::linkTag(null,null,null,null,$link)."\n";
 		foreach($this->cssFiles as $url=>$media)
-			$html.=CHtml::cssFile($url,$media)."\n";
+		    $html.=CHtml::cssFile($url,$media)."\n";
 		foreach($this->css as $css)
-			$html.=CHtml::css($css[0],$css[1])."\n";
+		    $html.=CHtml::css($css[0],$css[1])."\n";
 		if($this->enableJavaScript)
 		{
-			if(isset($this->scriptFiles[self::POS_HEAD]))
-			{
-				foreach($this->scriptFiles[self::POS_HEAD] as $scriptFile)
-					$html.=CHtml::scriptFile($scriptFile)."\n";
-			}
-
-			if(isset($this->scripts[self::POS_HEAD]))
-				$html.=CHtml::script(implode("\n",$this->scripts[self::POS_HEAD]))."\n";
+		    if(isset($this->scriptFiles[self::POS_HEAD]))
+		    {
+		        foreach($this->scriptFiles[self::POS_HEAD] as $scriptFile)
+		            $html.=CHtml::scriptFile($scriptFile)."\n";
+		    }
+		
+		    if(isset($this->scripts[self::POS_HEAD]))
+		        $html.=CHtml::script(implode("\n",$this->scripts[self::POS_HEAD]))."\n";
 		}
-
+		
+		if (!empty($mtags))
+		{
+		    $count=0;
+		    $output=preg_replace('/(<\\/title\b[^>]*>)/is','$1<###title###>',$output,1,$count);
+		    if($count)
+		        $output=str_replace('<###title###>',$mtags,$output);
+		    else
+		    {
+		        $output=preg_replace('/(<\\/head\s*>)/is','<###head###>$1',$output,1,$count);
+		        if($count)
+		            $output=str_replace('<###head###>',$mtags,$output);
+		        else
+		        $output=$mtags.$output;
+		    }
+		}
 		if($html!=='')
 		{
-			$count=0;
-			$output=preg_replace('/(<title\b[^>]*>|<\\/head\s*>)/is','<###head###>$1',$output,1,$count);
-			if($count)
-				$output=str_replace('<###head###>',$html,$output);
-			else
-				$output=$html.$output;
+		    $count=0;
+		    //$output=preg_replace('/(<title\b[^>]*>|<\\/head\s*>)/is','<###head###>$1',$output,1,$count);
+		    $output=preg_replace('/(<\\/head\s*>)/is','<###head###>$1',$output,1,$count);
+		    if($count)
+		        $output=str_replace('<###head###>',$html,$output);
+		    else
+		        $output=$html.$output;
 		}
 	}
 


### PR DESCRIPTION
This way &lt;title&gt; can be closer to start of the &lt;head&gt; tag, instead of pushed to the very bottom (included CSS/JS doesn't depend on the place of &lt;title&gt; tag any more).
