### PR TITLE
Issue #189: CDateValidator and 32b PHP

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ Version 1.1.13 work in progress
 - Bug #138: CMysqlSchema fixed to support MySQL ANSI mode (cebe)
 - Bug #140: Fixed validation CJuiButton with type buttonset (adminnu)
 - Bug #162: Eventhandler attached twice when behavior is set enabled after attaching it (cebe)
+- Bug #189: CDateValidator rejected valid dates older than 1902 if using a 32 bits PHP. (François Gannaz)
 - Bug #218: Fixed problem when using 'union' and 'order/limit/offset' in CDbCommand::buildQuery (nsanden)
 - Bug #276: Tweaked CGridView stylesheet to include a hover style for the selected row (acorncom)
 - Bug #810: Gii now adds a number to the end of relation name if same named relation already exists instead of not generating relation (n30kill, samdark)

--- a/framework/utils/CDateTimeParser.php
+++ b/framework/utils/CDateTimeParser.php
@@ -79,6 +79,27 @@ class CDateTimeParser
 	 */
 	public static function parse($value,$pattern='MM/dd/yyyy',$defaults=array())
 	{
+		$p=self::parseIntoArray($value, $pattern, $defaults);
+		if(CTimestamp::isValidDate($p[0],$p[1],$p[2]) && CTimestamp::isValidTime($p[3],$p[4],$p[5]))
+			return CTimestamp::getTimestamp($p[3],$p[4],$p[5],$p[1],$p[2],$p[0]);
+		else
+			return false;
+	}
+
+	/**
+	 * Converts a date string into an array (year, month, day, hour, minute, second).
+	 * @param string $value the date string to be parsed
+	 * @param string $pattern the pattern that the date string is following
+	 * @param array $defaults the default values for year, month, day, hour, minute and second.
+	 * The default values will be used in case when the pattern doesn't specify the
+	 * corresponding fields. For example, if the pattern is 'MM/dd/yyyy' and this
+	 * parameter is array('minute'=>0, 'second'=>0), then the actual minute and second
+	 * for the parsing result will take value 0, while the actual hour value will be
+	 * the current hour obtained by date('H'). This parameter has been available since version 1.1.5.
+	 * @return array (year, month, day, hour, minute, second) for the date string. False if parsing fails.
+	 */
+	public static function parseIntoArray($value,$pattern='MM/dd/yyyy',$defaults=array())
+	{
 		if(self::$_mbstringAvailable===null)
 			self::$_mbstringAvailable=extension_loaded('mbstring');
 
@@ -254,10 +275,7 @@ class CDateTimeParser
 			$second=(int)$second;
 		}
 
-		if(CTimestamp::isValidDate($year,$month,$day) && CTimestamp::isValidTime($hour,$minute,$second))
-			return CTimestamp::getTimestamp($hour,$minute,$second,$month,$day,$year);
-		else
-			return false;
+		return array($year,$month,$day,$hour,$minute,$second);
 	}
 
 	/*

--- a/framework/validators/CDateValidator.php
+++ b/framework/validators/CDateValidator.php
@@ -56,12 +56,19 @@ class CDateValidator extends CValidator
 		$valid=false;
 		foreach($formats as $format)
 		{
-			$timestamp=CDateTimeParser::parse($value,$format,array('month'=>1,'day'=>1,'hour'=>0,'minute'=>0,'second'=>0));
-			if($timestamp!==false)
+			$p=CDateTimeParser::parseIntoArray($value, $format, array('month'=>1,'day'=>1,'hour'=>0,'minute'=>0,'second'=>0));
+			if(CTimestamp::isValidDate($p[0],$p[1],$p[2]) && CTimestamp::isValidTime($p[3],$p[4],$p[5]))
 			{
 				$valid=true;
 				if($this->timestampAttribute!==null)
-					$object->{$this->timestampAttribute}=$timestamp;
+				{
+					$ts=CTimestamp::getTimestamp($p[3],$p[4],$p[5],$p[1],$p[2],$p[0]);
+					if ($ts)
+						$object->{$this->timestampAttribute}=$ts;
+					else
+						$valid=false;
+				}
+
 				break;
 			}
 		}

--- a/tests/framework/validators/CDateValidatorTest.php
+++ b/tests/framework/validators/CDateValidatorTest.php
@@ -61,6 +61,28 @@ class CDateValidatorTest extends CTestCase
     }
 
     /**
+     * Test with old dates
+     *
+     * @return null
+     */
+    public function testOldDates()
+    {
+        // negative timestamp
+        $model = $this->getModelMock();
+        $model->foo = '01/01/1910';
+        $this->assertTrue($model->validate());
+        $model->foo = '42/01/1910';
+        $this->assertFalse($model->validate());
+
+        // out of range of 32b timestamps
+        $model = $this->getModelMock(array('format' => 'dd-MM-yyyy'));
+        $model->foo = '01-01-1818';
+        $this->assertTrue($model->validate());
+        $model->foo = '01-24-1818';
+        $this->assertFalse($model->validate());
+    }
+
+    /**
      * Mocks up an object to test with
      *
      * @param array $operator optional parameters to configure rule


### PR DESCRIPTION
Fixes the issue #189. Unit tests included.

A simpler patch was proposed a few days ago, but it broke backward compatibility on a corner case (i.e. strict comparison of the output of CDateTimeParser on a 32b PHP for a date older than 1902). This patch does not break BC. It adds a new method to CDateTimeParser, `parseIntoArray()`, so that the validator can distinguish between a invalid date and a valid date with no timestamp. See the commits messages for more details.