### PR TITLE
Fix #1966: Add phpdoc type info for properties in CWsdlGenerator

### DIFF
--- a/framework/web/services/CWsdlGenerator.php
+++ b/framework/web/services/CWsdlGenerator.php
@@ -119,8 +119,17 @@ class CWsdlGenerator extends CComponent
 		'mixed'=>'xsd:anyType',
 	);
 
+	/*
+	 * @var array operations
+	 */
 	protected $operations;
+	/*
+	 * @var array types
+	 */
 	protected $types;
+	/*
+	 * @var array messages
+	 */
 	protected $messages;
 
 	/**


### PR DESCRIPTION
Fix issue #1966.
