### PR TITLE
Autoloader fix for including unexistent files

### DIFF
--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -418,13 +418,13 @@ class YiiBase
 					}
 				}
 				else
-					include($className.'.php');
+					@include($className.'.php');
 			}
 			else  // class name with namespace in PHP 5.3
 			{
 				$namespace=str_replace('\\','.',ltrim($className,'\\'));
 				if(($path=self::getPathOfAlias($namespace))!==false)
-					include($path.'.php');
+					@include($path.'.php');
 				else
 					return false;
 			}


### PR DESCRIPTION
This minor fix to bug related to loading nonexistent files.
What happens if you use 

```
class_exists('SomeNonexistentClass');
```

well, if `self::$enableIncludePath==true` a notice will be triggered.
Is `class_exists` supposed to generate notices? No.

P.S. We discovered this bug while developing a Yii module for Codeception. 
In unit testing frameworks like Codeception or PHPUnit all notices are treated as errors and stop test execution.
So it's pretty important to avoid them in code.
