### PR TITLE
Fix memcache install for php 5.5 builds in travis

### DIFF
--- a/tests/travis/memcache-setup.sh
+++ b/tests/travis/memcache-setup.sh
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-if [ "$(expr "$TRAVIS_PHP_VERSION" "<" "5.5")" -eq 1 ]; then
-  echo 'y' | pecl install memcache > ~/memcache.log || ( echo "=== MEMCACHE BUILD FAILED ==="; cat ~/memcache.log )
-else
-  wget http://pecl.php.net/get/memcache-2.2.7.tgz
-  tar -zxf memcache-2.2.7.tgz
-  sh -c "cd memcache-2.2.7 && phpize && ./configure --enable-memcache && make && sudo make install"
-  echo "extension=memcache.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s/.*:\s*//"`
-fi
+install_memcache() {
+    if [ "$(expr "$TRAVIS_PHP_VERSION" "<" "5.5")" -eq 1 ]; then
+        echo 'y' | pecl install memcache
+    else
+        MEMCACHE_VERSION="2.2.7"
+        wget "http://pecl.php.net/get/memcache-$MEMCACHE_VERSION.tgz" &&
+        tar -zxf "memcache-$MEMCACHE_VERSION.tgz" &&
+        sh -c "cd memcache-$MEMCACHE_VERSION && phpize && ./configure --enable-memcache && make && sudo make install" &&
+        echo "extension=memcache.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s/.*:\s*//"`
+    fi
+
+    return $?
+}
+
+install_memcache > ~/memcache.log || ( echo "=== MEMCACHE BUILD FAILED ==="; cat ~/memcache.log )


### PR DESCRIPTION
Hi

As you can see here:
https://travis-ci.org/yiisoft/yii/jobs/4871285/#L179
Some test are skipped for php 5.5. Those are the one dependent on memcache.

In php 5.4. builds this is just ok:
https://travis-ci.org/yiisoft/yii/jobs/4871284/#L41

There was just small bug in installation of memcache:
https://github.com/arvenil/yii/commit/3c339515d5ccb565c9389e4802ffbe4716902d35#L0R9
(https://github.com/yiisoft/yii/commit/26786ccbd60e603c3fe114fecab3a12ea97bb1a3#L0R9)

I have also switched this script back to `#!/bin/sh` by removing one bashizm:
https://github.com/arvenil/yii/commit/367c6dce7a4367f6d13cc35095c31cf277334c9e#L0R3
(https://github.com/yiisoft/yii/commit/aea124110ebdc996203a904adc7a109b96d7653e#L0L1)

And also silenced output for installing memcache in php 5.5 builds as this was done for previous versions:
https://github.com/arvenil/yii/commit/9a216ae3bb3a29ebd28ce8299897c72e74a75473#L0R17
(https://github.com/yiisoft/yii/pull/931, https://github.com/yiisoft/yii/pull/927)

In short: Tests in php 5.5 builds which use memcache should work now :)
