### PR TITLE
[travis ci] Enable memcache for PHP v5.5 builds

### DIFF
--- a/tests/travis/memcache-setup.sh
+++ b/tests/travis/memcache-setup.sh
@@ -5,6 +5,6 @@ if [[ $TRAVIS_PHP_VERSION < 5.5 ]]; then
 else
   wget http://pecl.php.net/get/memcache-2.2.7.tgz
   tar -zxf memcache-2.2.7.tgz
-  sh -c "cd memcache-2.2.7 && phpize && ./configue --enable-memcache && make && sudo make install"
+  sh -c "cd memcache-2.2.7 && phpize && ./configure --enable-memcache && make && sudo make install"
   echo "memcache.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s/.*:\s*//"`
 fi


### PR DESCRIPTION
Related to #1873, this PR builds and enables the pecl memcache extension for PHP 5.5-alpha.
