### PR TITLE
Fixes #1635: CDateFormatter::format() with 'ZZZZZ' pattern used to return timezone in RFC 822 format, now returns in ISO 8601 format as it stated in CLDR.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@ Version 1.1.13 work in progress
 - Bug #1552: Fixed potential vulnerability in CJavaScript::encode(): $safe parameter didn't used to be passed to the recursive method calls (resurtm)
 - Bug #1584: Fixed CGridView urls when enableHistory was used with "path" urlFormat (mdomba)
 - Bug #1624: Requirements page now tries all other preferred languages when the most preferred one is missing (ArtVal)
+- Bug #1635: CDateFormatter::format() with 'ZZZZZ' pattern used to return timezone in RFC 822 format, now returns in ISO 8601 format as it stated in CLDR (resurtm)
 - Bug: Table schema is refreshed on Gii model generation when schemaCachingDuration is used (SonkoDmitry)
 - Bug: CDbCommand::setFetchMode wasn't accepting additional arguments needed for PDO::FETCH_CLASS (samdark)
 - Enh #84: Log route categories are now accepted in form of array. Added CLogRoute::except and parameter to CLogRoute::getLogs that allows you to exclude specific categories (paystey)

--- a/framework/i18n/CDateFormatter.php
+++ b/framework/i18n/CDateFormatter.php
@@ -508,7 +508,7 @@ class CDateFormatter extends CComponent
 		if($pattern[0]==='z' || $pattern[0]==='v')
 			return @date('T', @mktime($date['hours'], $date['minutes'], $date['seconds'], $date['mon'], $date['mday'], $date['year']));
 		elseif($pattern[0]==='Z')
-			return @date('O', @mktime($date['hours'], $date['minutes'], $date['seconds'], $date['mon'], $date['mday'], $date['year']));
+			return @date('P', @mktime($date['hours'], $date['minutes'], $date['seconds'], $date['mon'], $date['mday'], $date['year']));
 		else
 			throw new CException(Yii::t('yii','The pattern for time zone must be "z" or "v".'));
 	}

--- a/tests/framework/i18n/CDateFormatterTest.php
+++ b/tests/framework/i18n/CDateFormatterTest.php
@@ -35,4 +35,21 @@ class CDateFormatterTest extends CTestCase
 		$this->assertEquals('1927 04 30 05:05:51', Yii::app()->dateFormatter->format("yyyy MM dd hh:mm:ss", '1927-04-30 05:05:51 UTC'));
 	}
 
+	public function testTimeZones()
+	{
+		date_default_timezone_set('UTC');
+		$this->assertEquals('+00:00', Yii::app()->dateFormatter->format('ZZZZZ', time()));
+
+		date_default_timezone_set('Etc/GMT-6');
+		$this->assertEquals('+06:00', Yii::app()->dateFormatter->format('ZZZZZ', time()));
+
+		date_default_timezone_set('Etc/GMT+10');
+		$this->assertEquals('-10:00', Yii::app()->dateFormatter->format('ZZZZZ', time()));
+
+		date_default_timezone_set('Europe/Moscow');
+		$this->assertEquals('+04:00', Yii::app()->dateFormatter->format('ZZZZZ', time()));
+
+		date_default_timezone_set('America/Los_Angeles');
+		$this->assertEquals('-07:00', Yii::app()->dateFormatter->format('ZZZZZ', time()));
+	}
 }


### PR DESCRIPTION
Fixes #1635: CDateFormatter::format() with 'ZZZZZ' pattern used to return timezone in RFC 822 format, now returns in ISO 8601 format as it stated in CLDR.
