### PR TITLE
Update framework/web/helpers/CHtml.php

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -549,6 +549,16 @@ class CHtml
 			unset($htmlOptions['for']);
 		else
 			$htmlOptions['for']=$for;
+		if(isset($htmlOptions['beforeInnerLabel']))
+		{
+			$label=$htmlOptions['beforeInnerLabel'].$label;
+			unset($htmlOptions['beforeInnerLabel']);
+		}
+		if(isset($htmlOptions['afterInnerLabel']))
+		{
+			$label=$label.$htmlOptions['afterInnerLabel'];
+			unset($htmlOptions['afterInnerLabel']);
+		}			
 		if(isset($htmlOptions['required']))
 		{
 			if($htmlOptions['required'])


### PR DESCRIPTION
Add some inner "prefix"/"suffix" html code around the label content, without modifying CHtml::$beforeRequiredLabel and CHtml::$afterRequiredLabel

Example source code of how to use

```
echo $form->labelEx($model,'email', array('class'=>'control-label', 'beforeInnerLabel'=>'<i class="icon-envelope"></i> '));
echo $form->labelEx($model,'subject', array('class'=>'control-label', 'beforeInnerLabel'=>'<i class="icon-question-sign"></i> '));
```

It this case we are adding an image <i class="icon-envelope"></i> before the label content "Email"

beforeInnerLabel and afterInnerLabel can also be used if a label don't have the "require" tag.

See produced html code demo page http://shop.glasbuttek.lu/information/contact
