### PR TITLE
Update framework/web/helpers/CHtml.php

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -1971,7 +1971,7 @@ EOD;
 	 * </ul>
 	 * @return string the generated list options
 	 */
-	public static function listOptions($selection,$listData,&$htmlOptions)
+	public static function listOptions($selection, $listData = array(), &$htmlOptions)
 	{
 		$raw=isset($htmlOptions['encode']) && !$htmlOptions['encode'];
 		$content='';


### PR DESCRIPTION
If `$listData` is empty or not an array, `Invalid argument supplied for foreach()` warning is thrown.
