### PR TITLE
add `internal_operator` param to CDbCriteria::addCondition function

### DIFF
--- a/framework/db/schema/CDbCriteria.php
+++ b/framework/db/schema/CDbCriteria.php
@@ -357,7 +357,7 @@ class CDbCriteria extends CComponent
 				$this->params[self::PARAM_PREFIX.self::$paramCount++]=$value;
 			}
 		}
-		return $this->addCondition(implode(" $columnOperator ",$params), $operator);
+		return $this->addCondition($params, $operator,$columnOperator);
 	}
 
 	/**

--- a/tests/framework/db/schema/CDbCriteriaTest.php
+++ b/tests/framework/db/schema/CDbCriteriaTest.php
@@ -144,7 +144,7 @@ class CDbCriteriaTest extends CTestCase {
 		$criteria = new CDbCriteria();
 		$criteria->addColumnCondition(array('A' => 1, 'B' => null, 'C' => '2'));
 
-		$this->assertEquals('A=:ycp0 AND B IS NULL AND C=:ycp1', $criteria->condition);
+		$this->assertEquals('(A=:ycp0) AND (B IS NULL) AND (C=:ycp1)', $criteria->condition);
 		$this->assertEquals(1, $criteria->params[':ycp0']);
 		$this->assertEquals('2', $criteria->params[':ycp1']);
 	}


### PR DESCRIPTION
This feature allow for more difficult conditions, without create new CDbCriteria
a simple example:
now:

``` php
        $tmpCriteria = new CDbCriteria();
        $tmpCriteria->addCondition(array(
            'status => :status',
            'status = 0 AND owner = :uid'
        ), 'OR');
        $criteria->mergeWith($tmpCriteria, true);
```

after this changes:

``` php
        $criteria->addCondition(array(
            'status => :status',
            'status = 0 AND owner = :uid'
        ), 'AND', 'OR');
```

I'm very confused, but if request will be accepted, please check grammar in function description
