### PR TITLE
CActiveRecord::deleteAll and updateAll should use scope

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -1705,6 +1705,7 @@ abstract class CActiveRecord extends CModel
 		Yii::trace(get_class($this).'.updateAll()','system.db.ar.CActiveRecord');
 		$builder=$this->getCommandBuilder();
 		$criteria=$builder->createCriteria($condition,$params);
+		$this->applyScopes($criteria);
 		$command=$builder->createUpdateCommand($this->getTableSchema(),$attributes,$criteria);
 		return $command->execute();
 	}
@@ -1757,6 +1758,7 @@ abstract class CActiveRecord extends CModel
 		Yii::trace(get_class($this).'.deleteAll()','system.db.ar.CActiveRecord');
 		$builder=$this->getCommandBuilder();
 		$criteria=$builder->createCriteria($condition,$params);
+		$this->applyScopes($criteria);
 		$command=$builder->createDeleteCommand($this->getTableSchema(),$criteria);
 		return $command->execute();
 	}

--- a/tests/framework/db/ar/CActiveRecordTest.php
+++ b/tests/framework/db/ar/CActiveRecordTest.php
@@ -230,6 +230,22 @@ class CActiveRecordTest extends CTestCase
 		$this->assertNull(Post::model()->findByPk(5));
 	}
 
+	public function testDeleteAllWithScope()
+	{
+		$posts = Post::model()->count();
+		Post::model()->post3()->deleteAll();
+		$this->assertEquals($posts - 1, Post::model()->count());
+	}
+
+	public function testUpdateAllWithScope()
+	{
+		
+		Post::model()->post3()->updateAll(array('title' => 'post'));
+		$post3=Post::model()->post3()->find();
+		$post=Post::model()->findByPk(1);
+		$this->assertNotEquals($post3->title, $post->title);
+	}
+
 	public function testRefresh()
 	{
 		$post=Post::model()->findByPk(1);


### PR DESCRIPTION
It fixes #1571. I think this is the proper behavior or otherwise there should be an exception thrown if someone tries to use a scope with these methods. I wrote unit tests but I was not sure why there is a CActiveRecord2Test so I added the test only to CActiveRecordTest.
/cc @qiangxue 
