### PR TITLE
add previous exception to base yii exception classes as param

### DIFF
--- a/framework/base/CHttpException.php
+++ b/framework/base/CHttpException.php
@@ -30,10 +30,11 @@ class CHttpException extends CException
 	 * @param integer $status HTTP status code, such as 404, 500, etc.
 	 * @param string $message error message
 	 * @param integer $code error code
+	 * @param Exception $previous previous exception if nested exception
 	 */
-	public function __construct($status,$message=null,$code=0)
+	public function __construct($status,$message=null,$code=0,Exception $previous=null)
 	{
 		$this->statusCode=$status;
-		parent::__construct($message,$code);
+		parent::__construct($message,$code,$previous);
 	}
 }

--- a/framework/db/CDbException.php
+++ b/framework/db/CDbException.php
@@ -29,10 +29,11 @@ class CDbException extends CException
 	 * @param string $message PDO error message
 	 * @param integer $code PDO error code
 	 * @param mixed $errorInfo PDO error info
+	 * @param Exception $previous previous exception if nested exception
 	 */
-	public function __construct($message,$code=0,$errorInfo=null)
+	public function __construct($message,$code=0,$errorInfo=null,Exception $previous=null)
 	{
 		$this->errorInfo=$errorInfo;
-		parent::__construct($message,$code);
+		parent::__construct($message,$code,$previous);
 	}
 }


### PR DESCRIPTION
Problem: CException Yii base exception class allows previous exception as param, and CDbException or CHttpException do not.
Fix: add previous exception to base yii exception class constructors as param and pass this param to parent (CException) construct method.
