### PR TITLE
A little update to saveAs() documentation for better clarify/verboseness

### DIFF
--- a/framework/web/CUploadedFile.php
+++ b/framework/web/CUploadedFile.php
@@ -183,6 +183,8 @@ class CUploadedFile extends CComponent
 
 	/**
 	 * Saves the uploaded file.
+	 * Note: this method uses php's move_uploaded_file() method. As such, if the target file ($file) 
+	 * already exists it is overwritten.
 	 * @param string $file the file path used to save the uploaded file
 	 * @param boolean $deleteTempFile whether to delete the temporary file after saving.
 	 * If true, you will not be able to save the uploaded file again in the current request.


### PR DESCRIPTION
adding to documentation of 'saveAs()' a few words regarding the fact that it's overwriting existing files (if exists) without any questions asked
