### PR TITLE
Fix #1574: MessageCommand::extractMessages fails to ignore invalid categories

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,7 @@ Version 1.1.13 work in progress
 - Bug #1485 CSort does not quote table alias when using CDbCriteria (undsoft)
 - Bug #1499: Fixed CVarDumper highlighting "\" (antoncpu)
 - Bug #1552: Fixed potential vulnerability in CJavaScript::encode(): $safe parameter didn't used to be passed to the recursive method calls (resurtm)
+- Bug #1575: MessageCommand::extractMessages fails to ignore invalid category definitions (softark)
 - Enh #84: Log route categories are now accepted in form of array. Added CLogRoute::except and parameter to CLogRoute::getLogs that allows you to exclude specific categories (paystey)
 - Enh #104: Added CWebLogRoute::$collapsedInFireBug property to control whether the log should be collapsed by default in Firebug (marcovtwout)
 - Enh #117: Added CPhpMessageSource::$extensionPaths to allow extensions, that do not have a base class to use as category prefix, to register message source (rcoelho, cebe)

--- a/framework/cli/commands/MessageCommand.php
+++ b/framework/cli/commands/MessageCommand.php
@@ -132,7 +132,7 @@ EOD;
 
 		foreach ($translator as $currentTranslator)
 		{
-			$n=preg_match_all('/\b'.$currentTranslator.'\s*\(\s*(\'.*?(?<!\\\\)\'|".*?(?<!\\\\)")\s*,\s*(\'.*?(?<!\\\\)\'|".*?(?<!\\\\)")\s*[,\)]/s',$subject,$matches,PREG_SET_ORDER);
+			$n=preg_match_all('/\b'.$currentTranslator.'\s*\(\s*(\'[\w.]*?(?<!\.)\'|"[\w.]*?(?<!\.)")\s*,\s*(\'.*?(?<!\\\\)\'|".*?(?<!\\\\)")\s*[,\)]/s',$subject,$matches,PREG_SET_ORDER);
 
 			for($i=0;$i<$n;++$i)
 			{


### PR DESCRIPTION
MessageCommand::extractMessages searches the source files for messages typically in the format of 

```
Yii::t('category', 'message');
```

Currently, both the category and the message are retrieved by the matching pattern of

```
(\'.*?(?<!\\\\)\'|".*?(?<!\\\\)")
```

But for the category, this pattern is too loose. As a consequent, the method sometimes fails to ignore the inappropriate candidate for it.

For example, we might write something like the following in our wrapper function for Yii::t() .

```
public static function mt($category='general', $str='', $params=array())
{
    return Yii::t("MyModule." . $category, $str, $params);
}
```

This source could crash message command very easily, because extractMessages would catch a very lengthy string as a category and fail to write a message file.

As a category is expected to be a very simple string, like 'app' or 'myModule.general', we could use a more restrictive matching pattern for it.

```
(\'[\w.]*?(?<!\.)\'|"[\w.]*?(?<!\.)")
```

This means that we allow only word characters and ".", and it should not be terminated by ".".
