### PR TITLE
Tiny fix. Array-typed parameter passed to basename in remapScripts method of CClientScript

### DIFF
--- a/framework/web/CClientScript.php
+++ b/framework/web/CClientScript.php
@@ -283,7 +283,7 @@ class CClientScript extends CApplicationComponent
 			$jsFiles[$position]=array();
 			foreach($scriptFiles as $scriptFile=>$scriptFileValue)
 			{
-				$name=basename($scriptFileValue);
+				$name=basename($scriptFile);
 				if(isset($this->scriptMap[$name]))
 				{
 					if($this->scriptMap[$name]!==false)


### PR DESCRIPTION
When the registered script file with non-empty htmlOptions,then will cause this error.
