### PR TITLE
#1712 CBehavior knows the name that it was attached to owner

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -80,6 +80,7 @@ Version 1.1.13 work in progress
 - Enh #1596: Added CGridView::rowHtmlOptionsExpression to allow set HTML attributes for the row (Ryadnov)
 - Enh #1657: CDbCommandBuilder::createUpdateCounterCommand now can be used with float values (samdark, hyzhakus)
 - Enh #1658: CFormatter::formatHtml() is now more flexible and customizable through new CFormatter::$htmlPurifierOptions property (resurtm)
+- Enh #1712: CBehavior knows the name that it was attached to owner (dmtrs)
 - Enh: Fixed the check for ajaxUpdate false value in jquery.yiilistview.js as that never happens (mdomba)
 - Enh: Requirements checker: added check for Oracle database (pdo_oci extension) and MSSQL (pdo_dblib, pdo_sqlsrv and pdo_mssql extensions) (resurtm)
 - Enh: Added CChainedLogFilter class to allow adding multiple filters to a logroute (cebe)

--- a/framework/base/CBehavior.php
+++ b/framework/base/CBehavior.php
@@ -22,6 +22,8 @@ class CBehavior extends CComponent implements IBehavior
 	private $_enabled;
 	private $_owner;
 
+	public $attachedId;
+
 	/**
 	 * Declares events and the corresponding event handler methods.
 	 * The events are defined by the {@link owner} component, while the handler

--- a/framework/base/CComponent.php
+++ b/framework/base/CComponent.php
@@ -324,6 +324,7 @@ class CComponent
 	{
 		if(!($behavior instanceof IBehavior))
 			$behavior=Yii::createComponent($behavior);
+		$behavior->attachedId=$name;
 		$behavior->setEnabled(true);
 		$behavior->attach($this);
 		return $this->_m[$name]=$behavior;

--- a/tests/framework/base/CBehaviorTest.php
+++ b/tests/framework/base/CBehaviorTest.php
@@ -18,6 +18,16 @@ class CBehaviorTest extends CTestCase {
 		$component->test2();
 	}
 
+	public function testAttachedBehaviorId()
+	{
+		$id = uniqid();
+		$component=new NewComponent;
+		$component->attachBehavior($id, new NewBehavior);
+		$behavior = $component->asa($id);
+
+		$this->assertEquals($id, $behavior->attachedId);
+	}
+
     public function testDisableBehaviors(){
         $component=new NewComponent;
         $component->attachBehavior('a',new NewBehavior);


### PR DESCRIPTION
- Added `CBehavior::$attachedId` to get the name that the specific `CBehavior` object was attached to owner.