### PR TITLE
CHtml: fix throw notice in encode function 

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -95,6 +95,7 @@ class CHtml
 	 */
 	public static function encode($text)
 	{
+		$text = is_array($text)?null:$text;
 		return htmlspecialchars($text,ENT_QUOTES,Yii::app()->charset);
 	}
 


### PR DESCRIPTION
if variable $text in function encode is array
