### PR TITLE
Fixes #2121: CMssqlSchema::resetSequence() incorrectly resets sequence.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@ Version 1.1.14 work in progress
 - Bug #2086: Fixed .hgignore rule for assets folder (GeXu3, Koduc)
 - Bug #2087: CLocale: getLocaleDisplayName() was only returning the language display name, not the full locale display name (brandonkelly)
 - Bug #2112: Fixed broken yiic shell CRUD command (mbischof)
+- Bug #2121: CMssqlSchema::resetSequence() incorrectly resets sequence (resurtm, joewoodhouse)
 - Bug #2123: Fixed error in plural rules handling if locale has no plural rules defined (cebe, stepanselyuk)
 - Bug #2146: CEmailValidator fix when fsockopen() can output uncatched error 'Connection refused (61)' (armab)
 - Bug #2159: Fixed SQL syntax for delete command with join in MySQL (serebrov)

--- a/framework/db/schema/mssql/CMssqlSchema.php
+++ b/framework/db/schema/mssql/CMssqlSchema.php
@@ -83,7 +83,7 @@ class CMssqlSchema extends CDbSchema
 	 * The sequence will be reset such that the primary key of the next new row inserted
 	 * will have the specified value or 1.
 	 * @param CDbTableSchema $table the table schema whose primary key sequence will be reset
-	 * @param mixed $value the value for the primary key of the next new row inserted. If this is not set,
+	 * @param integer|null $value the value for the primary key of the next new row inserted. If this is not set,
 	 * the next new row's primary key will have a value 1.
 	 * @since 1.1.6
 	 */
@@ -93,8 +93,9 @@ class CMssqlSchema extends CDbSchema
 		{
 			$db=$this->getDbConnection();
 			if($value===null)
-				$value=$db->createCommand("SELECT MAX(`{$table->primaryKey}`) FROM {$table->rawName}")->queryScalar();
-			$value=(int)$value;
+				$value=(int)$db->createCommand("SELECT MAX([{$table->primaryKey}]) FROM {$table->rawName}")->queryScalar();
+			else
+				$value=(int)($value)-1;
 			$name=strtr($table->rawName,array('['=>'',']'=>''));
 			$db->createCommand("DBCC CHECKIDENT ('$name', RESEED, $value)")->execute();
 		}

--- a/tests/framework/db/schema/CMssqlTest.php
+++ b/tests/framework/db/schema/CMssqlTest.php
@@ -22,7 +22,7 @@ class CMssqlTest extends CTestCase
 	const DB_NAME='yii';
 	const DB_USER='test';
 	const DB_PASS='test';
-	const DB_DSN_PREFIX='dblib'; // Set this to 'mssql' or 'sqlsrv' on MS Windows or 'dblib' on GNU/Linux.
+	const DB_DSN_PREFIX='sqlsrv'; // Set this to 'mssql' or 'sqlsrv' on MS Windows or 'dblib' on GNU/Linux.
 
 	/**
 	 * @var CDbConnection
@@ -375,5 +375,25 @@ EOD;
 		$this->assertEquals(4, $user->primaryKey);
 		$this->assertEquals(4, $user->id);
 		$this->assertEquals(4, $this->db->createCommand('SELECT MAX(id) FROM [dbo].[users]')->queryScalar());
+	}
+
+	public function testResetSequence()
+	{
+		$tables=$this->db->schema->tables;
+
+		$this->db->schema->resetSequence($tables['users']);
+		$this->db->createCommand()->insert('users',array('username'=>'testerX','password'=>'passwordX','email'=>'emailX@gmail.com'));
+		$id=$this->db->createCommand()->select('id')->from('users')->where("[username]='testerX'")->queryScalar();
+		$this->assertEquals(4,$id);
+
+		$this->db->schema->resetSequence($tables['users'],100);
+		$this->db->createCommand()->insert('users',array('username'=>'testerY','password'=>'passwordY','email'=>'emailY@gmail.com'));
+		$id=$this->db->createCommand()->select('id')->from('users')->where("[username]='testerY'")->queryScalar();
+		$this->assertEquals(100,$id);
+
+		$this->db->schema->resetSequence($tables['users']);
+		$this->db->createCommand()->insert('users',array('username'=>'testerZ','password'=>'passwordZ','email'=>'emailZ@gmail.com'));
+		$id=$this->db->createCommand()->select('id')->from('users')->where("[username]='testerZ'")->queryScalar();
+		$this->assertEquals(101,$id);
 	}
 }


### PR DESCRIPTION
Fixes #2121: CMssqlSchema::resetSequence() incorrectly resets sequence.

Tested with MS SQL Server 2008 R2.
