### PR TITLE
Change #1986. Added support of _renderItem in CJuiAutoComplete

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 
 Version 1.1.14 work in progress
 -------------------------------
+- Chg #1986: Added ability to use custom renderer for CJuiAutoComplete items
 - Bug #150: Fixed CWidget was not switching between view paths when using themes (antoncpu)
 - Bug #1464: Fixed transparent background for ImageMagick in CCaptchaAction (manuel-84, cebe)
 - Bug #1763: CSqlDataProvider was appending another ORDER BY string to an existing ORDER BY statement when using fieldname with dot (szako)

--- a/framework/zii/widgets/jui/CJuiAutoComplete.php
+++ b/framework/zii/widgets/jui/CJuiAutoComplete.php
@@ -20,6 +20,10 @@ Yii::import('zii.widgets.jui.CJuiInputWidget');
  * <pre>
  * $this->widget('zii.widgets.jui.CJuiAutoComplete',array(
  *     'name'=>'city',
+ *     'renderer' => 'js:function(ul,item){
+ *                         return $( "<li>" ).data( "item.autocomplete", item ).append( "<a>" 
+ *                         + item.label + "<br>" + item.desc + "</a>" ).appendTo( ul );
+ *                     }',
  *     'source'=>array('ac1','ac2','ac3'),
  *     // additional javascript options for the autocomplete plugin
  *     'options'=>array(
@@ -67,6 +71,12 @@ class CJuiAutoComplete extends CJuiInputWidget
 	public $sourceUrl;
 
 	/**
+     * @var string javascript callback. Formats autocomplete items
+	 * {@link http://jqueryui.com/autocomplete/#custom-data}.
+     */
+    public $renderer;
+
+	/**
 	 * Run this widget.
 	 * This method registers necessary javascript and renders the needed HTML code.
 	 */
@@ -91,7 +101,17 @@ class CJuiAutoComplete extends CJuiInputWidget
 		else
 			$this->options['source']=$this->source;
 
+		$customRenderer = false;
+		if (null !== $this->renderer)
+			$customRenderer = CJavaScript::encode($this->renderer);
+
 		$options=CJavaScript::encode($this->options);
-		Yii::app()->getClientScript()->registerScript(__CLASS__.'#'.$id,"jQuery('#{$id}').autocomplete($options);");
+		if ($customRenderer)
+			$js = "jQuery('#{$id}').autocomplete($options).data('autocomplete')._renderItem={$customRenderer};";
+		 else
+			$js = "jQuery('#{$id}').autocomplete($options);";
+
+		$cs = Yii::app()->getClientScript();
+		$cs->registerScript(__CLASS__.'#'.$id, $js);
 	}
 }


### PR DESCRIPTION
Issue #1986
Added support of _renderItem to be able to use custom renderer like this,

```
 $( "#ID" ).autocomplete({
minLength: 2,
source: customSource,
}).data( "autocomplete" )._renderItem = function( ul, item ) {
return $( "<li>" )
.data( "item.autocomplete", item )
.append( "<a>" + item.label + "<br>" + item.desc + "</a>" )
.appendTo( ul );
};
});
```

see http://jqueryui.com/autocomplete/#custom-data
