### PR TITLE
Support for MySQL BIT(M) data type proper default values

### DIFF
--- a/framework/db/schema/mysql/CMysqlColumnSchema.php
+++ b/framework/db/schema/mysql/CMysqlColumnSchema.php
@@ -42,7 +42,9 @@ class CMysqlColumnSchema extends CDbColumnSchema
 	 */
 	protected function extractDefault($defaultValue)
 	{
-		if($this->dbType==='timestamp' && $defaultValue==='CURRENT_TIMESTAMP')
+		if(strncmp($this->dbType,'bit',3)===0 && strpos($defaultValue, 'b')===0)
+			parent::extractDefault(trim($defaultValue, 'b\''));
+		else if($this->dbType==='timestamp' && $defaultValue==='CURRENT_TIMESTAMP')
 			$this->defaultValue=null;
 		else
 			parent::extractDefault($defaultValue);


### PR DESCRIPTION
CMysqlColumnSchema: support for MySQL BIT(M) data type proper default values.
For example, MySQL (MariaDB) return default value as "b'1'" string, not as "1", so, this case should be considered especially. See also http://dev.mysql.com/doc/refman/5.0/en/bit-type.html
This patch supports only BIT(M), where M = [1..32], but on MySQL M = [1..64]
