### PR TITLE
Issue #1896: English text in 404 error

### DIFF
--- a/framework/views/es/error500.php
+++ b/framework/views/es/error500.php
@@ -22,11 +22,13 @@ p {font-family:"Verdana";font-weight:normal;color:black;font-size:9pt;margin-top
 <h1>Internal Server Error</h1>
 <h2><?php echo nl2br(CHtml::encode($data['message'])); ?></h2>
 <p>
-An internal error occurred while the Web server was processing your request.
-Please contact <?php echo $data['admin']; ?> to report this problem.
+Un error interno ocurrió cuando el servidor estaba procesando su solicitud.
 </p>
 <p>
-Thank you.
+Si piensa que este es un error del servidor, por favor contacte a <?php echo $data['admin']; ?>.
+</p>
+<p>
+Gracias.
 </p>
 <div class="version">
 <?php echo date('Y-m-d H:i:s',$data['time']) .' '. $data['version']; ?>

--- a/framework/views/fr/error404.php
+++ b/framework/views/fr/error404.php
@@ -21,7 +21,6 @@ p {font-family:"Verdana";font-weight:normal;color:black;font-size:9pt;margin-top
 <h2><?php echo nl2br(CHtml::encode($data['message'])); ?></h2>
 <p>
 L'URL demandée n'existe pas sur ce serveur.
-If you entered the URL manually please check your spelling and try again.
 Si vous avez saisi l'URL manuellement, vérifiez la, et réessayez.
 </p>
 <p>


### PR DESCRIPTION
Fixes the issue #1896.

Removes  orphan English text on: 

https://github.com/yiisoft/yii/blob/master/framework/views/fr/error404.php

and provides spanish translation for

https://github.com/yiisoft/yii/blob/master/framework/views/es/error500.php
