### PR TITLE
Fix #1522 - Formatted CActiveRecord::tableName() value.

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -425,7 +425,7 @@ abstract class CActiveRecord extends CModel
 	 */
 	public function tableName()
 	{
-		return get_class($this);
+		return Yii::app()->format->formatAsTableName(get_class($this));
 	}
 
 	/**

--- a/framework/utils/CFormatter.php
+++ b/framework/utils/CFormatter.php
@@ -256,6 +256,17 @@ class CFormatter extends CApplicationComponent
 		return number_format($value,$this->numberFormat['decimals'],$this->numberFormat['decimalSeparator'],$this->numberFormat['thousandSeparator']);
 	}
 
+    /**
+     * Formats the value (usually class name) as a database table name in lowercase with underscores.
+     * @param mixed $value the value to be formatted.
+     * @access public
+     * @return string the formatted table name.
+     */
+	public function formatAsTableName($value)
+	{
+		return strtolower(preg_replace('/([a-z])([A-Z])/', '$1_$2', $value));
+	}
+
 	/**
 	 * @return CHtmlPurifier the HTML purifier instance
 	 */


### PR DESCRIPTION
Issue #1522
- `CFormatter::formatAsTableName()` added.
- `CActiveRecord::tableName()` updated.
