### PR TITLE
fix bug in CWidget::getViewPath()

### DIFF
--- a/framework/web/widgets/CWidget.php
+++ b/framework/web/widgets/CWidget.php
@@ -165,8 +165,8 @@ class CWidget extends CBaseController
 	public function getViewPath($checkTheme=false)
 	{
 		$className=get_class($this);
-		if(isset(self::$_viewPaths[$className]))
-			return self::$_viewPaths[$className];
+		if(isset(self::$_viewPaths[$className][$checkTheme]))
+			return self::$_viewPaths[$className][$checkTheme];
 		else
 		{
 			if($checkTheme && ($theme=Yii::app()->getTheme())!==null)
@@ -177,11 +177,11 @@ class CWidget extends CBaseController
 				else
 					$path.=$className;
 				if(is_dir($path))
-					return self::$_viewPaths[$className]=$path;
+					return self::$_viewPaths[$className][$checkTheme]=$path;
 			}
 
 			$class=new ReflectionClass($className);
-			return self::$_viewPaths[$className]=dirname($class->getFileName()).DIRECTORY_SEPARATOR.'views';
+			return self::$_viewPaths[$className][$checkTheme]=dirname($class->getFileName()).DIRECTORY_SEPARATOR.'views';
 		}
 	}
 


### PR DESCRIPTION
new attempt fix https://github.com/yiisoft/yii/pull/472

**problem description:**
Application has applied theme.
In theme created folder for widget views, but view file for widget not created.
In this case widget must render file from folder alongside widget, but application throws exception

The problem is that when _getViewPath()_ cache paths in __viewPaths_ param _$checkTheme_ is ignored.

enviroment for test https://github.com/Ryadnov/yii-issue472
