### PR TITLE
Issue 189 fix: CDateValidator and dates before year 1902 (32b)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 
 Version 1.1.13 work in progress
 -------------------------------
+- Bug #189: CDateValidator rejected valid dates older than 1902 if using a 32 bits PHP. (François Gannaz)
 - Bug #93: Criteria modification in CActiveRecord::beforeFind() did not apply when record was loaded in relational context. See UPGRADE instructions for details on behavior change. (cebe)
 - Bug #109: formatNumber() now uses number_format() instead of round(), because of round() error in IEEE754 accuracy limitations (SonkoDmitry)
 - Bug #110: MSSQL: fixed empty $primaryKey value after saving CActiveRecord model (resurtm)

--- a/framework/utils/CDateTimeParser.php
+++ b/framework/utils/CDateTimeParser.php
@@ -75,7 +75,7 @@ class CDateTimeParser
 	 * parameter is array('minute'=>0, 'second'=>0), then the actual minute and second
 	 * for the parsing result will take value 0, while the actual hour value will be
 	 * the current hour obtained by date('H'). This parameter has been available since version 1.1.5.
-	 * @return integer timestamp for the date string. False if parsing fails.
+	 * @return integer timestamp for the date string (may be null). False if parsing fails.
 	 */
 	public static function parse($value,$pattern='MM/dd/yyyy',$defaults=array())
 	{
@@ -255,7 +255,10 @@ class CDateTimeParser
 		}
 
 		if(CTimestamp::isValidDate($year,$month,$day) && CTimestamp::isValidTime($hour,$minute,$second))
-			return CTimestamp::getTimestamp($hour,$minute,$second,$month,$day,$year);
+		{
+			$ts=CTimestamp::getTimestamp($hour,$minute,$second,$month,$day,$year);
+			return $ts?$ts:null;
+		}
 		else
 			return false;
 	}

--- a/tests/framework/validators/CDateValidatorTest.php
+++ b/tests/framework/validators/CDateValidatorTest.php
@@ -61,6 +61,28 @@ class CDateValidatorTest extends CTestCase
     }
 
     /**
+     * Test with old dates
+     *
+     * @return null
+     */
+    public function testOldDates()
+    {
+        // negative timestamp
+        $model = $this->getModelMock();
+        $model->foo = '01/01/1910';
+        $this->assertTrue($model->validate());
+        $model->foo = '42/01/1910';
+        $this->assertFalse($model->validate());
+
+        // out of range of 32b timestamps
+        $model = $this->getModelMock(array('format' => 'dd-MM-yyyy'));
+        $model->foo = '01-01-1818';
+        $this->assertTrue($model->validate());
+        $model->foo = '01-24-1818';
+        $this->assertFalse($model->validate());
+    }
+
+    /**
      * Mocks up an object to test with
      *
      * @param array $operator optional parameters to configure rule


### PR DESCRIPTION
CDateTimeParser::parse() returns a timestamp when the datetime is valid.
When the date was out of timestamp range, the return value was false.
It is now NULL, therefore CDateValidator works without any change.

Tested both on 32b and 64b systems. Unit tests included (they fail on 32b PHP before this fix).
