### PR TITLE
Use ':input' selector when removing errorCss

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,6 +43,7 @@ Version 1.1.14 work in progress
 - Bug #2283: Gii Model Generator's tooltips are not working and always invisible (resurtm)
 - Bug #2289: CDbCacheDependency with reuseDependentData did not invalidate cache when getting cache across different requests (marcovtwout)
 - Bug #2299: CMssqlSchema: findTableNames(), getTables() and getTableNames() methods used to prepend schema prefix to the table names twice (resurtm)
+- Bug #2368: Reset error CSS for ':input', which includes SELECT elements (blueyed)
 - Enh: Better CFileLogRoute performance (Qiang, samdark)
 - Enh: Refactored CHttpRequest::getDelete and CHttpRequest::getPut not to use _restParams directly (samdark)
 - Enh #755: Allow to get currently running command from CConsoleApplication (klimov-paul)

--- a/framework/web/js/source/jquery.yiiactiveform.js
+++ b/framework/web/js/source/jquery.yiiactiveform.js
@@ -202,7 +202,7 @@
 					/*
 					 * If the form is submited (non ajax) with errors, labels and input gets the class 'error'
 					 */
-					$form.find('label, input').each(function () {
+					$form.find('label, :input').each(function () {
 						$(this).removeClass(settings.errorCss);
 					});
 					$('#' + settings.summaryID).hide().find('ul').html('');
@@ -260,7 +260,7 @@
 				attribute.errorCssClass + ' ' +
 				attribute.successCssClass
 			);
-			$container.find('label, input').each(function () {
+			$container.find('label, :input').each(function () {
 				$(this).removeClass(errorCss);
 			});
 


### PR DESCRIPTION
This fixes SELECT boxes staying red after a submitted field with error
gets fixed by the user.

Fixes #2368
