### PR TITLE
Update framework/web/helpers/CHtml.php

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -549,6 +549,16 @@ class CHtml
 			unset($htmlOptions['for']);
 		else
 			$htmlOptions['for']=$for;
+		if(isset($htmlOptions['beforeInnerRequiredLabel']))
+                {
+                        $label=$htmlOptions['beforeInnerRequiredLabel'].$label;
+                        unset($htmlOptions['beforeInnerRequiredLabel']);
+                }
+                if(isset($htmlOptions['afterInnerRequiredLabel']))
+                {
+                        $label=$label.$htmlOptions['afterInnerRequiredLabel'];
+                        unset($htmlOptions['afterInnerRequiredLabel']);
+                }
 		if(isset($htmlOptions['required']))
 		{
 			if($htmlOptions['required'])


### PR DESCRIPTION
If $beforeRequiredLabel and $afterRequiredLabel are already set you can use beforeInnerRequiredLabel and/or afterInnerRequiredLabel trough htmlOptions.

With this patch you are able to generate html code like this.

```
<label class="control-label required" for="ContactForm_name"><i class="icon-user"></i> Name <span class="required">*</span></label>
```

by simple call like that.

```
$form->labelEx($model,'name', array('class'=>'control-label', 'beforeInnerRequiredLabel'=>'<i class="icon-user"></i> '));
```
