### PR TITLE
GettextMessageSource: added category name to cache key

### DIFF
--- a/framework/i18n/CGettextMessageSource.php
+++ b/framework/i18n/CGettextMessageSource.php
@@ -91,7 +91,7 @@ class CGettextMessageSource extends CMessageSource
 
 		if ($this->cachingDuration > 0 && $this->cacheID!==false && ($cache=Yii::app()->getComponent($this->cacheID))!==null)
 		{
-			$key = self::CACHE_KEY_PREFIX . $messageFile;
+			$key = self::CACHE_KEY_PREFIX . $messageFile . "." . $category;
 			if (($data=$cache->get($key)) !== false)
 				return unserialize($data);
 		}


### PR DESCRIPTION
fix: added category name to cache key, because messages are set to cache by category.
fix problem: when we use many categories in pofile and use cache, framework sets messages to cache from one category and the next time (from other category) gets messages from cache form wrong category.
