### PR TITLE
SQlite default value fix

### DIFF
--- a/framework/db/schema/sqlite/CSqliteColumnSchema.php
+++ b/framework/db/schema/sqlite/CSqliteColumnSchema.php
@@ -24,7 +24,7 @@ class CSqliteColumnSchema extends CDbColumnSchema
 	 */
 	protected function extractDefault($defaultValue)
 	{
-		if ($this->dbType==='timestamp' && $defaultValue==='CURRENT_TIMESTAMP')
+		if($this->dbType==='timestamp' && $defaultValue==='CURRENT_TIMESTAMP')
 			$this->defaultValue=null;
 		else
 			$this->defaultValue=$this->typecast(strcasecmp($defaultValue,'null') ? $defaultValue : null);


### PR DESCRIPTION
Prevent inserting string 'CURRENT_TIMESTAMP' on column defined like:

"create_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
