### PR TITLE
zii: jQuery UI documentation links updated

### DIFF
--- a/framework/zii/widgets/jui/CJuiAccordion.php
+++ b/framework/zii/widgets/jui/CJuiAccordion.php
@@ -35,8 +35,10 @@ Yii::import('zii.widgets.jui.CJuiWidget');
  *
  * By configuring the {@link options} property, you may specify the options
  * that need to be passed to the JUI accordion plugin. Please refer to
- * the {@link http://api.jqueryui.com/accordion/ JUI Accordion} documentation
- * for possible options (name-value pairs).
+ * the {@link http://api.jqueryui.com/accordion/ JUI Accordion API}
+ * documentation for possible options (name-value pairs) and
+ * {@link http://jqueryui.com/accordion/ JUI Accordion page} for general
+ * description and demo.
  *
  * @author Sebastian Thierer <sebathi@gmail.com>
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/framework/zii/widgets/jui/CJuiAutoComplete.php
+++ b/framework/zii/widgets/jui/CJuiAutoComplete.php
@@ -33,8 +33,10 @@ Yii::import('zii.widgets.jui.CJuiInputWidget');
  *
  * By configuring the {@link options} property, you may specify the options
  * that need to be passed to the JUI autocomplete plugin. Please refer to
- * the {@link http://api.jqueryui.com/autocomplete/ JUI
- * autocomplete} documentation for possible options (name-value pairs).
+ * the {@link http://api.jqueryui.com/autocomplete/ JUI AutoComplete API}
+ * documentation for possible options (name-value pairs) and
+ * {@link http://jqueryui.com/autocomplete/ JUI AutoComplete page} for
+ * general description and demo.
  *
  * By configuring the {@link source} property, you may specify where to search
  * the autocomplete options for each item. If source is an array, the list is

--- a/framework/zii/widgets/jui/CJuiButton.php
+++ b/framework/zii/widgets/jui/CJuiButton.php
@@ -38,8 +38,10 @@ Yii::import('zii.widgets.jui.CJuiInputWidget');
  *
  * By configuring the {@link options} property, you may specify the options
  * that need to be passed to the JUI button plugin. Please refer to
- * the {@link http://api.jqueryui.com/button/ JUI Button} documentation
- * for possible options (name-value pairs).
+ * the {@link http://api.jqueryui.com/button/ JUI Button API} documentation
+ * for possible options (name-value pairs) and
+ * {@link http://jqueryui.com/button/ JUI Button page} for general description
+ * and demo.
  *
  * @author Sebastian Thierer <sebathi@gmail.com>
  * @package zii.widgets.jui

--- a/framework/zii/widgets/jui/CJuiDatePicker.php
+++ b/framework/zii/widgets/jui/CJuiDatePicker.php
@@ -32,8 +32,10 @@ Yii::import('zii.widgets.jui.CJuiInputWidget');
  *
  * By configuring the {@link options} property, you may specify the options
  * that need to be passed to the JUI datepicker plugin. Please refer to
- * the {@link http://api.jqueryui.com/datepicker/ JUI datepicker} documentation
- * for possible options (name-value pairs).
+ * the {@link http://api.jqueryui.com/datepicker/ JUI DatePicker API}
+ * documentation for possible options (name-value pairs) and
+ * {@link http://jqueryui.com/datepicker/ JUI DatePicker page} for general
+ * description and demo.
  *
  * @author Sebastian Thierer <sebathi@gmail.com>
  * @package zii.widgets.jui

--- a/framework/zii/widgets/jui/CJuiDialog.php
+++ b/framework/zii/widgets/jui/CJuiDialog.php
@@ -39,8 +39,10 @@ Yii::import('zii.widgets.jui.CJuiWidget');
  *
  * By configuring the {@link options} property, you may specify the options
  * that need to be passed to the JUI dialog plugin. Please refer to
- * the {@link http://api.jqueryui.com/dialog/ JUI Dialog} documentation
- * for possible options (name-value pairs).
+ * the {@link http://api.jqueryui.com/dialog/ JUI Dialog API} documentation
+ * for possible options (name-value pairs) and
+ * {@link http://jqueryui.com/dialog/ JUI Dialog page} for general description
+ * and demo.
  *
  * @author Sebastian Thierer <sebathi@gmail.com>
  * @package zii.widgets.jui

--- a/framework/zii/widgets/jui/CJuiDraggable.php
+++ b/framework/zii/widgets/jui/CJuiDraggable.php
@@ -32,8 +32,10 @@ Yii::import('zii.widgets.jui.CJuiWidget');
  *
  * By configuring the {@link options} property, you may specify the options
  * that need to be passed to the JUI Draggable plugin. Please refer to
- * the {@link http://api.jqueryui.com/draggable/ JUI Draggable} documentation
- * for possible options (name-value pairs).
+ * the {@link http://api.jqueryui.com/draggable/ JUI Draggable API} documentation
+ * for possible options (name-value pairs) and
+ * {@link http://jqueryui.com/draggable/ JUI Draggable page} for general
+ * description and demo.
  *
  * @author Sebastian Thierer <sebathi@gmail.com>
  * @package zii.widgets.jui

--- a/framework/zii/widgets/jui/CJuiDroppable.php
+++ b/framework/zii/widgets/jui/CJuiDroppable.php
@@ -32,8 +32,10 @@ Yii::import('zii.widgets.jui.CJuiWidget');
  *
  * By configuring the {@link options} property, you may specify the options
  * that need to be passed to the JUI Droppable plugin. Please refer to
- * the {@link http://api.jqueryui.com/droppable/ JUI Droppable} documentation
- * for possible options (name-value pairs).
+ * the {@link http://api.jqueryui.com/droppable/ JUI Droppable API} documentation
+ * for possible options (name-value pairs) and
+ * {@link http://jqueryui.com/droppable/ JUI Droppable page} for general
+ * description and demo.
  *
  * @author Sebastian Thierer <sebathi@gmail.com>
  * @package zii.widgets.jui

--- a/framework/zii/widgets/jui/CJuiProgressBar.php
+++ b/framework/zii/widgets/jui/CJuiProgressBar.php
@@ -32,8 +32,10 @@ Yii::import('zii.widgets.jui.CJuiWidget');
  *
  * By configuring the {@link options} property, you may specify the options
  * that need to be passed to the JUI progressbar plugin. Please refer to
- * the {@link http://api.jqueryui.com/progressbar/ JUI Progressbar} documentation
- * for possible options (name-value pairs).
+ * the {@link http://api.jqueryui.com/progressbar/ JUI ProgressBar} documentation
+ * for possible options (name-value pairs) and
+ * {@link http://jqueryui.com/progressbar/ JUI ProgressBar page} for general
+ * description and demo.
  *
  * @author Sebastian Thierer <sebathi@gmail.com>
  * @package zii.widgets.jui

--- a/framework/zii/widgets/jui/CJuiResizable.php
+++ b/framework/zii/widgets/jui/CJuiResizable.php
@@ -32,8 +32,10 @@ Yii::import('zii.widgets.jui.CJuiWidget');
  *
  * By configuring the {@link options} property, you may specify the options
  * that need to be passed to the JUI Resizable plugin. Please refer to
- * the {@link http://api.jqueryui.com/resizable/ JUI Resizable} documentation
- * for possible options (name-value pairs).
+ * the {@link http://api.jqueryui.com/resizable/ JUI Resizable API} documentation
+ * for possible options (name-value pairs) and
+ * {@link http://jqueryui.com/resizable/ JUI Resizable page} for general
+ * description and demo.
  *
  * @author Sebastian Thierer <sebathi@gmail.com>
  * @package zii.widgets.jui

--- a/framework/zii/widgets/jui/CJuiSelectable.php
+++ b/framework/zii/widgets/jui/CJuiSelectable.php
@@ -33,8 +33,10 @@ Yii::import('zii.widgets.jui.CJuiWidget');
  *
  * By configuring the {@link options} property, you may specify the options
  * that need to be passed to the JUI Selectable plugin. Please refer to
- * the {@link http://api.jqueryui.com/selectable/ JUI Selectable} documentation
- * for possible options (name-value pairs).
+ * the {@link http://api.jqueryui.com/selectable/ JUI Selectable API}
+ * documentation for possible options (name-value pairs) and
+ * {@link http://jqueryui.com/selectable/ JUI Selectable page} for general
+ * description and demo.
  *
  * @author Sebastian Thierer <sebathi@gmail.com>
  * @package zii.widgets.jui

--- a/framework/zii/widgets/jui/CJuiSlider.php
+++ b/framework/zii/widgets/jui/CJuiSlider.php
@@ -33,8 +33,10 @@ Yii::import('zii.widgets.jui.CJuiWidget');
  *
  * By configuring the {@link options} property, you may specify the options
  * that need to be passed to the JUI slider plugin. Please refer to
- * the {@link http://api.jqueryui.com/slider/ JUI slider} documentation
- * for possible options (name-value pairs).
+ * the {@link http://api.jqueryui.com/slider/ JUI Slider API} documentation
+ * for possible options (name-value pairs) and
+ * {@link http://jqueryui.com/slider/ JUI Slider page} for general
+ * description and demo.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @package zii.widgets.jui

--- a/framework/zii/widgets/jui/CJuiSliderInput.php
+++ b/framework/zii/widgets/jui/CJuiSliderInput.php
@@ -54,8 +54,10 @@ Yii::import('zii.widgets.jui.CJuiInputWidget');
  *
  * By configuring the {@link options} property, you may specify the options
  * that need to be passed to the JUI slider plugin. Please refer to
- * the {@link http://api.jqueryui.com/slider/ JUI slider} documentation
- * for possible options (name-value pairs).
+ * the {@link http://api.jqueryui.com/slider/ JUI Slider API} documentation
+ * for possible options (name-value pairs) and
+ * {@link http://jqueryui.com/slider/ JUI Slider page} for general
+ * description and demo.
  *
  * @author Sebastian Thierer <sebathi@gmail.com>
  * @package zii.widgets.jui

--- a/framework/zii/widgets/jui/CJuiSortable.php
+++ b/framework/zii/widgets/jui/CJuiSortable.php
@@ -33,8 +33,10 @@ Yii::import('zii.widgets.jui.CJuiWidget');
  *
  * By configuring the {@link options} property, you may specify the options
  * that need to be passed to the JUI Sortable plugin. Please refer to
- * the {@link http://api.jqueryui.com/sortable/ JUI Sortable} documentation
- * for possible options (name-value pairs).
+ * the {@link http://api.jqueryui.com/sortable/ JUI Sortable API} documentation
+ * for possible options (name-value pairs) and
+ * {@link http://jqueryui.com/sortable/ JUI Sortable page} for general
+ * description and demo.
  *
  * If you are using JavaScript expressions anywhere in the code, please wrap it
  * with {@link CJavaScriptExpression} and Yii will use it as code.

--- a/framework/zii/widgets/jui/CJuiTabs.php
+++ b/framework/zii/widgets/jui/CJuiTabs.php
@@ -34,8 +34,10 @@ Yii::import('zii.widgets.jui.CJuiWidget');
  *
  * By configuring the {@link options} property, you may specify the options
  * that need to be passed to the JUI tabs plugin. Please refer to
- * the {@link http://api.jqueryui.com/tabs/ JUI tabs} documentation
- * for possible options (name-value pairs).
+ * the {@link http://api.jqueryui.com/tabs/ JUI Tabs API} documentation
+ * for possible options (name-value pairs) and
+ * {@link http://jqueryui.com/tabs/ JUI Tabs page} for general
+ * description and demo.
  *
  * @author Sebastian Thierer <sebathi@gmail.com>
  * @package zii.widgets.jui


### PR DESCRIPTION
Widgets' documentation locations on jqueryui.com were changed since their last update. This is not an error but referring directly to the proper links (without redirects) is much better.
