### PR TITLE
js error when selected range: 'min' or 'max'

### DIFF
--- a/framework/zii/widgets/jui/CJuiSliderInput.php
+++ b/framework/zii/widgets/jui/CJuiSliderInput.php
@@ -98,7 +98,7 @@ class CJuiSliderInput extends CJuiInputWidget
 		if(isset($this->htmlOptions['name']))
 			$name=$this->htmlOptions['name'];
 
-		$isRange=isset($this->options['range']) && $this->options['range'];
+		$isRange=isset($this->options['range']) && $this->options['range'] && is_bool($this->options['range']);
 
 		if($this->hasModel())
 		{


### PR DESCRIPTION
http://api.jqueryui.com/slider/#option-range

Multiple types supported:
Boolean: If set to true, the slider will detect if you have two handles and create a styleable range element between these two.
String: Either "min" or "max". A min range goes from the slider min to one handle. A max range goes from one handle to the slider max.
