### PR TITLE
Render client scripts after all meta tags

### DIFF
--- a/framework/web/CClientScript.php
+++ b/framework/web/CClientScript.php
@@ -372,9 +372,9 @@ class CClientScript extends CApplicationComponent
 		if($html!=='')
 		{
 			$count=0;
-			$output=preg_replace('/<\\/head\s*>/is','<###head###>$1',$output,1,$count);
+			$output=preg_replace('/(<\\/head\s*>)/is','<###head###>$1',$output,1,$count);
 			if(!$count)
-				$output=preg_replace('/<\\/title\s*>/is','$1<###head###>',$output,1,$count);
+				$output=preg_replace('/(<\\/title\s*>)/is','$1<###head###>',$output,1,$count);
 				
 			if($count)
 				$output=str_replace('<###head###>',$html,$output);


### PR DESCRIPTION
Now scripts are rendered before  "<title>"(if POS_HEAD). It's not good for SEO. It would be better to render them before "</head>"
