### PR TITLE
Yii List View incompatible with Chrome translation feature

### DIFF
--- a/framework/zii/widgets/CBaseListView.php
+++ b/framework/zii/widgets/CBaseListView.php
@@ -183,7 +183,7 @@ abstract class CBaseListView extends CWidget
 		echo CHtml::openTag('div',array(
 			'class'=>'keys',
 			'style'=>'display:none',
-			'title'=>Yii::app()->getRequest()->getUrl(),
+			'data-url'=>Yii::app()->getRequest()->getUrl(),
 		));
 		foreach($this->dataProvider->getKeys() as $key)
 			echo "<span>".CHtml::encode($key)."</span>";

--- a/framework/zii/widgets/assets/listview/jquery.yiilistview.js
+++ b/framework/zii/widgets/assets/listview/jquery.yiilistview.js
@@ -85,7 +85,7 @@
 	 */
 	$.fn.yiiListView.getUrl = function(id) {
 		var settings = $.fn.yiiListView.settings[id];
-		return settings.url || $('#'+id+' > div.keys').attr('title');
+		return settings.url || $('#'+id+' > div.keys').attr('data-url');
 	};
 
 	/**


### PR DESCRIPTION
jquery.fn.yiiListView.getUrl should fetch the url from a data attribute rather than from title attribute,

- Data attributes are preferable for setting metadata in the markup
- In this case it was creating issues with translation tools, leading to parts of URLs being translated, hence performing invalid requests