### PR TITLE
Added new property CDbTestCase.fixturesPath

### DIFF
--- a/framework/test/CDbTestCase.php
+++ b/framework/test/CDbTestCase.php
@@ -41,8 +41,7 @@ abstract class CDbTestCase extends CTestCase
 {
 
 	/**
-	 * @var string valid fixtures path for the current test. Path must be
-	 * valid alias.
+	 * @var string valid fixtures path for the current test. Path must be valid alias.
 	 * @since 1.1.14
 	 */
 	public $fixturePath;
@@ -127,7 +126,7 @@ abstract class CDbTestCase extends CTestCase
 				$this->getFixtureManager()->basePath=$basePath;
 			else
 				throw new CException(Yii::t('yii','{path}" is not a valid directory.',array(
-					'{path}' => $this->fixturePath
+					'{path}'=>$this->fixturePath
 				)));
 		}
 		if(is_array($this->fixtures))


### PR DESCRIPTION
I think this must be implemented, i have my test well-structured in different folders, so my fixtures folders looks like unit-tests folder (not equals of course). @cebe this one is also for issue https://github.com/yiisoft/yii/issues/1936. Any thoughts  of other core-developers?
