### PR TITLE
Add support for MySQL BIT(1) as boolean type

### DIFF
--- a/framework/db/schema/mysql/CMysqlColumnSchema.php
+++ b/framework/db/schema/mysql/CMysqlColumnSchema.php
@@ -27,7 +27,7 @@ class CMysqlColumnSchema extends CDbColumnSchema
 			$this->type='string';
 		elseif(strpos($dbType,'float')!==false || strpos($dbType,'double')!==false)
 			$this->type='double';
-		elseif(strpos($dbType,'bit(1)')!==false)
+		elseif(strpos($dbType,'tinyint(1)')!==false)
 			$this->type='boolean';
 		elseif(strpos($dbType,'int')===0 && strpos($dbType,'unsigned')===false || preg_match('/(bit|tinyint|smallint|mediumint)/',$dbType))
 			$this->type='integer';


### PR DESCRIPTION
This updates the MySQL database code to recognise the BIT(1) datatype as a boolean field, rather than previously using the 'BOOL' datatype which is just a synonym for TINYINT(1) and did not work.
