### PR TITLE
Fixed #1625: CEmailLogRoute does not properly encode UTF-8 characters contained in logs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,7 +31,7 @@ Version 1.1.13 work in progress
 - Bug #1584: Fixed CGridView urls when enableHistory was used with "path" urlFormat (mdomba)
 - Bug #1622: CLocale::getTerritory() used to return invalid territory name when locales (language tags) were specified without territory part (e.g. 'de', 'fr') (resurtm)
 - Bug #1624: Requirements page now tries all other preferred languages when the most preferred one is missing (ArtVal)
-- Bug #1625: CEmailLogRoute does not properly encode UTF-8 characters contained in logs, CEmailLogRoute::$utf8Charset property added (mdomba, resurtm)
+- Bug #1625: CEmailLogRoute does not properly encode UTF8 characters contained in logs, CEmailLogRoute::$utf8 property added (mdomba, resurtm)
 - Bug #1646: CLocale::getTerritory() used to return invalid territory name when locales (language tags) were specified with script part (e.g. 'zh-Hans-CN', 'zh-Hant-HK') (resurtm)
 - Bug: Table schema is refreshed on Gii model generation when schemaCachingDuration is used (SonkoDmitry)
 - Bug: CDbCommand::setFetchMode wasn't accepting additional arguments needed for PDO::FETCH_CLASS (samdark)

--- a/framework/logging/CEmailLogRoute.php
+++ b/framework/logging/CEmailLogRoute.php
@@ -31,7 +31,7 @@ class CEmailLogRoute extends CLogRoute
 	 * non-latin or UTF-8 characters. Emails would be UTF-8 encoded.
 	 * @since 1.1.13
 	 */
-	public $utf8Charset=false;
+	public $utf8=false;
 	/**
 	 * @var array list of destination email addresses.
 	 */
@@ -75,7 +75,7 @@ class CEmailLogRoute extends CLogRoute
 	protected function sendEmail($email,$subject,$message)
 	{
 		$headers=$this->getHeaders();
-		if($this->utf8Charset)
+		if($this->utf8)
 		{
 			$headers[]="MIME-Version: 1.0";
 			$headers[]="Content-type: text/plain; charset=UTF-8";
@@ -87,7 +87,7 @@ class CEmailLogRoute extends CLogRoute
 			preg_match_all('/([^<]*)<([^>]*)>/iu',$from,$matches);
 			if(isset($matches[1][0],$matches[2][0]))
 			{
-				$name=$this->utf8Charset ? '=?UTF-8?B?'.base64_encode(trim($matches[1][0])).'?=' : trim($matches[1][0]);
+				$name=$this->utf8 ? '=?UTF-8?B?'.base64_encode(trim($matches[1][0])).'?=' : trim($matches[1][0]);
 				$from=trim($matches[2][0]);
 				$headers[]="From: {$name} <{$from}>";
 			}


### PR DESCRIPTION
Fixed #1625: CEmailLogRoute does not properly encode UTF-8 characters contained in logs.

Usage:

``` php
'log'=>array(
    'class'=>'CLogRouter',
    'routes'=>array(
        // ...
        array(
            'class'=>'CEmailLogRoute',
            'categories'=>'application.*',
            'emails'=>'resurtm@gmail.com',
            'subject'=>'Тестовая тема письма',
            'sentFrom'=>'Василий Пупкин <vasya@mail.ru>',
            //'sentFrom'=>'vasya@mail.ru',
            'utf8'=>true,
        ),
    ),
),

// ...

Yii::trace('Тестовое UTF-8 сообщение.');
```
