### PR TITLE
Issue 2303 Active Record get meta data recursion

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -399,7 +399,10 @@ abstract class CActiveRecord extends CModel
 	{
 		$className=get_class($this);
 		if(!array_key_exists($className,self::$_md))
+		{
+			self::$_md[$className]=null; // preventing recursive invokes of {@link getMetaData()} via {@link __get()}
 			self::$_md[$className]=new CActiveRecordMetaData($this);
+		}
 		return self::$_md[$className];
 	}
 


### PR DESCRIPTION
Fixes issue #2303.

CActiveRecord::getMetaData() has been updated preventing recursive invokes via  __get().
This allows magic setters and getters to be invoked without waiting for meta data composition and faling into recursion

Now issue #2251 should be satisfied fully.
