### PR TITLE
PHPDoc: `CCacheDependency` → `CCacheDependency|ICacheDependency`

### DIFF
--- a/framework/db/CDbConnection.php
+++ b/framework/db/CDbConnection.php
@@ -157,7 +157,7 @@ class CDbConnection extends CApplicationComponent
 	 */
 	public $queryCachingDuration=0;
 	/**
-	 * @var CCacheDependency the dependency that will be used when saving query results into cache.
+	 * @var CCacheDependency|ICacheDependency the dependency that will be used when saving query results into cache.
 	 * @see queryCachingDuration
 	 * @since 1.1.7
 	 */
@@ -343,7 +343,8 @@ class CDbConnection extends CApplicationComponent
 	 * without actually executing the SQL statement.
 	 * @param integer $duration the number of seconds that query results may remain valid in cache.
 	 * If this is 0, the caching will be disabled.
-	 * @param CCacheDependency $dependency the dependency that will be used when saving the query results into cache.
+	 * @param CCacheDependency|ICacheDependency $dependency the dependency that will be used when saving
+	 * the query results into cache.
 	 * @param integer $queryCount number of SQL queries that need to be cached after calling this method. Defaults to 1,
 	 * meaning that the next SQL query will be cached.
 	 * @return CDbConnection the connection instance itself.

--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -99,7 +99,8 @@ abstract class CActiveRecord extends CModel
 	 * It changes the query caching parameter of the {@link dbConnection} instance.
 	 * @param integer $duration the number of seconds that query results may remain valid in cache.
 	 * If this is 0, the caching will be disabled.
-	 * @param CCacheDependency $dependency the dependency that will be used when saving the query results into cache.
+	 * @param CCacheDependency|ICacheDependency $dependency the dependency that will be used when saving
+	 * the query results into cache.
 	 * @param integer $queryCount number of SQL queries that need to be cached after calling this method. Defaults to 1,
 	 * meaning that the next SQL query will be cached.
 	 * @return CActiveRecord the active record instance itself.


### PR DESCRIPTION
`CChainedCacheDependency` implements `ICacheDependency` interface, but does not extends `CCacheDependency`. But both `CDbConnection::cache()` and `CActiveRecord::cache()` methods could also accept `CChainedCacheDependency` besides `CDbCacheDependency`, `CGlobalStateCacheDependency`, etc.

This type specification imprecision leads IDEs to show warnings (at least PhpStorm warns about that).

Before this fix:
![](http://storage3.static.itmages.ru/i/13/0118/h_1358498886_3215627_78cbd44896.png)

After this fix:
![](http://storage4.static.itmages.ru/i/13/0118/h_1358498894_8901039_0213e7e089.png)
