### PR TITLE
PHPDoc-Complete Comments for Controller Template

### DIFF
--- a/framework/gii/generators/crud/templates/default/controller.php
+++ b/framework/gii/generators/crud/templates/default/controller.php
@@ -154,7 +154,7 @@ class <?php echo $this->controllerClass; ?> extends <?php echo $this->baseContro
 	 * Returns the data model based on the primary key given in the GET variable.
 	 * If the data model is not found, an HTTP exception will be raised.
 	 * @param integer $id the ID of the model to be loaded
-	 * @return CModel the loaded model
+	 * @return <?php echo $this->modelClass; ?> the loaded model
 	 * @throws CHttpException
 	 */
 	public function loadModel($id)
@@ -167,7 +167,7 @@ class <?php echo $this->controllerClass; ?> extends <?php echo $this->baseContro
 
 	/**
 	 * Performs the AJAX validation.
-	 * @param CModel $model the model to be validated
+	 * @param <?php echo $this->modelClass; ?> $model the model to be validated
 	 */
 	protected function performAjaxValidation($model)
 	{


### PR DESCRIPTION
The title pretty much says it: This PR completes the PHPdoc in the controller template, which in turn will reduce the number of warnings in editors that parse them.
