### PR TITLE
Make parameters in CDbCriteria::mergeWith() more consistent

### DIFF
--- a/framework/db/schema/CDbCriteria.php
+++ b/framework/db/schema/CDbCriteria.php
@@ -480,12 +480,15 @@ class CDbCriteria extends CComponent
 	 * Also, the criteria passed as the parameter takes precedence in case
 	 * two options cannot be merged (e.g. LIMIT, OFFSET).
 	 * @param mixed $criteria the criteria to be merged with. Either an array or CDbCriteria.
-	 * @param boolean $useAnd whether to use 'AND' to merge condition and having options.
-	 * If false, 'OR' will be used instead. Defaults to 'AND'.
+	 * @param mixed $operator the operator used to merge condition and having options.
+	 * It true to use 'AND' to merge condition and having options.
+	 * If false, 'OR' will be used instead.
+	 * Defaults to 'AND'.
 	 */
-	public function mergeWith($criteria,$useAnd=true)
+	public function mergeWith($criteria,$operator='AND')
 	{
-		$and=$useAnd ? 'AND' : 'OR';
+		if(is_bool($operator))		
+			$operator=$operator ? 'AND' : 'OR';
 		if(is_array($criteria))
 			$criteria=new self($criteria);
 		if($this->select!==$criteria->select)
@@ -505,7 +508,7 @@ class CDbCriteria extends CComponent
 			if($this->condition==='')
 				$this->condition=$criteria->condition;
 			elseif($criteria->condition!=='')
-				$this->condition="({$this->condition}) $and ({$criteria->condition})";
+				$this->condition="({$this->condition}) $operator ({$criteria->condition})";
 		}
 
 		if($this->params!==$criteria->params)
@@ -549,7 +552,7 @@ class CDbCriteria extends CComponent
 			if($this->having==='')
 				$this->having=$criteria->having;
 			elseif($criteria->having!=='')
-				$this->having="({$this->having}) $and ({$criteria->having})";
+				$this->having="({$this->having}) $operator ({$criteria->having})";
 		}
 
 		if($criteria->distinct>0)
@@ -611,7 +614,7 @@ class CDbCriteria extends CComponent
 						unset($v[$opt]);
 					}
 					$this->with[$k]=new self($this->with[$k]);
-					$this->with[$k]->mergeWith($v,$useAnd);
+					$this->with[$k]->mergeWith($v,$operator);
 					$this->with[$k]=$this->with[$k]->toArray();
 					if (count($excludes)!==0)
 						$this->with[$k]=CMap::mergeArray($this->with[$k],$excludes);


### PR DESCRIPTION
Во всех  методах CDbCriteria, где есть необходимость в операторах AND или OR, используется строка для их указания, и только в методе mergeWith для єтих целей используется логическое значение. 
Предлагаю в методе mergeWith так же использовать строку, но оставить логический тип для совместимости.
