### PR TITLE
Changes to PHP error handling.

### DIFF
--- a/framework/logging/CLogger.php
+++ b/framework/logging/CLogger.php
@@ -351,4 +351,32 @@ class CLogger extends CComponent
 	{
 		$this->raiseEvent('onFlush', $event);
 	}
+	
+	/**
+	 * Returns string representation (eg "E_NOTICE") of a PHP error code
+	 * @param int $code
+	 * @return string
+	 */
+	public static function parsePhpErrorCode($code)
+	{
+		switch ($code)
+		{
+			case E_ERROR : return 'E_ERROR'; 
+			case E_WARNING : return 'E_WARNING'; 
+			case E_PARSE : return 'E_PARSE'; 
+			case E_NOTICE : return 'E_NOTICE'; 
+			case E_CORE_ERROR : return 'E_CORE_ERROR'; 
+			case E_CORE_WARNING : return 'E_CORE_WARNING'; 
+			case E_COMPILE_ERROR : return 'E_COMPILE_ERROR'; 
+			case E_COMPILE_WARNING : return 'E_COMPILE_WARNING'; 
+			case E_USER_ERROR : return 'E_USER_ERROR'; 
+			case E_USER_WARNING : return 'E_USER_WARNING'; 
+			case E_USER_NOTICE : return 'E_USER_NOTICE'; 
+			case E_STRICT : return 'E_STRICT';
+			case E_RECOVERABLE_ERROR : return 'E_RECOVERABLE_ERROR';
+			case E_DEPRECATED : return 'E_DEPRECATED';
+			case E_USER_DEPRECATED : return 'E_USER_DEPRECATED';
+			default : return 'E_UNDEFINED';
+		}
+	}
 }


### PR DESCRIPTION
This commit attempts to solve a problem of minor PHP errors causing the app to exit. App will now exit only if the error event was not handled, allowing developers to set up custom error handlers that will ignore certain types of errors (eg notices). PHP errors are also logged using an appropriate level, depending on error code (E_ERROR, E_NOTICE etc). A shutdown function is also registered to attempt to catch fatal errors (and at least log them).

See here for more details:
http://www.yiiframework.com/forum/index.php/topic/41244-handling-php-errors/
