### PR TITLE
Fixes #104: Added CWebLogRoute::$collapsedInFireBug property to control whether the log should be collapsed by default in Firebug.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@ Version 1.1.13 work in progress
 - Bug #1444: Fixed CGoogleApi::register call to registerScriptFile (mdomba)
 - Bug #1465: Fixed CHtml::beginForm() when CActiveForm with method GET and ajaxButton is used (mdomba)
 - Bug #1485 CSort does not quote table alias when using CDbCriteria (undsoft)
+- Enh #104: Added CWebLogRoute::$collapsedInFireBug property to control whether the log should be collapsed by default in Firebug (marcovtwout)
 - Enh #117: Added CPhpMessageSource::$extensionPaths to allow extensions, that do not have a base class to use as category prefix, to register message source (rcoelho, cebe)
 - Enh #291: CFormatter::formatDate and formatDateTime now also accept strings in strtotime() format (francis_tm, cebe)
 - Enh #486: CHttpSession::$gCProbability and CDbHttpSession::$gCProbability are floats now. Minimal possible $gCProbability value has been changed to the ≈0.00000005% (1/2147483647), was integer 1% before, default value left unchanged (1%) (resurtm)

--- a/framework/logging/CWebLogRoute.php
+++ b/framework/logging/CWebLogRoute.php
@@ -24,14 +24,12 @@ class CWebLogRoute extends CLogRoute
 	 * @var boolean whether the log should be displayed in FireBug instead of browser window. Defaults to false.
 	 */
 	public $showInFireBug=false;
-
 	/**
 	 * @var boolean whether the log should be ignored in FireBug for ajax calls. Defaults to true.
 	 * This option should be used carefully, because an ajax call returns all output as a result data.
 	 * For example if the ajax call expects a json type result any output from the logger will cause ajax call to fail.
 	 */
 	public $ignoreAjaxInFireBug=true;
-
 	/**
 	 * @var boolean whether the log should be ignored in FireBug for Flash/Flex calls. Defaults to true.
 	 * This option should be used carefully, because an Flash/Flex call returns all output as a result data.
@@ -39,6 +37,11 @@ class CWebLogRoute extends CLogRoute
 	 * @since 1.1.11
 	 */
 	public $ignoreFlashInFireBug=true;
+	/**
+	 * @var boolean whether the log should be collapsed by default in Firebug. Defaults to false.
+	 * @since 1.1.13.
+	 */
+	public $collapsedInFireBug=false;
 
 	/**
 	 * Displays the log messages.

--- a/framework/views/ar/log-firebug.php
+++ b/framework/views/ar/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Application Log");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Application Log");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/bg/log-firebug.php
+++ b/framework/views/bg/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Application Log");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Application Log");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/de/log-firebug.php
+++ b/framework/views/de/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Anwendungsprotokoll");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Anwendungsprotokoll");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/el/log-firebug.php
+++ b/framework/views/el/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Application Log");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Application Log");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/es/log-firebug.php
+++ b/framework/views/es/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Registro de Aplicación");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Registro de Aplicación");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/fr/log-firebug.php
+++ b/framework/views/fr/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Application Log");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Application Log");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/he/log-firebug.php
+++ b/framework/views/he/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("רשומות האפליקציה");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("רשומות האפליקציה");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/hr/log-firebug.php
+++ b/framework/views/hr/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Prijavnica");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Prijavnica");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/id/log-firebug.php
+++ b/framework/views/id/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Log Aplikasi");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Log Aplikasi");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/it/log-firebug.php
+++ b/framework/views/it/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Application Log");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Application Log");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/ja/log-firebug.php
+++ b/framework/views/ja/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("アプリケーションログ");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("アプリケーションログ");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/ko/log-firebug.php
+++ b/framework/views/ko/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Application Log");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Application Log");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/log-firebug.php
+++ b/framework/views/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Application Log");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Application Log");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/lt/log-firebug.php
+++ b/framework/views/lt/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Programos žurnalas");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Programos žurnalas");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/lv/log-firebug.php
+++ b/framework/views/lv/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Lietojumprogrammas žurnāls");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Lietojumprogrammas žurnāls");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/nl/log-firebug.php
+++ b/framework/views/nl/log-firebug.php
@@ -1,7 +1,7 @@
 <script type="text/javascript">
 /*<![CDATA[*/
 if(typeof(console)=='object') {
-    console.group("Applicatie Logboek");
+    console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Applicatie Logboek");
 <?php
 foreach($data as $index=>$log) {
     $time=date('H:i:s.',$log[3]).(int)(($log[3]-(int)$log[3])*1000);

--- a/framework/views/no/log-firebug.php
+++ b/framework/views/no/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Applikasjonslogg");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Applikasjonslogg");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/pl/log-firebug.php
+++ b/framework/views/pl/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Log aplikacji");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Log aplikacji");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/pt/log-firebug.php
+++ b/framework/views/pt/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Log da Aplicação");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Log da Aplicação");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/pt_br/log-firebug.php
+++ b/framework/views/pt_br/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Log da Aplicação");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Log da Aplicação");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/ro/log-firebug.php
+++ b/framework/views/ro/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Application Log");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Application Log");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/ru/log-firebug.php
+++ b/framework/views/ru/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Журнал приложения");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Журнал приложения");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/sk/log-firebug.php
+++ b/framework/views/sk/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Aplikačný Log");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Aplikačný Log");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/sv/log-firebug.php
+++ b/framework/views/sv/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Applikationslogg");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Applikationslogg");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/uk/log-firebug.php
+++ b/framework/views/uk/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Журнал додатку");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Журнал додатку");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/vi/log-firebug.php
+++ b/framework/views/vi/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("Application Log");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("Application Log");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/zh_cn/log-firebug.php
+++ b/framework/views/zh_cn/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("程序日志");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("程序日志");
 <?php
 foreach($data as $index=>$log)
 {

--- a/framework/views/zh_tw/log-firebug.php
+++ b/framework/views/zh_tw/log-firebug.php
@@ -2,7 +2,7 @@
 /*<![CDATA[*/
 if(typeof(console)=='object')
 {
-	console.group("應用程式日誌");
+	console.<?php echo $this->collapsedInFireBug?'groupCollapsed':'group'; ?>("應用程式日誌");
 <?php
 foreach($data as $index=>$log)
 {


### PR DESCRIPTION
Fixes #104: Added CWebLogRoute::$collapsedInFireBug property to control whether the log should be collapsed by default in Firebug.
