### PR TITLE
Fixed potential vulnerability in CJavaScript::encode(): $safe parameter didn't used to be passed to the recursive method calls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@ Version 1.1.13 work in progress
 - Bug #1444: Fixed CGoogleApi::register call to registerScriptFile (mdomba)
 - Bug #1465: Fixed CHtml::beginForm() when CActiveForm with method GET and ajaxButton is used (mdomba)
 - Bug #1485 CSort does not quote table alias when using CDbCriteria (undsoft)
+- Bug: Fixed potential vulnerability in CJavaScript::encode(): $safe parameter didn't used to be passed to the recursive method calls (resurtm)
 - Enh #104: Added CWebLogRoute::$collapsedInFireBug property to control whether the log should be collapsed by default in Firebug (marcovtwout)
 - Enh #84: Log route categories are now accepted in form of array. Added CLogRoute::except and parameter to CLogRoute::getLogs that allows you to exclude specific categories (paystey)
 - Enh #117: Added CPhpMessageSource::$extensionPaths to allow extensions, that do not have a base class to use as category prefix, to register message source (rcoelho, cebe)

--- a/framework/web/helpers/CJavaScript.php
+++ b/framework/web/helpers/CJavaScript.php
@@ -83,20 +83,20 @@ class CJavaScript
 		elseif($value instanceof CJavaScriptExpression)
 			return $value->__toString();
 		elseif(is_object($value))
-			return self::encode(get_object_vars($value));
+			return self::encode(get_object_vars($value),$safe);
 		elseif(is_array($value))
 		{
 			$es=array();
 			if(($n=count($value))>0 && array_keys($value)!==range(0,$n-1))
 			{
 				foreach($value as $k=>$v)
-					$es[]="'".self::quote($k)."':".self::encode($v);
+					$es[]="'".self::quote($k)."':".self::encode($v,$safe);
 				return '{'.implode(',',$es).'}';
 			}
 			else
 			{
 				foreach($value as $v)
-					$es[]=self::encode($v);
+					$es[]=self::encode($v,$safe);
 				return '['.implode(',',$es).']';
 			}
 		}


### PR DESCRIPTION
Let's assume situation where we're building JS library to be used together with some widget:

``` php
<script type="text/javascript">
var testWidget = function(options) {
    for (var key in options) {
        var value = options[key];

        jQuery('#testWidget').append(
            '<p><a href="#" id="testWidget_' + key + '">' + key + '</a></p>'
        );

        (function(value) {
            jQuery('#testWidget_' + key).click(
                jQuery.isFunction(value)
                    ? value
                    : function() { alert('secure string: "' + value + '"'); }
            );
        })(value);
    }
};
</script>

<?php
class TestWidget extends CWidget
{
    public $options=array();

    public function run()
    {
        $options=CJavaScript::encode($this->options,true); // do NOT allow 'js:' notation
        Yii::app()->getClientScript()->registerScript('TestWidget','(function() {
            new testWidget('.$options.');
        })();');
        echo CHtml::tag('div',array('id'=>'testWidget'));
    }
}

$this->widget('TestWidget',array('options'=>array(
    'value1'=>'js:function() { alert("insecure JS function, which comes from user, #1"); }',
    'value2'=>new CJavaScriptExpression('function() { alert("secure JS function, which comes from developer, #2"); }'),
)));
?>
```

Resulting JS generated AFTER applying patch provided in this PR:

``` js
new testWidget({'value1':'js:function() { alert(\"insecure JS function, which comes from user, #1\"); }','value2':function() { alert("secure JS function, which comes from developer, #2"); }});
```

And BEFORE (even CJavaScript::encode() were called with $safe equal to true):

``` js
new testWidget({'value1':function() { alert("insecure JS function, which comes from user, #1"); },'value2':function() { alert("secure JS function, which comes from developer, #2"); }});
```

This would lead click event to run end user's JS function from the string. Of course this is a bug.
