### PR TITLE
Fixes #1763 CSqlDataProvider order by bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Version 1.1.14 work in progress
 -------------------------------
 - Bug #150: Fixed CWidget was not switching between view paths when using themes (antoncpu)
 - Bug #1464: Fixed transparent background for ImageMagick in CCaptchaAction (manuel-84, cebe)
+- Bug #1763: CSqlDataProvider was appending another ORDER BY string to an existing ORDER BY statement when using fieldname with dot (szako)
 - Bug #1915: CDataProviderIterator: fixed init in case of disabled pagination (antoncpu)
 - Bug #1941: yiiactiveform.js form reset now uses CHtml::errorCss instead of a hardcoded value (mdomba)
 - Bug #1942: CActiveForm client/ajax validation will now remove error class from server side validation (mdomba)

--- a/framework/web/CSqlDataProvider.php
+++ b/framework/web/CSqlDataProvider.php
@@ -87,7 +87,7 @@ class CSqlDataProvider extends CDataProvider
 			$order=$sort->getOrderBy();
 			if(!empty($order))
 			{
-				if(preg_match('/\s+order\s+by\s+[\w\s,]+$/i',$command->text))
+				if(preg_match('/\s+order\s+by\s+[\w\s,\.]+$/i',$command->text))
 					$command->text.=', '.$order;
 				else
 					$command->text.=' ORDER BY '.$order;


### PR DESCRIPTION
Issue #1763

CSqlDataProvider->fetchData( ) appends another ORDER BY statement when fieldnames with dot used.
