### PR TITLE
radioButtonList crashes when argument $select is supplied as an array of selected elements.

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -996,7 +996,7 @@ EOD;
 		$id=0;
 		foreach($data as $value=>$label)
 		{
-			$checked=!strcmp($value,$select);
+			$checked=!is_array($select) && !strcmp($value,$select) || is_array($select) && in_array($value,$select);
 			$htmlOptions['value']=$value;
 			$htmlOptions['id']=$baseID.'_'.$id++;
 			$option=self::radioButton($name,$checked,$htmlOptions);


### PR DESCRIPTION
Up to now it could only accept a single checkbox value. 

However, when supplying array of selected element, it would throw error:
"strcmp() expects parameter 2 to be string, array given"

Now it evaluates correctly just like checkBoxList. 
