### PR TITLE
Enhancing extensibility of CActive* class hierarchy

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -103,6 +103,7 @@ Version 1.1.13 work in progress
 - Enh #1596: Added CGridView::rowHtmlOptionsExpression to allow set HTML attributes for the row (Ryadnov)
 - Enh #1657: CDbCommandBuilder::createUpdateCounterCommand now can be used with float values (samdark, hyzhakus)
 - Enh #1658: CFormatter::formatHtml() is now more flexible and customizable through new CFormatter::$htmlPurifierOptions property (resurtm)
+- Enh #1863: Enhancing extensibility of CActive* class hierarchy
 - Enh: Fixed the check for ajaxUpdate false value in jquery.yiilistview.js as that never happens (mdomba)
 - Enh: Requirements checker: added check for Oracle database (pdo_oci extension) and MSSQL (pdo_dblib, pdo_sqlsrv and pdo_mssql extensions) (resurtm)
 - Enh: Added CChainedLogFilter class to allow adding multiple filters to a logroute (cebe)

--- a/framework/db/ar/CActiveFinder.php
+++ b/framework/db/ar/CActiveFinder.php
@@ -169,6 +169,15 @@ class CActiveFinder extends CComponent
 		$this->destroyJoinTree();
 	}
 
+	/** CActiveRecord::model factory method. You may override this method to use your CActive* parallel class hierarchy
+	 * @param string active record class name.
+	 * @return CActiveRecord active record model instance.
+	 */
+	public function getModel($className)
+	{
+		return CActiveRecord::model($className);
+	}
+
 	private function destroyJoinTree()
 	{
 		if($this->_joinTree!==null)
@@ -212,7 +221,7 @@ class CActiveFinder extends CComponent
 					array('{class}'=>get_class($parent->model), '{name}'=>$with)));
 
 			$relation=clone $relation;
-			$model=CActiveRecord::model($relation->className);
+			$model=$this->getModel($relation->className);
 
 			if($relation instanceof CActiveRelation)
 			{
@@ -361,7 +370,7 @@ class CJoinElement
 		{
 			$this->relation=$relation;
 			$this->_parent=$parent;
-			$this->model=CActiveRecord::model($relation->className);
+			$this->model=$this->_finder->getModel($relation->className);
 			$this->_builder=$this->model->getCommandBuilder();
 			$this->tableAlias=$relation->alias===null?$relation->name:$relation->alias;
 			$this->rawTableAlias=$this->_builder->getSchema()->quoteTableName($this->tableAlias);
@@ -1344,7 +1353,7 @@ class CStatElement
 	private function queryOneMany()
 	{
 		$relation=$this->relation;
-		$model=CActiveRecord::model($relation->className);
+		$model=$this->_finder->getModel($relation->className);
 		$builder=$model->getCommandBuilder();
 		$schema=$builder->getSchema();
 		$table=$model->getTableSchema();
@@ -1455,7 +1464,7 @@ class CStatElement
 	private function queryManyMany($joinTableName,$keys)
 	{
 		$relation=$this->relation;
-		$model=CActiveRecord::model($relation->className);
+		$model=$this->_finder->getModel($relation->className);
 		$table=$model->getTableSchema();
 		$builder=$model->getCommandBuilder();
 		$schema=$builder->getSchema();

--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -268,7 +268,7 @@ abstract class CActiveRecord extends CModel
 			$r=$name;
 		unset($this->_related[$name]);
 
-		$finder=new CActiveFinder($this,$r);
+		$finder=$this->getActiveFinder($r);
 		$finder->lazyFind($this);
 
 		if(!isset($this->_related[$name]))
@@ -885,6 +885,15 @@ abstract class CActiveRecord extends CModel
 		$this->raiseEvent('onAfterFind',$event);
 	}
 
+	/** Factory method to get instance of CActiveFinder. You may override this method to use your CActive* parallel class hierarchy
+	 * @param mixed $with the relation names to be actively looked for
+	 * @return CActiveFinder active finder for the operation
+	 */
+	public function getActiveFinder($with)
+	{
+		return new CActiveFinder($this, $with);
+	}
+
 	/**
 	 * This method is invoked before saving a record (after validation, if any).
 	 * The default implementation raises the {@link onBeforeSave} event.
@@ -1298,7 +1307,7 @@ abstract class CActiveRecord extends CModel
 		}
 		else
 		{
-			$finder=new CActiveFinder($this,$criteria->with);
+			$finder=$this->getActiveFinder($criteria->with);
 			return $finder->query($criteria,$all);
 		}
 	}
@@ -1495,7 +1504,7 @@ abstract class CActiveRecord extends CModel
 		if(($criteria=$this->getDbCriteria(false))!==null && !empty($criteria->with))
 		{
 			$this->resetScope(false);
-			$finder=new CActiveFinder($this,$criteria->with);
+			$finder=$this->getActiveFinder($criteria->with);
 			return $finder->findBySql($sql,$params);
 		}
 		else
@@ -1518,7 +1527,7 @@ abstract class CActiveRecord extends CModel
 		if(($criteria=$this->getDbCriteria(false))!==null && !empty($criteria->with))
 		{
 			$this->resetScope(false);
-			$finder=new CActiveFinder($this,$criteria->with);
+			$finder=$this->getActiveFinder($criteria->with);
 			return $finder->findAllBySql($sql,$params);
 		}
 		else
@@ -1546,7 +1555,7 @@ abstract class CActiveRecord extends CModel
 			return $builder->createCountCommand($this->getTableSchema(),$criteria)->queryScalar();
 		else
 		{
-			$finder=new CActiveFinder($this,$criteria->with);
+			$finder=$this->getActiveFinder($criteria->with);
 			return $finder->count($criteria);
 		}
 	}
@@ -1573,7 +1582,7 @@ abstract class CActiveRecord extends CModel
 			return $builder->createCountCommand($this->getTableSchema(),$criteria)->queryScalar();
 		else
 		{
-			$finder=new CActiveFinder($this,$criteria->with);
+			$finder=$this->getActiveFinder($criteria->with);
 			return $finder->count($criteria);
 		}
 	}
@@ -1614,7 +1623,7 @@ abstract class CActiveRecord extends CModel
 		else
 		{
 			$criteria->select='*';
-			$finder=new CActiveFinder($this,$criteria->with);
+			$finder=$this->getActiveFinder($criteria->with);
 			return $finder->count($criteria)>0;
 		}
 	}

--- a/framework/validators/CExistValidator.php
+++ b/framework/validators/CExistValidator.php
@@ -74,7 +74,7 @@ class CExistValidator extends CValidator
 
 		$className=$this->className===null?get_class($object):Yii::import($this->className);
 		$attributeName=$this->attributeName===null?$attribute:$this->attributeName;
-		$finder=CActiveRecord::model($className);
+		$finder=$this->getModel($className);
 		$table=$finder->getTableSchema();
 		if(($column=$table->getColumn($attributeName))===null)
 			throw new CException(Yii::t('yii','Table "{table}" does not have a column named "{column}".',
@@ -95,5 +95,15 @@ class CExistValidator extends CValidator
 			$this->addError($object,$attribute,$message,array('{value}'=>CHtml::encode($value)));
 		}
 	}
+
+	/** CActiveRecord::model factory method. You may override this method to use your CActive* parallel class hierarchy
+	 * @param string active record class name.
+	 * @return CActiveRecord active record model instance.
+	 */
+	protected function getModel($className)
+	{
+		return CActiveRecord::model($className);
+	}
+	
 }
 

--- a/framework/validators/CUniqueValidator.php
+++ b/framework/validators/CUniqueValidator.php
@@ -84,7 +84,7 @@ class CUniqueValidator extends CValidator
 
 		$className=$this->className===null?get_class($object):Yii::import($this->className);
 		$attributeName=$this->attributeName===null?$attribute:$this->attributeName;
-		$finder=CActiveRecord::model($className);
+		$finder=$this->getModel($className);
 		$table=$finder->getTableSchema();
 		if(($column=$table->getColumn($attributeName))===null)
 			throw new CException(Yii::t('yii','Table "{table}" does not have a column named "{column}".',
@@ -125,6 +125,15 @@ class CUniqueValidator extends CValidator
 			$message=$this->message!==null?$this->message:Yii::t('yii','{attribute} "{value}" has already been taken.');
 			$this->addError($object,$attribute,$message,array('{value}'=>CHtml::encode($value)));
 		}
+	}
+	
+	/** CActiveRecord::model factory method. You may override this method to use your CActive* parallel class hierarchy
+	 * @param string active record class name.
+	 * @return CActiveRecord active record model instance.
+	 */
+	protected function getModel($className)
+	{
+		return CActiveRecord::model($className);
 	}
 }
 

--- a/framework/web/CActiveDataProvider.php
+++ b/framework/web/CActiveDataProvider.php
@@ -71,7 +71,7 @@ class CActiveDataProvider extends CDataProvider
 		if(is_string($modelClass))
 		{
 			$this->modelClass=$modelClass;
-			$this->model=CActiveRecord::model($this->modelClass);
+			$this->model=$this->getModel($this->modelClass);
 		}
 		elseif($modelClass instanceof CActiveRecord)
 		{
@@ -114,6 +114,15 @@ class CActiveDataProvider extends CDataProvider
 		if(($sort=parent::getSort($className))!==false)
 			$sort->modelClass=$this->modelClass;
 		return $sort;
+	}
+
+	/** CActiveRecord::model factory method. You may override this method to use your CActive* parallel class hierarchy
+	 * @param string active record class name.
+	 * @return CActiveRecord active record model instance.
+	 */
+	protected function getModel($className)
+	{
+		return CActiveRecord::model($className);
 	}
 
 	/**

--- a/framework/web/CSort.php
+++ b/framework/web/CSort.php
@@ -237,7 +237,7 @@ class CSort extends CComponent
 		else
 		{
 			if($this->modelClass!==null)
-				$schema=CActiveRecord::model($this->modelClass)->getDbConnection()->getSchema();
+				$schema=$this->getModel($this->modelClass)->getDbConnection()->getSchema();
 			$orders=array();
 			foreach($directions as $attribute=>$descending)
 			{
@@ -257,7 +257,7 @@ class CSort extends CComponent
 						if(($pos=strpos($attribute,'.'))!==false)
 							$attribute=$schema->quoteTableName(substr($attribute,0,$pos)).'.'.$schema->quoteColumnName(substr($attribute,$pos+1));
 						else
-							$attribute=($criteria===null || $criteria->alias===null ? CActiveRecord::model($this->modelClass)->getTableAlias(true) : $schema->quoteTableName($criteria->alias)).'.'.$schema->quoteColumnName($attribute);
+							$attribute=($criteria===null || $criteria->alias===null ? $this->getModel($this->modelClass)->getTableAlias(true) : $schema->quoteTableName($criteria->alias)).'.'.$schema->quoteColumnName($attribute);
 					}
 					$orders[]=$descending?$attribute.' DESC':$attribute;
 				}
@@ -327,7 +327,7 @@ class CSort extends CComponent
 		elseif(is_string($definition))
 			$attribute=$definition;
 		if($this->modelClass!==null)
-			return CActiveRecord::model($this->modelClass)->getAttributeLabel($attribute);
+			return $this->getModel($this->modelClass)->getAttributeLabel($attribute);
 		else
 			return $attribute;
 	}
@@ -422,7 +422,7 @@ class CSort extends CComponent
 		if($this->attributes!==array())
 			$attributes=$this->attributes;
 		elseif($this->modelClass!==null)
-			$attributes=CActiveRecord::model($this->modelClass)->attributeNames();
+			$attributes=$this->getModel($this->modelClass)->attributeNames();
 		else
 			return false;
 		foreach($attributes as $name=>$definition)
@@ -434,13 +434,22 @@ class CSort extends CComponent
 			}
 			elseif($definition==='*')
 			{
-				if($this->modelClass!==null && CActiveRecord::model($this->modelClass)->hasAttribute($attribute))
+				if($this->modelClass!==null && $this->getModel($this->modelClass)->hasAttribute($attribute))
 					return $attribute;
 			}
 			elseif($definition===$attribute)
 				return $attribute;
 		}
 		return false;
+	}
+
+	/** CActiveRecord::model factory method. You may override this method to use your CActive* parallel class hierarchy
+	 * @param string active record class name.
+	 * @return CActiveRecord active record model instance.
+	 */
+	protected function getModel($className)
+	{
+		return CActiveRecord::model($className);
 	}
 
 	/**


### PR DESCRIPTION
#1863 Introduced CActiveFinder and CActiveRecord::model() factory methods instead of `CActiveRecord::model()` and `new CActiveFinder()` direct invocations

Author:    denisarius denisarius@gmail.com
