### PR TITLE
change commas into dots for JS validation

### DIFF
--- a/framework/validators/CNumberValidator.php
+++ b/framework/validators/CNumberValidator.php
@@ -143,6 +143,7 @@ class CNumberValidator extends CValidator
 if(!value.match($pattern)) {
 	messages.push(".CJSON::encode($message).");
 }
+value = value.replace(',', '.');
 ";
 		if($this->min!==null)
 		{


### PR DESCRIPTION
When validating a number in Javascript, convert commas to periods after validating the pattern.

This fixes problems with some number systems which use the comma instead of the period as a decimal separator.
