### PR TITLE
fix CLogger bug

### DIFF
--- a/framework/logging/CLogger.php
+++ b/framework/logging/CLogger.php
@@ -72,7 +72,7 @@ class CLogger extends CComponent
 	/**
 	 * @var array log categories for excluding from filtering (used when filtering)
 	 */
-	private $_except;
+	private $_except=array();
 	/**
 	 * @var array the profiling results (category, token => time in seconds)
 	 */


### PR DESCRIPTION
if call `Yii::app()->db->getStats()`  we get error

> Invalid argument supplied for foreach() 
> /framework/logging/CLogger.php(194)

because `$this->_except` is null

@samdark http://yiiframework.ru/forum/viewtopic.php?f=6&t=8777
