### PR TITLE
removing alert() from jquery.yiilistview.js

### DIFF
--- a/framework/zii/widgets/assets/listview/jquery.yiilistview.js
+++ b/framework/zii/widgets/assets/listview/jquery.yiilistview.js
@@ -111,7 +111,11 @@
 			},
 			error: function(XMLHttpRequest, textStatus, errorThrown) {
 				$('#'+id).removeClass(settings.loadingClass);
-				alert(XMLHttpRequest.responseText);
+				try {
+					console.info(XMLHttpRequest.responseText);
+				} catch(err) {
+					// fail silently
+				}
 			}
 		}, options || {});
 


### PR DESCRIPTION
If you have an automatically updating list and one request does not work, it gives the user a javascript alert with no possibility of the developer to override it (short of overriding `window.alert`).

That should not be the case as it bugs the end user with an alert dialog on every failed ajax request.  I think most generic would be to trigger an event. What do you think?
