### PR TITLE
Enh #100: Make CLogFilter::getContext() able to handle more precise $logVars

### DIFF
--- a/framework/collections/CMap.php
+++ b/framework/collections/CMap.php
@@ -46,7 +46,7 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	/**
 	 * Constructor.
 	 * Initializes the list with an array or an iterable object.
-	 * @param array $data the initial data. Default is null, meaning no initialization.
+	 * @param array $data the intial data. Default is null, meaning no initialization.
 	 * @param boolean $readOnly whether the list is read-only
 	 * @throws CException If data is not null and neither an array nor an iterator.
 	 */
@@ -118,10 +118,6 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 */
 	public function itemAt($key)
 	{
-		if ( is_array($key) ) {
-			return self::searchArrayPath($this->_d, $key);
-		}
-
 		if(isset($this->_d[$key]))
 			return $this->_d[$key];
 		else
@@ -229,7 +225,7 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * If the merge is recursive, the following algorithm is performed:
 	 * <ul>
 	 * <li>the map data is saved as $a, and the source data is saved as $b;</li>
-	 * <li>if $a and $b both have an array indexed at the same string key, the arrays will be merged using this algorithm;</li>
+	 * <li>if $a and $b both have an array indxed at the same string key, the arrays will be merged using this algorithm;</li>
 	 * <li>any integer-indexed elements in $b will be appended to $a and reindexed accordingly;</li>
 	 * <li>any string-indexed elements in $b will overwrite elements in $a with the same index;</li>
 	 * </ul>
@@ -276,7 +272,7 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * For integer-keyed elements, the elements from the latter array will
 	 * be appended to the former array.
 	 * @param array $a array to be merged to
-	 * @param array $b array to be merged from. You can specify additional
+	 * @param array $b array to be merged from. You can specifiy additional
 	 * arrays via third argument, fourth argument etc.
 	 * @return array the merged array (the original arrays are not changed.)
 	 * @see mergeWith
@@ -299,35 +295,6 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 			}
 		}
 		return $res;
-	}
-
-	/**
-	 * Walks through a given array by a specified path.
-	 * Each item of the path array specifies the next nested key
-	 * in the array
-	 * @param array $array array to be searched
-	 * @param array $path  array of each level key
-	 * @return mixed the value of the array at the end of the path
-	 */
-	public static function searchArrayPath($array, $path) {
-		if ( is_string($path) ) {
-			$path = explode('.', $path);
-		}
-
-		if(!is_array($path)) {
-			return null;
-		}
-
-		$key = reset($path);
-		if(!isset($array[$key])) {
-			return null;
-		}
-
-		if( count($path) == 1 ) {
-			return $array[$key];
-		}
-
-		return self::searchArrayPath($array[$key], array_slice($path, 1));
 	}
 
 	/**

--- a/framework/logging/CLogFilter.php
+++ b/framework/logging/CLogFilter.php
@@ -98,7 +98,7 @@ class CLogFilter extends CComponent implements ILogFilter
 		{
 			if ( is_array($name) ) {
 				$imploded_name = implode('.', $name);
-				$context[] = "\${$imploded_name}=".var_export(CMap::searchArrayPath($GLOBALS, $name), true);
+				$context[] = "\${$imploded_name}=".var_export($this->searchArrayPath($GLOBALS, $name), true);
 			} else {
 				if(!empty($GLOBALS[$name]))
 					$context[]="\${$name}=".var_export($GLOBALS[$name],true);
@@ -106,5 +106,31 @@ class CLogFilter extends CComponent implements ILogFilter
 		}
 
 		return implode("\n\n",$context);
+	}
+
+	/**
+	 * Searches through array by a given path.
+	 * Each item in path represents a key of the array.
+	 *
+	 * @param array $array array to be searched
+	 * @param array $path  array with array keys
+	 * @return mixed the value of the array at the end of the path
+	 */
+	private function searchArrayPath($array, $path) {
+
+		if(!is_array($path)) {
+			return null;
+		}
+
+		$key = reset($path);
+		if(!isset($array[$key])) {
+			return null;
+		}
+
+		if( count($path) == 1 ) {
+			return $array[$key];
+		}
+
+		return $this->searchArrayPath($array[$key], array_slice($path, 1));
 	}
 }

--- a/tests/framework/collections/CMapTest.php
+++ b/tests/framework/collections/CMapTest.php
@@ -150,36 +150,6 @@ class CMapTest extends CTestCase
 		$this->assertEquals($this->item3, $map['k3']['k4']);
 	}
 
-	public function testItemAtWithPath()
-	{
-		$value = 'value';
-		$a=array(
-			'lvl1'=>array(
-				'lvl2'=>array(
-					'lvl3'=>array(
-						'key'=>$value
-					)
-				)
-			)
-		);
-		$b=array(
-			0=>array(
-				0=>array(
-					1=>array(
-						2=>$value
-					)
-				)
-			)
-		);
-		$map=new CMap($a);
-		$map2=new CMap($b);
-
-		$this->assertEquals($value, $map->itemAt(array('lvl1', 'lvl2', 'lvl3', 'key')));
-		$this->assertEquals($value, $map2->itemAt(array(0,0,1,2)));
-		$this->assertNull($map->itemAt(array('lvl1', 'lvl2', 'unknown')));
-		$this->assertNull($map->itemAt(array()));
-	}
-
 	public function testArrayRead()
 	{
 		$this->assertEquals($this->item1,$this->map['key1']);


### PR DESCRIPTION
This should fix #100 

Needed a recursive method, which I thought would be great in a more global scope. so i put it to CMap.

Added tests and other tests seems to work nicely.
