### PR TITLE
Improved understandability of the model template

### DIFF
--- a/framework/gii/generators/model/templates/default/model.php
+++ b/framework/gii/generators/model/templates/default/model.php
@@ -53,26 +53,6 @@
 class <?php echo $modelClass; ?> extends <?php echo $this->baseClass."\n"; ?>
 {
 	/**
-	 * Returns the static model of the specified AR class.
-	 * @param string $className active record class name.
-	 * @return <?php echo $modelClass; ?> the static model class
-	 */
-	public static function model($className=__CLASS__)
-	{
-		return parent::model($className);
-	}
-<?php if($connectionId!='db'):?>
-
-	/**
-	 * @return CDbConnection database connection
-	 */
-	public function getDbConnection()
-	{
-		return Yii::app()-><?php echo $connectionId ?>;
-	}
-<?php endif?>
-
-	/**
 	 * @return string the associated database table name
 	 */
 	public function tableName()
@@ -125,6 +105,9 @@ class <?php echo $modelClass; ?> extends <?php echo $this->baseClass."\n"; ?>
 
 	/**
 	 * Retrieves a list of models based on the current search/filter conditions.
+	 * Purpose of this method is that you can initialize the model with some values
+	 *  and then run this `search` on it, getting the CActiveDataProvider instance loaded
+	 *  with records found. This way model becomes the filter which can be used in grid views or somewhere else.
 	 * @return CActiveDataProvider the data provider that can return the models based on the search/filter conditions.
 	 */
 	public function search()
@@ -151,5 +134,26 @@ foreach($columns as $name=>$column)
 		return new CActiveDataProvider($this, array(
 			'criteria'=>$criteria,
 		));
+	}
+
+<?php if($connectionId!='db'):?>
+	/**
+	 * @return CDbConnection database connection
+	 */
+	public function getDbConnection()
+	{
+		return Yii::app()-><?php echo $connectionId ?>;
+	}
+<?php endif?>
+
+	/**
+	 * Returns the static model of the specified AR class.
+	 * Please note that you should have this exact method in all your CActiveRecord descendants!
+	 * @param string $className active record class name.
+	 * @return <?php echo $modelClass; ?> the static model class
+	 */
+	public static function model($className=__CLASS__)
+	{
+		return parent::model($className);
 	}
 }


### PR DESCRIPTION
I propose the following improvements in the default Gii template for model:
1. Auxiliary appendixes which are `model` and `getDbConnection` should be in very bottom of the model class and not in the very top, because on top of class definition should reside the most important features, which here undoubtedly are `tableName`, `rules` and `relations`.
2. Docblock for `search` method includes the explanations about it, because it's not immediately clear for a newcomer why this method exists and how it should be used.

By the way, this `search` method is a clear violation of single responsibility principle anyway, because it forces a model to search for set of other models of the same class, and ActiveRecord is not about it.
