### PR TITLE
Added in Fileinfo PECL extension check for CFileValidator

### DIFF
--- a/requirements/index.php
+++ b/requirements/index.php
@@ -143,7 +143,7 @@ $requirements=array(
         false,
         extension_loaded("fileinfo"),
         '<a href="http://www.yiiframework.com/doc/api/CFileValidator">CFileValidator</a>',
-        t('yii','In order to use MIME-type validation provided by CFileValidator fileinfo PECL extension should be installed.')
+        t('yii','Required by CFileValidator for MIME-type validation')
     ),
 );
 


### PR DESCRIPTION
The mimetype checking is a really slick feature, but it's buried in Yii.  Adding it to the requirements page might both allow a quick check to see if things are setup (for those of us using it) and might draw additional attention to this nifty feature.
