### PR TITLE
Reset attribute status on validation error.

### DIFF
--- a/framework/web/js/source/jquery.yiiactiveform.js
+++ b/framework/web/js/source/jquery.yiiactiveform.js
@@ -260,6 +260,7 @@
 			);
 
 			if (hasError) {
+				attribute.status = 2;
 				$error.html(messages[attribute.id][0]);
 				$container.addClass(attribute.errorCssClass);
 			} else if (attribute.enableAjaxValidation || attribute.clientValidation) {


### PR DESCRIPTION
Let's say, we have a form with two fields: `password` (validators: required, compare) and `password_repeat`. If the form's client/ajax validation is enabled and password confirmation is wrong, then the password field will have "wrong confirmation" error. If we then fix our confirmation, the error will still there, because password attribute was already marked as validated (status = 1).
Is it possible to set the attribute's status to 2 (pending) on validation error, so the attribute can be revalidated later together with another (not validated yet or invalid) attributes?
