### PR TITLE
Fixed #2087

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ Version 1.1.14 work in progress
 - Bug #2030: Fixed problem with MySQL 4.x: Undefined Index: Comment in CMysqlSchema (cebe)
 - Bug #2049: CStatElement relation with join option throw exception when key-field present on joined table (Yiivgeny)
 - Bug #2078: Fixed problem with "undefined" parameter in query string when using CListView or CGridView with enableHistory (Parpaing)
+- Bug #2087: CLocale: getLocaleDisplayName() was only returning the language display name, not the full locale display name (brandonkelly)
 - Enh: Better CFileLogRoute performance (Qiang, samdark)
 - Enh #1847: Added COutputCache::varyByLanguage to generate separate cache for different languages (Obramko)
 - Enh #1977: CFormatter::normalizeDateValue() now is protected instead of private to enable child classes to override it (etienneq)

--- a/framework/i18n/CLocale.php
+++ b/framework/i18n/CLocale.php
@@ -417,7 +417,7 @@ class CLocale extends CComponent
 	public function getLocaleDisplayName($id=null, $category='languages')
 	{
 		$id = $this->getCanonicalID($id);
-		if (($category == 'languages') && ($id=$this->getLanguageID($id)) && (isset($this->_data[$category][$id])))
+		if (($category == 'languages') && (isset($this->_data[$category][$id])))
 		{
 			return $this->_data[$category][$id];
 		}
@@ -445,6 +445,7 @@ class CLocale extends CComponent
 	 */
 	public function getLanguage($id)
 	{
+		$id = $this->getLanguageID($id);
 		return $this->getLocaleDisplayName($id, 'languages');
 	}
 


### PR DESCRIPTION
#2087

CLocale->getLocaleDisplayName() now returns the full display name for the locale ID passed in, no longer chopping off the territory chunk first. getLanguage() continues to chop off the territory chunk like it was.
