### PR TITLE
Issue #1792: clear CWebUser access cache on logout

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,6 +54,7 @@ Version 1.1.13 work in progress
 - Bug #1676: Fixed listData() grouping when no group was specified (mdomba)
 - Bug #1716: Fixed CCodeModel::pluralize() and CConsoleCommand::pluralize() so it doesn't force lowercase the first letter in any words (nsanden)
 - Bug #1726: Fixed the error Undefined variable: json in CJSON.php when json_decode function did not exist (heyhoo)
+- Bug #1792: Fixed persistent access permissions when two identities were used in a single application run. (jhenriquemc, François Gannaz)
 - Bug: Table schema is refreshed on Gii model generation when schemaCachingDuration is used (SonkoDmitry)
 - Bug: CDbCommand::setFetchMode wasn't accepting additional arguments needed for PDO::FETCH_CLASS (samdark)
 - Bug: CCaptchaAction::validate check wasn't working properly in some cases (samdark, Qiang)

--- a/framework/web/auth/CWebUser.php
+++ b/framework/web/auth/CWebUser.php
@@ -266,6 +266,7 @@ class CWebUser extends CApplicationComponent implements IWebUser
 				Yii::app()->getSession()->destroy();
 			else
 				$this->clearStates();
+			$this->_access=array();
 			$this->afterLogout();
 		}
 	}


### PR DESCRIPTION
Closes issue #1792 "Control Access still persists after logout".

`CWebUser::checkAccess()` uses an internal cache that wasn't emptied on logout. This created wrong access permissions when 2 identities were used in a single application run.
