### PR TITLE
Gii model code generator fixed

### DIFF
--- a/framework/gii/generators/model/ModelCode.php
+++ b/framework/gii/generators/model/ModelCode.php
@@ -188,7 +188,7 @@ class ModelCode extends CCodeModel
 
 	public function getTableSchema($tableName)
 	{
-		if (Yii::app()->{$this->connectionId}->schemaCachingDuration !== 0)
+		if (Yii::app()->{$this->connectionId}->schemaCachingDuration!==0)
 			Yii::app()->{$this->connectionId}->schema->refresh();
 		return Yii::app()->{$this->connectionId}->getSchema()->getTable($tableName);
 	}


### PR DESCRIPTION
If we use "schemaCachingDuration" value in db config, then use Gii model
generator we have one problem. If table scheme updated without
migration, we have old schema cache. I'm offer forcibly update db scheme
if "schemaCachingDuration" used.
