### PR TITLE
Changed CFilter to use CVarDumper to dump vars

### DIFF
--- a/framework/logging/CLogFilter.php
+++ b/framework/logging/CLogFilter.php
@@ -97,7 +97,7 @@ class CLogFilter extends CComponent implements ILogFilter
 		foreach($this->logVars as $name)
 		{
 			if(!empty($GLOBALS[$name]))
-				$context[]="\${$name}=".var_export($GLOBALS[$name],true);
+				$context[]="\${$name}=".CVarDumper::dumpAsString($GLOBALS[$name]);
 		}
 
 		return implode("\n\n",$context);


### PR DESCRIPTION
Adjusted to make sure of `CVarDumper`'s auto-catching of Yii object recursion.

One thing it's probably worth discussing.  The previous setup (using `var_export`) would dump objects in more detail than the default `CVarDumper` setup.

I wonder about adding another `$dumpLevel` to CFilter and setting it to default to 100.  `var_export` errors out if it runs into a recursive structure.  Do we want to emulate that same behavior to keep from breaking BC?

I'm inclined to think this new behavior is better than the old, but it will differ slightly.  But because it's for logging, it may not be a giant problem.  Thoughts?
