### PR TITLE
ParseUrl should take into consideration baseUrl when the UrlRoule hasHostInfo

### DIFF
--- a/framework/web/CUrlManager.php
+++ b/framework/web/CUrlManager.php
@@ -815,7 +815,7 @@ class CUrlRule extends CBaseUrlRule
 		}
 
 		if($this->hasHostInfo)
-			$pathInfo=strtolower($request->getHostInfo()).rtrim('/'.$pathInfo,'/');
+			$pathInfo=strtolower($request->getHostInfo().$request->getBaseUrl()).rtrim('/'.$pathInfo,'/');
 
 		$pathInfo.='/';
 


### PR DESCRIPTION
This should be just in case the Yii is installed at

http://example.com/app 

and you use absolute path routes 
