### PR TITLE
Fixes #2357: filter extending from CFilterWidget is initialized 2 times.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,6 +43,7 @@ Version 1.1.14 work in progress
 - Bug #2283: Gii Model Generator's tooltips are not working and always invisible (resurtm)
 - Bug #2289: CDbCacheDependency with reuseDependentData did not invalidate cache when getting cache across different requests (marcovtwout)
 - Bug #2299: CMssqlSchema: findTableNames(), getTables() and getTableNames() methods used to prepend schema prefix to the table names twice (resurtm)
+- Bug #2357: Filter extending from CFilterWidget is initialized 2 times (andersonamuller, resurtm)
 - Enh: Better CFileLogRoute performance (Qiang, samdark)
 - Enh: Refactored CHttpRequest::getDelete and CHttpRequest::getPut not to use _restParams directly (samdark)
 - Enh #1142: CSecurityManager::computeHMAC() has been made public (resurtm)

--- a/UPGRADE
+++ b/UPGRADE
@@ -43,6 +43,10 @@ Upgrading from v1.1.13
 - CSecurityManager::computeHMAC() method is now public and third parameter has been added. You must change signature
   of this method in the extended child class to fit new circumstances. Otherwise an E_STRICT error will be issued.
 
+- CFilterWidget and its descendants (COutputCache, COutputProcessor, CContentDecorator, CHtmlPurifier, CMarkdown,
+  CTextHighlighter) used to be initialized twice (CFilterWidget::init() called two times). Make sure you're not relying
+  on this characteristic in your application code since it has been fixed.
+
 Upgrading from v1.1.12
 ----------------------
 - Both jQuery and jQueryUI were updated. Check [jQuery UI upgrade guide](http://jqueryui.com/upgrade-guide/1.9/)

--- a/framework/web/widgets/CFilterWidget.php
+++ b/framework/web/widgets/CFilterWidget.php
@@ -64,7 +64,6 @@ class CFilterWidget extends CWidget implements IFilter
 	 */
 	public function filter($filterChain)
 	{
-		$this->init();
 		if(!$this->stopAction)
 		{
 			$filterChain->run();


### PR DESCRIPTION
Fixes #2357: filter extending from CFilterWidget is initialized 2 times.
