### PR TITLE
Fix the way URL parameters are encoded

### DIFF
--- a/framework/web/CUrlManager.php
+++ b/framework/web/CUrlManager.php
@@ -429,12 +429,14 @@ class CUrlManager extends CApplicationComponent
 		foreach($params as $k => $v)
 		{
 			if ($key!==null)
-				$k = $key.'['.$k.']';
-
+				$k = $key.'['.urlencode($k).']';
+			else
+				$k = urlencode($k);
+			
 			if (is_array($v))
 				$pairs[]=$this->createPathInfo($v,$equal,$ampersand, $k);
 			else
-				$pairs[]=urlencode($k).$equal.urlencode($v);
+				$pairs[]=$k.$equal.urlencode($v);
 		}
 		return implode($ampersand,$pairs);
 	}


### PR DESCRIPTION
I'm not sure on the intended functionality here but it seems to be broken to me.

running:

`$this->createUrl('checkout/confirmation', array('order'=> array('666', '999')));`

Gives me

`/checkout/confirmation/order%5B0%5D/666/order%5B1%5D/999`
But it should give:
`/checkout/confirmation/order[0]/666/order[1]/999`

Again, I'm not sure if this was intended, although I can't see why it would be, but I can't seem to find any bug reports or other people having issues with it.

**Edit**
To be clear:
I'm only disabling encoding of square braces used to denote array parameters, the parameter key string will still be encoded.
