### PR TITLE
add yiic as bin script to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,9 @@
 		"irc": "irc://irc.freenode.net/yii",
 		"source": "https://github.com/yiisoft/yii"
 	},
+    "bin": [
+        "framework/yiic"
+    ],
 	"require": {
 		"php": ">=5.1.0"
 	}


### PR DESCRIPTION
I add framework/yiic to composer.json, so that composer creates a link into vendir/bin.
