### PR TITLE
Fixes #2122: CActiveRecord, lazy load: 'params' from relations used in 'through' option were not applied to the final SQL statement.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@ Version 1.1.14 work in progress
 - Bug #2087: CLocale: getLocaleDisplayName() was only returning the language display name, not the full locale display name (brandonkelly)
 - Bug #2112: Fixed broken yiic shell CRUD command (mbischof)
 - Bug #2121: CMssqlSchema::resetSequence() incorrectly resets sequence (resurtm, joewoodhouse)
+- Bug #2122: CActiveRecord, lazy load: 'params' from relations used in 'through' option were not applied to the final SQL statement (resurtm)
 - Bug #2123: Fixed error in plural rules handling if locale has no plural rules defined (cebe, stepanselyuk)
 - Bug #2146: CEmailValidator fix when fsockopen() can output uncatched error 'Connection refused (61)' (armab)
 - Bug #2159: Fixed SQL syntax for delete command with join in MySQL (serebrov)

--- a/framework/db/ar/CActiveFinder.php
+++ b/framework/db/ar/CActiveFinder.php
@@ -460,7 +460,11 @@ class CJoinElement
 
 		if(!$this->children)
 			return;
-		$child=end($this->children); // bridge(s) inside, we're taking only last necessary child
+
+		$params=array();
+		foreach($this->children as $child)
+			if(is_array($child->relation->params))
+				$params=array_merge($params,$child->relation->params);
 
 		$query=new CJoinQuery($child);
 		$query->selects=array($child->getColumnSelect($child->relation->select));
@@ -472,8 +476,7 @@ class CJoinElement
 		$query->joins[]=$child->relation->join;
 		$query->havings[]=$child->relation->having;
 		$query->orders[]=$child->relation->order;
-		if(is_array($child->relation->params))
-			$query->params=$child->relation->params;
+		$query->params=$params;
 		$query->elements[$child->id]=true;
 		if($child->relation instanceof CHasManyRelation)
 		{

--- a/tests/framework/db/ar/CActiveRecord2Test.php
+++ b/tests/framework/db/ar/CActiveRecord2Test.php
@@ -593,4 +593,15 @@ class CActiveRecord2Test extends CTestCase
 		Post2::model()->with('author','firstComment','comments','categories')->findAllBySql('SELECT * FROM test.posts WHERE id=100');
 		$this->assertTrue($posts===array());
 	}
+
+	/**
+	 * @see https://github.com/yiisoft/yii/issues/2122
+	 */
+	public function testIssue2122()
+	{
+		$user=User2::model()->findByPk(2);
+		$this->assertEquals(2,count($user->postsWithParam));
+		$this->assertEquals('post 2',$user->postsWithParam[0]->title);
+		$this->assertEquals('post 3',$user->postsWithParam[1]->title);
+	}
 }

--- a/tests/framework/db/data/models2.php
+++ b/tests/framework/db/data/models2.php
@@ -29,6 +29,11 @@ class User2 extends CActiveRecord
 		return array(
 			'posts'=>array(self::HAS_MANY,'Post2','author_id'),
 			'friends'=>array(self::MANY_MANY,'User2','test.user_friends(id,friend)'),
+
+			// CActiveRecord2Test::testIssue2122()
+			'commentsWithParam'=>array(self::HAS_MANY,'Comment2','author_id','on'=>'"commentsWithParam"."post_id">:postId',
+				'params'=>array(':postId'=>1)),
+			'postsWithParam'=>array(self::HAS_MANY,'Post2',array('post_id'=>'id'),'through'=>'commentsWithParam'),
 		);
 	}
 


### PR DESCRIPTION
Fixes #2122: CActiveRecord, lazy load: 'params' from relations used in 'through' option were not applied to the final SQL statement.
