### PR TITLE
Allow registering scriptFiles as async

### DIFF
--- a/framework/web/CClientScript.php
+++ b/framework/web/CClientScript.php
@@ -56,6 +56,16 @@ class CClientScript extends CApplicationComponent
 	 */
 	public $scriptMap=array();
 	/**
+	 * @var array the list of scripts that should always be included asynchronously.
+	 * This allows specifying scripts that will be included with 'async="async"' set even if the call to {@link registerClientScript} does not specify it.
+	 * This is particularly useful for scripts that appear in {@link $scriptMap}.
+	 *
+	 * If a script is registered as asynchronous, its name is appended to this array.
+	 *
+	 * @since 1.1.14
+	 */
+	public $asyncScripts=array();
+	/**
 	 * @var array list of custom script packages (name=>package spec).
 	 * This property keeps a list of named script packages, each of which can contain
 	 * a set of CSS and/or JavaScript script files, and their dependent package names.
@@ -362,7 +372,7 @@ class CClientScript extends CApplicationComponent
 			if(isset($this->scriptFiles[self::POS_HEAD]))
 			{
 				foreach($this->scriptFiles[self::POS_HEAD] as $scriptFile)
-					$html.=CHtml::scriptFile($scriptFile)."\n";
+					$html.=CHtml::scriptFile($scriptFile,(in_array($scriptFile,$this->asyncScripts)?true:false))."\n";
 			}
 
 			if(isset($this->scripts[self::POS_HEAD]))
@@ -390,7 +400,7 @@ class CClientScript extends CApplicationComponent
 		if(isset($this->scriptFiles[self::POS_BEGIN]))
 		{
 			foreach($this->scriptFiles[self::POS_BEGIN] as $scriptFile)
-				$html.=CHtml::scriptFile($scriptFile)."\n";
+				$html.=CHtml::scriptFile($scriptFile,(in_array($scriptFile,$this->asyncScripts)?true:false))."\n";
 		}
 		if(isset($this->scripts[self::POS_BEGIN]))
 			$html.=CHtml::script(implode("\n",$this->scripts[self::POS_BEGIN]))."\n";
@@ -422,7 +432,7 @@ class CClientScript extends CApplicationComponent
 		if(isset($this->scriptFiles[self::POS_END]))
 		{
 			foreach($this->scriptFiles[self::POS_END] as $scriptFile)
-				$html.=CHtml::scriptFile($scriptFile)."\n";
+				$html.=CHtml::scriptFile($scriptFile,(in_array($scriptFile,$this->asyncScripts)?true:false))."\n";
 		}
 		$scripts=isset($this->scripts[self::POS_END]) ? $this->scripts[self::POS_END] : array();
 		if(isset($this->scripts[self::POS_READY]))

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -276,21 +276,23 @@ class CHtml
 	/**
 	 * Encloses the given JavaScript within a script tag.
 	 * @param string $text the JavaScript to be enclosed
+	 * @param boolean $async whether the script should be executed asynchronously, defaults to false. (@since 1.1.14)
 	 * @return string the enclosed JavaScript
 	 */
-	public static function script($text)
+	public static function script($text,$async=false)
 	{
-		return "<script type=\"text/javascript\">\n/*<![CDATA[*/\n{$text}\n/*]]>*/\n</script>";
+		return '<script type="text/javascript"'.($async?' async="async"':'').">\n/*<![CDATA[*/\n{$text}\n/*]]>*/\n</script>";
 	}
 
 	/**
 	 * Includes a JavaScript file.
 	 * @param string $url URL for the JavaScript file
+	 * @param boolean $async whether the script should be included asynchronously, defaults to false. (@since 1.1.14)
 	 * @return string the JavaScript file tag
 	 */
-	public static function scriptFile($url)
+	public static function scriptFile($url,$async=false)
 	{
-		return '<script type="text/javascript" src="'.self::encode($url).'"></script>';
+		return '<script type="text/javascript"'.($async?' async="async"':'').' src="'.self::encode($url).'"></script>';
 	}
 
 	/**


### PR DESCRIPTION
This fixes #1724, it adds the ability to add 'async="async"' to <script> tags in CHtml and also adds an array $asyncScripts to CClientScript such that the scripts listed in it will be tagged async in the resulting HTML file.
