### PR TITLE
remove check access SQL query for guest user

### DIFF
--- a/framework/web/auth/CDbAuthManager.php
+++ b/framework/web/auth/CDbAuthManager.php
@@ -71,6 +71,8 @@ class CDbAuthManager extends CAuthManager
 	 */
 	public function checkAccess($itemName,$userId,$params=array())
 	{
+		if($userId===null)
+			return false;
 		$assignments=$this->getAuthAssignments($userId);
 		return $this->checkAccessRecursive($itemName,$userId,$params,$assignments);
 	}


### PR DESCRIPTION
Right now when logged out, this query runs on every logged out request:

``` mysql
SELECT * FROM `yii_auth_assignment` WHERE userid=:userid. Bound with :userid=NULL
```

Since there will never be such an entry, the query should be superfluous, no?
