### PR TITLE
Fixes #1669: CNumberValidator used to add wrong error messages in case non-numeric values being validated.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Version 1.1.14 work in progress
 - Bug #135: Fixed wrong CActiveRecord rows count with having (klimov-paul)
 - Bug #150: Fixed CWidget was not switching between view paths when using themes (antoncpu)
 - Bug #1464: Fixed transparent background for ImageMagick in CCaptchaAction (manuel-84, cebe)
+- Bug #1669: CNumberValidator used to add wrong error messages in case non-numeric values being validated (resurtm)
 - Bug #1693: Fixed log file will rotate twice when high performance (monque)
 - Bug #1724: Allow CClientScript registering scripts and script files with the HTML options (klimov-paul)
 - Bug #1763: CSqlDataProvider was appending another ORDER BY string to an existing ORDER BY statement when using fieldname with dot (szako)

--- a/framework/validators/CNumberValidator.php
+++ b/framework/validators/CNumberValidator.php
@@ -78,9 +78,10 @@ class CNumberValidator extends CValidator
 		$value=$object->$attribute;
 		if($this->allowEmpty && $this->isEmpty($value))
 			return;
-		if(is_array($value))
+		if(!is_numeric($value))
 		{
 			// https://github.com/yiisoft/yii/issues/1955
+			// https://github.com/yiisoft/yii/issues/1669
 			$message=$this->message!==null?$this->message:Yii::t('yii','{attribute} must be a number.');
 			$this->addError($object,$attribute,$message);
 			return;

--- a/tests/framework/validators/CNumberValidatorTest.php
+++ b/tests/framework/validators/CNumberValidatorTest.php
@@ -1,0 +1,43 @@
+<?php
+require_once('ValidatorTestModel.php');
+
+class CNumberValidatorTest extends CTestCase
+{
+	public function providerIssue1669()
+	{
+		return array(
+			// boolean
+			array(false, array('number' => array('Number must be a number.'))),
+			array(true, array('number' => array('Number must be a number.'))),
+			// integer
+			array(20, array('number' => array('Number is too big (maximum is 15).'))),
+			array(1, array('number' => array('Number is too small (minimum is 5).'))),
+			// float
+			array(20.5, array('number' => array('Number must be an integer.','Number is too big (maximum is 15).'))),
+			array(1.5, array('number' => array('Number must be an integer.','Number is too small (minimum is 5).'))),
+			// string
+			array('20', array('number' => array('Number is too big (maximum is 15).'))),
+			array('20.5', array('number' => array('Number must be an integer.','Number is too big (maximum is 15).'))),
+			array('1', array('number' => array('Number is too small (minimum is 5).'))),
+			array('1.5', array('number' => array('Number must be an integer.','Number is too small (minimum is 5).'))),
+			array('abc', array('number' => array('Number must be a number.'))),
+			array('a100', array('number' => array('Number must be a number.'))),
+			// array
+			array(array(1,2), array('number' => array('Number must be a number.'))),
+			// object
+			array((object)array('a'=>1,'b'=>2), array('number' => array('Number must be a number.'))),
+		);
+	}
+
+	/**
+	 * https://github.com/yiisoft/yii/issues/1669
+	 * @dataProvider providerIssue1669
+	 */
+	public function testIssue1669($value, $assertion)
+	{
+		$model = new ValidatorTestModel('CNumberValidatorTest');
+		$model->number = $value;
+		$model->validate(array('number'));
+		$this->assertSame($assertion, $model->getErrors());
+	}
+}

--- a/tests/framework/validators/ValidatorTestModel.php
+++ b/tests/framework/validators/ValidatorTestModel.php
@@ -9,6 +9,8 @@ class ValidatorTestModel extends CFormModel
 
 	public $url;
 
+	public $number;
+
 	public function rules()
 	{
 		return array(
@@ -22,6 +24,8 @@ class ValidatorTestModel extends CFormModel
 			array('email', 'email', 'allowEmpty'=>false, 'on'=>'CEmailValidatorTest'),
 
 			array('url', 'url', 'allowEmpty'=>false, 'on'=>'CUrlValidatorTest'),
+
+			array('number', 'numerical', 'min'=>5, 'max'=>15, 'integerOnly'=>true, 'on'=>'CNumberValidatorTest'),
 		);
 	}
 }


### PR DESCRIPTION
Fixes #1669: CNumberValidator used to add wrong error messages in case non-numeric values being validated.
