### PR TITLE
Fixed docs for createTable and dropTable methods

### DIFF
--- a/framework/db/CDbCommand.php
+++ b/framework/db/CDbCommand.php
@@ -1313,7 +1313,7 @@ class CDbCommand extends CComponent
 	 * @param string $table the name of the table to be created. The name will be properly quoted by the method.
 	 * @param array $columns the columns (name=>definition) in the new table.
 	 * @param string $options additional SQL fragment that will be appended to the generated SQL.
-	 * @return integer 0 is always returned (see PDO docs for more information http://php.net/manual/en/pdostatement.rowcount.php).
+	 * @return integer 0 is always returned. See {@link http://php.net/manual/en/pdostatement.rowcount.php} for more information.
 	 * @since 1.1.6
 	 */
 	public function createTable($table, $columns, $options=null)
@@ -1325,7 +1325,7 @@ class CDbCommand extends CComponent
 	 * Builds and executes a SQL statement for renaming a DB table.
 	 * @param string $table the table to be renamed. The name will be properly quoted by the method.
 	 * @param string $newName the new table name. The name will be properly quoted by the method.
-	 * @return integer number of rows affected by the execution.
+	 * @return integer 0 is always returned. See {@link http://php.net/manual/en/pdostatement.rowcount.php} for more information.
 	 * @since 1.1.6
 	 */
 	public function renameTable($table, $newName)
@@ -1336,7 +1336,7 @@ class CDbCommand extends CComponent
 	/**
 	 * Builds and executes a SQL statement for dropping a DB table.
 	 * @param string $table the table to be dropped. The name will be properly quoted by the method.
-	 * @return integer 0 is always returned (see PDO docs for more information http://php.net/manual/en/pdostatement.rowcount.php).
+	 * @return integer 0 is always returned. See {@link http://php.net/manual/en/pdostatement.rowcount.php} for more information.
 	 * @since 1.1.6
 	 */
 	public function dropTable($table)


### PR DESCRIPTION
Fix for the issue #1969
@mdomba please see this PR, is docs clear in this format or need to be written in somehow else format (i mean add more explanations)?
Btw. need to check method `renameTable` i guess it also returns 0.
