### PR TITLE
better fix for #835

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,7 +12,7 @@ Version 1.1.13 work in progress
 - Bug #140: Fixed validation CJuiButton with type buttonset (adminnu)
 - Bug #276: Tweaked CGridView stylesheet to include a hover style for the selected row (acorncom)
 - Bug #810: Gii now adds a number to the end of relation name if same named relation already exists instead of not generating relation (n30kill, samdark)
-- Bug #835: CApplication::onEndRequest is now called at the script shutdown to make sure log is written on forceful script termination (samdark)
+- Bug #835: CApplication::onEndRequest is now called at the script shutdown to make sure log is written on forceful script termination (samdark, cebe)
 - Bug #837: Fixed method CDbCriteria::__wakeup(), allowing to keep custom names for params and update all string parts for automatic params (klimov-paul)
 - Bug #959: Bug where non-lowercase keys cannot be found in CConsoleApplication::$commandMap fixed (resurtm)
 - Bug #962: Fixed handling of negative timestamps in CDateFormatter::format() (johnmendonca)

--- a/framework/base/CApplication.php
+++ b/framework/base/CApplication.php
@@ -165,31 +165,24 @@ abstract class CApplication extends CModule
 	{
 		if($this->hasEventHandler('onBeginRequest'))
 			$this->onBeginRequest(new CEvent($this));
-		register_shutdown_function(array($this, 'shutdown'));
+		register_shutdown_function(array($this,'end'),0,false);
 		$this->processRequest();
-	}
-
-	/**
-	 * This method is automatically called at the end of script execution and
-	 * should not be called explicitly. If overwritten, make sure to call
-	 * the parent implementation so that {@link onEndRequest} event is raised.
-	 *
-	 * @since 1.1.13
-	 */
-	public function shutdown()
-	{
 		if($this->hasEventHandler('onEndRequest'))
 			$this->onEndRequest(new CEvent($this));
 	}
 
 	/**
 	 * Terminates the application.
+	 * This method replaces PHP's exit() function by calling
+	 * {@link onEndRequest} before exiting.
 	 * @param integer $status exit status (value 0 means normal exit while other values mean abnormal exit).
 	 * @param boolean $exit whether to exit the current request. This parameter has been available since version 1.1.5.
 	 * It defaults to true, meaning the PHP's exit() function will be called at the end of this method.
 	 */
-	public function end($status=0, $exit=true)
+	public function end($status=0,$exit=true)
 	{
+		if($this->hasEventHandler('onEndRequest'))
+			$this->onEndRequest(new CEvent($this));
 		if($exit)
 			exit($status);
 	}


### PR DESCRIPTION
issue #835
reverts fix introduced with 5b28c6ab0081d274e2e2d506fe167c7d56e749a9

as onEndRequest will fire event only once I added app->end() method as
shutdown function to make sure onEndRequest gets called in any case.
If application called it before shutdown function has no effect.

onEndRequest is only called once, as you can see:

``` php
    /**
     * Raised right AFTER the application processes the request.
     * @param CEvent $event the event parameter
     */
    public function onEndRequest($event)
    {
        if(!$this->_ended)
        {
            $this->_ended=true;
            $this->raiseEvent('onEndRequest',$event);
        }
    }
```
