### PR TITLE
Enh #1725: Added CFileHelper::removeDirectory() static method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -102,6 +102,7 @@ Version 1.1.13 work in progress
 - Enh #1596: Added CGridView::rowHtmlOptionsExpression to allow set HTML attributes for the row (Ryadnov)
 - Enh #1657: CDbCommandBuilder::createUpdateCounterCommand now can be used with float values (samdark, hyzhakus)
 - Enh #1658: CFormatter::formatHtml() is now more flexible and customizable through new CFormatter::$htmlPurifierOptions property (resurtm)
+- Enh #1725: Added CFileHelper::removeDirectory() static method (resurtm, Ragazzo, samdark)
 - Enh: Fixed the check for ajaxUpdate false value in jquery.yiilistview.js as that never happens (mdomba)
 - Enh: Requirements checker: added check for Oracle database (pdo_oci extension) and MSSQL (pdo_dblib, pdo_sqlsrv and pdo_mssql extensions) (resurtm)
 - Enh: Added CChainedLogFilter class to allow adding multiple filters to a logroute (cebe)

--- a/framework/utils/CFileHelper.php
+++ b/framework/utils/CFileHelper.php
@@ -64,6 +64,30 @@ class CFileHelper
 	}
 
 	/**
+	 * Removes a directory recursively.
+	 * @param string $directory the directory to be deleted recursively.
+	 * @since 1.1.13
+	 */
+	public static function removeDirectory($directory)
+	{
+		if(!is_dir($directory) || !is_readable($directory))
+			return;
+		$handle=opendir($directory);
+		while(($item=readdir($handle))!==false)
+		{
+			if($item=='.' || $item=='..')
+				continue;
+			if(is_dir($path=$directory.DIRECTORY_SEPARATOR.$item))
+				self::removeDirectory($path);
+			else
+				unlink($path);
+		}
+		closedir($handle);
+		if(count(scandir($directory))==2)
+			rmdir($directory);
+	}
+
+	/**
 	 * Returns the files found under the specified directory and subdirectories.
 	 * @param string $dir the directory under which the files will be looked for
 	 * @param array $options options for file searching. Valid options are:

--- a/tests/framework/utils/CFileHelperTest.php
+++ b/tests/framework/utils/CFileHelperTest.php
@@ -6,7 +6,10 @@ class CFileHelperTest extends CTestCase
 	private $rootDir1="test1";
 	private $rootDir2="test2";
 	private $subDir='sub';
-	private $file='testfile';
+	private $file1='testfile';
+	private $file2='.htaccess';
+	private $file3='..svn';
+	private $file4='non-existent-file';
 
 	protected function setUp()
 	{
@@ -80,6 +83,42 @@ class CFileHelperTest extends CTestCase
 		$this->assertEquals($expectedMode,$subDir2Mode,"Subdir mode is not {$expectedMode}");
 	}
 
+	public function testRemoveDirectory()
+	{
+		$this->createTestStruct($this->testDir);
+
+		$ds=DIRECTORY_SEPARATOR;
+		$bd=$this->testDir.$ds;
+
+		$this->assertTrue(is_dir($bd.$this->rootDir1));
+		$this->assertTrue(is_dir($bd.$this->rootDir1.$ds.$this->subDir));
+		$this->assertFalse(is_dir($bd.$this->rootDir2));
+		$this->assertTrue(is_file($bd.$this->rootDir1.$ds.$this->subDir.$ds.$this->file1));
+		$this->assertTrue(is_file($bd.$this->rootDir1.$ds.$this->subDir.$ds.$this->file2));
+		$this->assertTrue(is_file($bd.$this->rootDir1.$ds.$this->subDir.$ds.$this->file3));
+		$this->assertFalse(is_file($bd.$this->rootDir1.$ds.$this->subDir.$ds.$this->file4));
+
+		CFileHelper::removeDirectory($bd.$this->rootDir2);
+
+		$this->assertTrue(is_dir($bd.$this->rootDir1));
+		$this->assertTrue(is_dir($bd.$this->rootDir1.$ds.$this->subDir));
+		$this->assertFalse(is_dir($bd.$this->rootDir2));
+		$this->assertTrue(is_file($bd.$this->rootDir1.$ds.$this->subDir.$ds.$this->file1));
+		$this->assertTrue(is_file($bd.$this->rootDir1.$ds.$this->subDir.$ds.$this->file2));
+		$this->assertTrue(is_file($bd.$this->rootDir1.$ds.$this->subDir.$ds.$this->file3));
+		$this->assertFalse(is_file($bd.$this->rootDir1.$ds.$this->subDir.$ds.$this->file4));
+
+		CFileHelper::removeDirectory($bd);
+
+		$this->assertFalse(is_dir($bd.$this->rootDir1));
+		$this->assertFalse(is_dir($bd.$this->rootDir1.$ds.$this->subDir));
+		$this->assertFalse(is_dir($bd.$this->rootDir2));
+		$this->assertFalse(is_file($bd.$this->rootDir1.$ds.$this->subDir.$ds.$this->file1));
+		$this->assertFalse(is_file($bd.$this->rootDir1.$ds.$this->subDir.$ds.$this->file2));
+		$this->assertFalse(is_file($bd.$this->rootDir1.$ds.$this->subDir.$ds.$this->file3));
+		$this->assertFalse(is_file($bd.$this->rootDir1.$ds.$this->subDir.$ds.$this->file4));
+	}
+
 	private function createTestStruct($testDir)
 	{
 		$rootDir=$testDir.DIRECTORY_SEPARATOR.$this->rootDir1;
@@ -88,8 +127,14 @@ class CFileHelperTest extends CTestCase
 		$subDir=$testDir.DIRECTORY_SEPARATOR.$this->rootDir1.DIRECTORY_SEPARATOR.$this->subDir;
 		mkdir($subDir);
 
-		$file=$testDir.DIRECTORY_SEPARATOR.$this->rootDir1.DIRECTORY_SEPARATOR.$this->subDir.DIRECTORY_SEPARATOR.$this->file;
-		file_put_contents($file,'12321312');
+		$file1=$testDir.DIRECTORY_SEPARATOR.$this->rootDir1.DIRECTORY_SEPARATOR.$this->subDir.DIRECTORY_SEPARATOR.$this->file1;
+		file_put_contents($file1,'12321312');
+
+		$file2=$testDir.DIRECTORY_SEPARATOR.$this->rootDir1.DIRECTORY_SEPARATOR.$this->subDir.DIRECTORY_SEPARATOR.$this->file2;
+		file_put_contents($file2,'.htaccess');
+
+		$file3=$testDir.DIRECTORY_SEPARATOR.$this->rootDir1.DIRECTORY_SEPARATOR.$this->subDir.DIRECTORY_SEPARATOR.$this->file3;
+		file_put_contents($file3,'..svn');
 	}
 
 	private function getMode($file)


### PR DESCRIPTION
Enh #1725: Added CFileHelper::removeDirectory() static method.

`opendir` way seems fastest possible: http://mattgeri.com/blog/2009/01/php-code-to-check-if-a-directory-is-empty/
