### PR TITLE
CHtml::$closeSingleTags and CHtml::$renderSpecialAttributesValue added

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,7 +48,7 @@ Version 1.1.13 work in progress
 - Enh #1396: Added 'text/csv' mime-type for the 'csv' file extension in utils/mimeTypes.php (effectively used by e.g. CHttpRequest::sendFile()) (rawtaz)
 - Enh #1426: Behaviors are now affecting memory consumption significantly less (slavcodev, creocoder, Qiang, samdark)
 - Enh #1443: Added CHttpRequest::getRawBody() that allows reading RAW HTTP request body multiple times (itamar82, resurtm, samdark)
-- Enh #1518: Allow to configure CHtml::$closeSingleTags and CHtml::$renderSpecAttrVal. Useful for HTML5 code (creocoder)
+- Enh #1518: Allow to configure CHtml::$closeSingleTags and CHtml::$renderSpecialAttributesValue. Useful for HTML5 code (creocoder)
 - Enh: Fixed the check for ajaxUpdate false value in jquery.yiilistview.js as that never happens (mdomba)
 - Enh: Requirements checker: added check for Oracle database (pdo_oci extension) and MSSQL (pdo_dblib, pdo_sqlsrv and pdo_mssql extensions) (resurtm)
 - Enh: Added CChainedLogFilter class to allow adding multiple filters to a logroute (cebe)

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -84,7 +84,7 @@ class CHtml
 	 * @var boolean whether to render special attributes value. Defaults to true. Can be setted to false for HTML5.
 	 * @since 1.1.13
 	 */
-	public static $renderSpecAttrVal=true;
+	public static $renderSpecialAttributesValue=true;
 
 	/**
 	 * Encodes special characters into HTML entities.
@@ -2267,7 +2267,7 @@ EOD;
 				if($value)
 				{
 					$html .= ' ' . $name;
-					if(self::$renderSpecAttrVal)
+					if(self::$renderSpecialAttributesValue)
 						$html .= '="' . $name . '"';
 				}
 			}


### PR DESCRIPTION
Allow using short single tags without close it:

For example:

```
<img src="..." alt="">
```

VS

```
<img src="..." alt="" />
```

Allow no render special attributes value:

For example:

```
<input name="..." disabled="disabled">
```

VS

```
<input name="..." disabled>
```

Give us pure html5 features!
