### PR TITLE
doc/guide/ja fixed a missing code block mark

### DIFF
--- a/docs/guide/ja/topics.theming.txt
+++ b/docs/guide/ja/topics.theming.txt
@@ -247,7 +247,7 @@ return array(
 <?php $this->widget('CLinkPager'); ?>
 
 <?php $this->widget('CLinkPager', array('skin'=>'classic')); ?>
-
+~~~
 
 ウィジェットを生成する際に初期プロパティ値を指定した場合は、そのプロパティ値が優先され、アプリケーションのスキンと結合されます。
 例えば、下記のビューのコードが生成するページャの初期値は、`array('header'=>'', 'maxButtonCount'=>6, 'cssFile'=>false)` となりますが、それはビューで指定された初期プロパティ値と `classic` スキンを結合した結果です。


### PR DESCRIPTION
OMG, I've noticed the flaw just after the 1.1.13 release.
