### PR TITLE
Update framework/web/services/CWsdlGenerator.php

### DIFF
--- a/framework/web/services/CWsdlGenerator.php
+++ b/framework/web/services/CWsdlGenerator.php
@@ -128,7 +128,7 @@ class CWsdlGenerator extends CComponent
 		if($this->serviceName===null)
 			$this->serviceName=$className;
 		if($this->namespace===null)
-			$this->namespace="urn:{$className}wsdl";
+			$this->namespace='urn:'.str_replace('\\','/',$className).'wsdl';
 
 		$reflection=new ReflectionClass($className);
 		foreach($reflection->getMethods() as $method)


### PR DESCRIPTION
Fixes the following error:

Warning:  DOMDocument::loadXML() [domdocument.loadxml]: xmlns:tns: 'some\namespaced\ClassName' is not a valid URI in Entity, line: 4 in \yii\framework\web\services\CWsdlGenerator.php on line 221

No unit test today, just a fastAndDumbErrorTest class:

``` php
<?php
class fastAndDumbErrorTest 
{

    public $serviceName;
    public $namespace;

    public function __construct()
    {

        $this->namespace = 'some\namespaced\ClassName';
        $this->serviceName = $this->namespace;

        $encoding = 'UTF-8';
        $serviceUrl = 'dummy';
        $this->buildDOM($serviceUrl,$encoding);
    }

    private function buildDOM($serviceUrl,$encoding)
    {
        $xml="<?xml version=\"1.0\" encoding=\"$encoding\"?>
<definitions name=\"{$this->serviceName}\" targetNamespace=\"{$this->namespace}\"
     xmlns=\"http://schemas.xmlsoap.org/wsdl/\"
     xmlns:tns=\"{$this->namespace}\"
     xmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"
     xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
     xmlns:wsdl=\"http://schemas.xmlsoap.org/wsdl/\"
     xmlns:soap-enc=\"http://schemas.xmlsoap.org/soap/encoding/\"></definitions>";

        $dom=new DOMDocument();
        $dom->loadXml($xml);

        //more code...
    }
}

new fastAndDumbErrorTest ();
```
