### PR TITLE
Update framework/db/ar/CActiveRecord.php

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -1068,9 +1068,7 @@ abstract class CActiveRecord extends CModel
 			Yii::trace(get_class($this).'.update()','system.db.ar.CActiveRecord');
 			if($this->_pk===null)
 				$this->_pk=$this->getPrimaryKey();
-			if (!$this->updateByPk($this->getOldPrimaryKey(),$this->getAttributes($attributes))) {
-				return false;
-			}
+			$this->updateByPk($this->getOldPrimaryKey(),$this->getAttributes($attributes));
 			$this->_pk=$this->getPrimaryKey();
 			$this->afterSave();
 			return true;


### PR DESCRIPTION
Если в ActiveRecord переопределить метод getTableAlias, то будут возникать ошибки неизвестной таблицы t, а так он будет использовать текущий алиас у таблицы
