### PR TITLE
Improved PHP Error Handling, take 2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 
 Version 1.1.14 work in progress
 -------------------------------
+- Enh: Improved handling of PHP errors by adding a config option to specify which PHP errors Yii should handle (pavlepredic)
 - Bug #135: Fixed wrong CActiveRecord rows count with having (klimov-paul)
 - Bug #150: Fixed CWidget was not switching between view paths when using themes (antoncpu)
 - Bug #1464: Fixed transparent background for ImageMagick in CCaptchaAction (manuel-84, cebe)

--- a/framework/base/CApplication.php
+++ b/framework/base/CApplication.php
@@ -97,6 +97,13 @@ abstract class CApplication extends CModule
 	 * the language that the messages and view files are in. Defaults to 'en_us' (US English).
 	 */
 	public $sourceLanguage='en_us';
+	/**
+	 * @var int specify what PHP errors should be handled by Yii.
+	 * Note that this will only have an effect if YII_ENABLE_ERROR_HANDLER is set to true.
+	 * If not specified, defaults to the current value of error_reporting().
+	 * @see http://www.php.net/manual/en/errorfunc.constants.php
+	 */
+	public $phpErrorReportingLevel;	
 
 	private $_id;
 	private $_basePath;
@@ -144,10 +151,11 @@ abstract class CApplication extends CModule
 
 		$this->preinit();
 
-		$this->initSystemHandlers();
 		$this->registerCoreComponents();
 
 		$this->configure($config);
+		//init system handlers after configuring, because we need the config value of phpErrorReportingLevel
+		$this->initSystemHandlers();
 		$this->attachBehaviors($this->behaviors);
 		$this->preloadComponents();
 
@@ -930,10 +938,13 @@ abstract class CApplication extends CModule
 	 */
 	protected function initSystemHandlers()
 	{
+		if ($this->phpErrorReportingLevel === null)
+			$this->phpErrorReportingLevel = error_reporting();
+
 		if(YII_ENABLE_EXCEPTION_HANDLER)
 			set_exception_handler(array($this,'handleException'));
 		if(YII_ENABLE_ERROR_HANDLER)
-			set_error_handler(array($this,'handleError'),error_reporting());
+			set_error_handler(array($this,'handleError'),$this->phpErrorReportingLevel);
 	}
 
 	/**


### PR DESCRIPTION
Here's another stab at improving Yii's PHP error handling. This time, I've simply added a config option that allows specifying which PHP errors Yii should handle. The only possible issue is the change in app constructor - I've changed the initialization order, and I have no idea if this can have some negative "butterfly" effect.

More info here: http://www.yiiframework.com/forum/index.php/topic/41244-handling-php-errors/
