### PR TITLE
Fix #1839: Add more whitespace to phpdoc for CAccessControlFilter.

### DIFF
--- a/framework/web/auth/CAccessControlFilter.php
+++ b/framework/web/auth/CAccessControlFilter.php
@@ -57,11 +57,11 @@
  *   'message'=>'Access Denied.',
  * 
  *   // optional, the denied method callback name, that will be called once the
- *	 // access is denied, instead of showing the customized error message. It can also be
+ *   // access is denied, instead of showing the customized error message. It can also be
  *   // a valid PHP callback, including class method name (array(ClassName/Object, MethodName)),
- *	 // or anonymous function (PHP 5.3.0+). The function/method signature should be as follows:
- *	 // function foo($user, $rule) { ... }
- *	 // where $user is the current application user object and $rule is this access rule.
+ *   // or anonymous function (PHP 5.3.0+). The function/method signature should be as follows:
+ *   // function foo($user, $rule) { ... }
+ *   // where $user is the current application user object and $rule is this access rule.
  *   // This option is available since version 1.1.11.
  *   'deniedCallback'=>'redirectToDeniedMethod',
   * )


### PR DESCRIPTION
I agree with @gusdecool in #1839 that there's so much text in this array doc that it would be more readable with some extra whitespace.
