### PR TITLE
Set timestampAttribute to null when CDateValidator allows empty

### DIFF
--- a/framework/validators/CDateValidator.php
+++ b/framework/validators/CDateValidator.php
@@ -49,8 +49,11 @@ class CDateValidator extends CValidator
 	protected function validateAttribute($object,$attribute)
 	{
 		$value=$object->$attribute;
-		if($this->allowEmpty && $this->isEmpty($value))
+		if($this->allowEmpty && $this->isEmpty($value)) {
+			if ($this->timestampAttribute !== null)
+				$object->{$this->timestampAttribute}=null;
 			return;
+		}
 
 		$valid=false;
 


### PR DESCRIPTION
Resubmit of https://github.com/yiisoft/yii/pull/806: "By the documentation, `timestampAttribute` should get set when the date is valid. If the validator is set to allow empty values, it's logical that `timestampAttribute` should be set to null when the original attribute is empty."

I find the alternative that is suggested - setting a default value with `CDefaultValidator` - unacceptably brittle because you have to use *two* validation rules that *have to be in this particular order*:

    array('start_date', 'default', 'value'=>null, 'setOnEmpty'=>false),
    array('start_date_str', 'date', 'format'=>'d/M/yyyy', 'timestampAttribute'=>'start_date'),