### PR TITLE
Update scope of private variable to be able to extend CAccessControlFilter 

### DIFF
--- a/framework/web/auth/CAccessControlFilter.php
+++ b/framework/web/auth/CAccessControlFilter.php
@@ -83,7 +83,7 @@ class CAccessControlFilter extends CFilter
 	 */
 	public $message;
 
-	private $_rules=array();
+	protected $_rules=array();
 
 	/**
 	 * @return array list of access rules.


### PR DESCRIPTION
The actual scope `private` forces us to override `setRules` and `$_rules` variable in order to extend from the class.
