### PR TITLE
Table comments for PostgreSQL and MySQL are available now through CDbTableSchema::$comment property

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -84,6 +84,7 @@ Version 1.1.13 work in progress
 - Enh #1596: Added CGridView::rowHtmlOptionsExpression to allow set HTML attributes for the row (Ryadnov)
 - Enh #1657: CDbCommandBuilder::createUpdateCounterCommand now can be used with float values (samdark, hyzhakus)
 - Enh #1658: CFormatter::formatHtml() is now more flexible and customizable through new CFormatter::$htmlPurifierOptions property (resurtm)
+- Enh #1749: Table comments for PostgreSQL and MySQL are available now through CDbTableSchema::$comment property (resurtm)
 - Enh: Fixed the check for ajaxUpdate false value in jquery.yiilistview.js as that never happens (mdomba)
 - Enh: Requirements checker: added check for Oracle database (pdo_oci extension) and MSSQL (pdo_dblib, pdo_sqlsrv and pdo_mssql extensions) (resurtm)
 - Enh: Added CChainedLogFilter class to allow adding multiple filters to a logroute (cebe)

--- a/framework/db/schema/CDbTableSchema.php
+++ b/framework/db/schema/CDbTableSchema.php
@@ -55,6 +55,13 @@ class CDbTableSchema extends CComponent
 	 * @var array column metadata of this table. Each array element is a CDbColumnSchema object, indexed by column names.
 	 */
 	public $columns=array();
+	/**
+	 * @var string comment of this table. Default value is empty string which means that no comment has been set
+	 * for the table. Null value means that RDBMS does not support table comments at all or comment retrieval
+	 * for the active RDBMS is not yet implemented.
+	 * @since 1.1.13
+	 */
+	public $comment='';
 
 	/**
 	 * Gets the named column metadata.

--- a/framework/db/schema/mssql/CMssqlSchema.php
+++ b/framework/db/schema/mssql/CMssqlSchema.php
@@ -129,6 +129,7 @@ class CMssqlSchema extends CDbSchema
 	{
 		$table=new CMssqlTableSchema;
 		$this->resolveTableNames($table,$name);
+		$this->resolveTableComment($table,$name);
 		//if (!in_array($table->name, $this->tableNames)) return null;
 		$table->primaryKey=$this->findPrimaryKey($table);
 		$table->foreignKeys=$this->findForeignKeys($table);
@@ -171,6 +172,16 @@ class CMssqlSchema extends CDbSchema
 			$table->schemaName=self::DEFAULT_SCHEMA;
 			$table->rawName=$this->quoteTableName($table->schemaName).'.'.$this->quoteTableName($table->name);
 		}
+	}
+
+	/**
+	 * Retrieves table comment by its name.
+	 * @param CMssqlTableSchema $table the table instance
+	 * @param string $name the unquoted table name
+	 */
+	protected function resolveTableComment($table,$name)
+	{
+		$table->comment=null;
 	}
 
 	/**

--- a/framework/db/schema/mysql/CMysqlSchema.php
+++ b/framework/db/schema/mysql/CMysqlSchema.php
@@ -115,6 +115,7 @@ class CMysqlSchema extends CDbSchema
 	{
 		$table=new CMysqlTableSchema;
 		$this->resolveTableNames($table,$name);
+		$this->resolveTableComment($table,$name);
 
 		if($this->findColumns($table))
 		{
@@ -144,6 +145,18 @@ class CMysqlSchema extends CDbSchema
 			$table->name=$parts[0];
 			$table->rawName=$this->quoteTableName($table->name);
 		}
+	}
+
+	/**
+	 * Retrieves table comment by its name.
+	 * @param CMysqlTableSchema $table the table instance
+	 * @param string $name the unquoted table name
+	 */
+	protected function resolveTableComment($table,$name)
+	{
+		$row=$this->getDbConnection()->createCommand('SHOW TABLE STATUS WHERE Name=:name')
+			->queryRow(true,array(':name'=>$name));
+		$table->comment=$row['Comment'];
 	}
 
 	/**

--- a/framework/db/schema/oci/COciSchema.php
+++ b/framework/db/schema/oci/COciSchema.php
@@ -117,6 +117,7 @@ class COciSchema extends CDbSchema
 	{
 		$table=new COciTableSchema;
 		$this->resolveTableNames($table,$name);
+		$this->resolveTableComment($table,$name);
 
 		if(!$this->findColumns($table))
 			return null;
@@ -150,6 +151,16 @@ class COciSchema extends CDbSchema
 			$table->rawName=$this->quoteTableName($tableName);
 		else
 			$table->rawName=$this->quoteTableName($schemaName).'.'.$this->quoteTableName($tableName);
+	}
+
+	/**
+	 * Retrieves table comment by its name.
+	 * @param COciTableSchema $table the table instance
+	 * @param string $name the unquoted table name
+	 */
+	protected function resolveTableComment($table,$name)
+	{
+		$table->comment=null;
 	}
 
 	/**

--- a/framework/db/schema/pgsql/CPgsqlSchema.php
+++ b/framework/db/schema/pgsql/CPgsqlSchema.php
@@ -106,6 +106,7 @@ class CPgsqlSchema extends CDbSchema
 	{
 		$table=new CPgsqlTableSchema;
 		$this->resolveTableNames($table,$name);
+		$this->resolveTableComment($table,$name);
 		if(!$this->findColumns($table))
 			return null;
 		$this->findConstraints($table);
@@ -152,6 +153,18 @@ class CPgsqlSchema extends CDbSchema
 			$table->rawName=$this->quoteTableName($tableName);
 		else
 			$table->rawName=$this->quoteTableName($schemaName).'.'.$this->quoteTableName($tableName);
+	}
+
+	/**
+	 * Retrieves table comment by its name.
+	 * @param CPgsqlTableSchema $table the table instance
+	 * @param string $name the unquoted table name
+	 */
+	protected function resolveTableComment($table,$name)
+	{
+		$row=$this->getDbConnection()->createCommand("SELECT obj_description(oid) FROM pg_class WHERE relname=:name AND relkind='r';")
+			->queryRow(true,array(':name'=>$table->name));
+		$table->comment=$row['obj_description'];
 	}
 
 	/**

--- a/framework/db/schema/sqlite/CSqliteSchema.php
+++ b/framework/db/schema/sqlite/CSqliteSchema.php
@@ -107,6 +107,7 @@ class CSqliteSchema extends CDbSchema
 		$table=new CDbTableSchema;
 		$table->name=$name;
 		$table->rawName=$this->quoteTableName($name);
+		$table->comment=null;
 
 		if($this->findColumns($table))
 		{

--- a/tests/framework/db/data/mysql.sql
+++ b/tests/framework/db/data/mysql.sql
@@ -10,7 +10,7 @@ CREATE TABLE users
 	username VARCHAR(128) NOT NULL COMMENT 'Name of the user',
 	password VARCHAR(128) NOT NULL COMMENT 'Hashed password',
 	email VARCHAR(128) NOT NULL
-) ENGINE=InnoDB;
+) ENGINE=InnoDB COMMENT='Users information table';
 
 INSERT INTO users (username, password, email) VALUES ('user1','pass1','email1');
 INSERT INTO users (username, password, email) VALUES ('user2','pass2','email2');
@@ -24,7 +24,7 @@ CREATE TABLE profiles
 	user_id INTEGER NOT NULL,
 	CONSTRAINT FK_profile_user FOREIGN KEY (user_id)
 		REFERENCES users (id) ON DELETE CASCADE ON UPDATE RESTRICT
-) ENGINE=InnoDB;
+) ENGINE=InnoDB COMMENT='User profiles.\nNewline.\n\nTwo new lines.';
 
 INSERT INTO profiles (first_name, last_name, user_id) VALUES ('first 1','last 1',1);
 INSERT INTO profiles (first_name, last_name, user_id) VALUES ('first 2','last 2',2);

--- a/tests/framework/db/data/postgres.sql
+++ b/tests/framework/db/data/postgres.sql
@@ -13,6 +13,7 @@ CREATE TABLE test.users
 	email VARCHAR(128) NOT NULL
 );
 
+COMMENT ON TABLE test.users IS 'Users information table';
 COMMENT ON COLUMN test.users.username IS 'Name of the user';
 COMMENT ON COLUMN test.users.password IS 'Hashed password';
 
@@ -44,6 +45,8 @@ CREATE TABLE test.profiles
 	CONSTRAINT FK_profile_user FOREIGN KEY (user_id)
 		REFERENCES test.users (id) ON DELETE CASCADE ON UPDATE RESTRICT
 );
+
+COMMENT ON TABLE test.profiles IS E'User profiles.\nNewline.\n\nTwo new lines.';
 
 INSERT INTO test.profiles (first_name, last_name, user_id) VALUES ('first 1','last 1',1);
 INSERT INTO test.profiles (first_name, last_name, user_id) VALUES ('first 2','last 2',2);

--- a/tests/framework/db/schema/CMysqlTest.php
+++ b/tests/framework/db/schema/CMysqlTest.php
@@ -302,4 +302,14 @@ class CMysqlTest extends CTestCase
 		$this->assertEquals('Hashed password',$usersColumns['password']->comment);
 		$this->assertEquals('',$usersColumns['email']->comment);
 	}
+
+	public function testTableComments()
+	{
+		$tables=$this->db->schema->tables;
+
+		$this->assertEquals('Users information table',$tables['users']->comment);
+		$this->assertEquals("User profiles.\nNewline.\n\nTwo new lines.",$tables['profiles']->comment);
+		$this->assertEquals('',$tables['posts']->comment);
+		$this->assertEquals('',$tables['comments']->comment);
+	}
 }

--- a/tests/framework/db/schema/CPostgresTest.php
+++ b/tests/framework/db/schema/CPostgresTest.php
@@ -271,4 +271,12 @@ class CPostgresTest extends CTestCase
 		$this->assertEquals('Hashed password',$usersColumns['password']->comment);
 		$this->assertEquals('',$usersColumns['email']->comment);
 	}
+
+	public function testTableComments()
+	{
+		$this->assertEquals('Users information table',$this->db->schema->getTable('test.users')->comment);
+		$this->assertEquals("User profiles.\nNewline.\n\nTwo new lines.",$this->db->schema->getTable('test.profiles')->comment);
+		$this->assertEquals('',$this->db->schema->getTable('test.posts')->comment);
+		$this->assertEquals('',$this->db->schema->getTable('test.comments')->comment);
+	}
 }

--- a/tests/framework/db/schema/CSqliteTest.php
+++ b/tests/framework/db/schema/CSqliteTest.php
@@ -279,4 +279,24 @@ class CSqliteTest extends CTestCase
 		$this->assertArrayHasKey('profiles_renamed',$this->db->schema->tables);
 		$this->assertArrayHasKey('users_renamed',$this->db->schema->tables);
 	}
+
+	public function testColumnComments()
+	{
+		$usersColumns=$this->db->schema->tables['users']->columns;
+
+		$this->assertEquals(null,$usersColumns['id']->comment);
+		$this->assertEquals(null,$usersColumns['username']->comment);
+		$this->assertEquals(null,$usersColumns['password']->comment);
+		$this->assertEquals(null,$usersColumns['email']->comment);
+	}
+
+	public function testTableComments()
+	{
+		$tables=$this->db->schema->tables;
+
+		$this->assertEquals(null,$tables['users']->comment);
+		$this->assertEquals(null,$tables['profiles']->comment);
+		$this->assertEquals(null,$tables['posts']->comment);
+		$this->assertEquals(null,$tables['comments']->comment);
+	}
 }


### PR DESCRIPTION
As #1123 and #1294 has been merged and column comments are available through Yii API now, so why not to do the same for tables? :)
