### PR TITLE
Store Meta tag by options excluding content.

### DIFF
--- a/framework/web/CClientScript.php
+++ b/framework/web/CClientScript.php
@@ -654,7 +654,7 @@ class CClientScript extends CApplicationComponent
 		if($httpEquiv!==null)
 			$options['http-equiv']=$httpEquiv;
 		$options['content']=$content;
-		$this->metaTags[null===$id?count($this->metaTags):$key]=$options;
+		$this->metaTags[null===$id?count($this->metaTags):$id]=$options;
 		$params=func_get_args();
 		$this->recordCachingAction('clientScript','registerMetaTag',$params);
 		return $this;


### PR DESCRIPTION
Ref: yiisoft/yii#1351
Are duplicate meta tags valid HTML?

Use the metatag options excluding the content as the key name.
Will allow changing/overwriting of previously registered meta tags.
