### PR TITLE
Compartmentalise serialisation-to-cookie in CWebUser

### DIFF
--- a/framework/web/auth/CWebUser.php
+++ b/framework/web/auth/CWebUser.php
@@ -516,7 +516,7 @@ class CWebUser extends CApplicationComponent implements IWebUser
 	/**
 	 * Convert the data object into a string that can be stored in the cookie.  Override this if you want to use a
 	 * different form of compression, eg JSON if you're also accessing the cookie data from JavaScript.
-	 * @param $data mixed
+	 * @param $data mixed The data to serialize
 	 * @return string
 	 */
 	protected function serializeData($data)
@@ -527,7 +527,7 @@ class CWebUser extends CApplicationComponent implements IWebUser
 	/**
 	 * Convert the data from its stringified form back into an object.  Override this if you want to use a
 	 * different form of compression, eg JSON if you're also accessing the cookie data from JavaScript.
-	 * @param $data mixed
+	 * @param $data mixed The data to serialize
 	 * @return string
 	 */
 	protected function unserializeData($data)

--- a/framework/web/auth/CWebUser.php
+++ b/framework/web/auth/CWebUser.php
@@ -450,7 +450,7 @@ class CWebUser extends CApplicationComponent implements IWebUser
 		$cookie=$request->getCookies()->itemAt($this->getStateKeyPrefix());
 		if($cookie && !empty($cookie->value) && is_string($cookie->value) && ($data=$app->getSecurityManager()->validateData($cookie->value))!==false)
 		{
-			$data=@unserialize($data);
+			$data=@$this->unserializeData($data);
 			if(is_array($data) && isset($data[0],$data[1],$data[2],$data[3]))
 			{
 				list($id,$name,$duration,$states)=$data;
@@ -481,7 +481,7 @@ class CWebUser extends CApplicationComponent implements IWebUser
 		$cookie=$cookies->itemAt($this->getStateKeyPrefix());
 		if($cookie && !empty($cookie->value) && ($data=Yii::app()->getSecurityManager()->validateData($cookie->value))!==false)
 		{
-			$data=@unserialize($data);
+			$data=@$this->unserializeData($data);
 			if(is_array($data) && isset($data[0],$data[1],$data[2],$data[3]))
 			{
 				$cookie->expire=time()+$data[2];
@@ -509,8 +509,30 @@ class CWebUser extends CApplicationComponent implements IWebUser
 			$duration,
 			$this->saveIdentityStates(),
 		);
-		$cookie->value=$app->getSecurityManager()->hashData(serialize($data));
+		$cookie->value=$app->getSecurityManager()->hashData($this->serializeData($data));
 		$app->getRequest()->getCookies()->add($cookie->name,$cookie);
+	}
+
+	/**
+	 * Convert the data object into a string that can be stored in the cookie.  Override this if you want to use a
+	 * different form of compression, eg JSON if you're also accessing the cookie data from JavaScript.
+	 * @param $data mixed
+	 * @return string
+	 */
+	protected function serializeData($data)
+	{
+		return serialize($data);
+	}
+
+	/**
+	 * Convert the data from its stringified form back into an object.  Override this if you want to use a
+	 * different form of compression, eg JSON if you're also accessing the cookie data from JavaScript.
+	 * @param $data mixed
+	 * @return string
+	 */
+	protected function unserializeData($data)
+	{
+		return unserialize($data);
 	}
 
 	/**


### PR DESCRIPTION
The current implementation of the save-state-to-cookie implementation uses PHP `serialize()` of a stdClass object, and conversely calls `unserialize()` on user-supplied data from the cookie.  Calling `unserialize()` on user-supplied data is high-risk (http://heine.familiedeelstra.com/security/unserialize etc): basically this behaviour allows an attacker to establish an instance of any class, with any data in member variables, and be sure that the `__destruct()` method will be called on it, so if a separate class in the framework contains a `__destruct()` call which has sensitive behaviour (such as writing variable data to disk, or performing database queries), exploits up to and including arbitrary shell execution are opened.

I don't think Yii core is at risk to this attack because there are no dangerous destructors in the framework, but *any* dangerous class which can be autoloaded (eg in extensions or vendors) can be used, so I for one would rather not have `unserialize()` called on user data on my sites; an acceptable alternative for me (and one which is also useful separately since I access the state cookie client-side with javascript) is to JSON-encode the data rather than serialising it.

This change abstracts the `serialize()` and `unserialize()` calls in CWebUser into separate protected methods so they can be easily overridden in subclasses without needing to duplicate big chunks of code in saveToCookie(), renewCookie() and restoreFromCookie().