### PR TITLE
CPasswordHelper

### DIFF
--- a/framework/utils/CPasswordHelper.php
+++ b/framework/utils/CPasswordHelper.php
@@ -28,7 +28,7 @@
  *
  * Generate a hash from a password:
  * <pre>
- * $hash = PasswordManager::hashPassword($password);
+ * $hash = PasswordHelper::hashPassword($password);
  * </pre>
  * This hash can be stored in a database (e.g. CHAR(64) CHARACTER SET latin1). The
  * hash is usually generated and saved to the database when the user enters a new password.
@@ -37,7 +37,7 @@
  *
  * To verify a password, fetch the user's saved hash from the database (into $hash) and:
  * <pre>
- * if (PasswordManager::verifyPassword($password, $hash)
+ * if (PasswordHelper::verifyPassword($password, $hash)
  *     // password is good
  * else
  *     // password is bad


### PR DESCRIPTION
The motivation and background for this component is exactly the same as described in PHP RFC [Adding simple password hashing API](https://wiki.php.net/rfc/password_hash), so I shall not explain that.

This class is different from what may be coming in PHP 5.5:
- it works with PHP 5.1+ rather than 5.5+
- it is written as a class rather than a set of functions in the global namespace
- it doesn't trigger_errors, it throws CException where necessary
- it is a Yii CApplicationComponent
- it has fewer options
- it has documentation
