### PR TITLE
Fixes #2406: CUrlManager::$urlRuleClass now supports path alias value

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,7 @@ Version 1.1.14 work in progress
 - Bug #2368: Reset error CSS for ':input', which includes SELECT elements (blueyed)
 - Bug #2398: Fixed 'Undefined variable: results' E_NOTICE at CProfileLogRoute (klimov-paul)
 - Bug #2402: Fixed clientValidation incorrectly rendered as HTML attribute, when used in CActiveForm::error() (mdomba)
+- Bug #2406: CUrlManager::$urlRuleClass now supports path alias value (as it was described in it's PHPDoc before this fix) (resurtm)
 - Enh: Better CFileLogRoute performance (Qiang, samdark)
 - Enh: Refactored CHttpRequest::getDelete and CHttpRequest::getPut not to use _restParams directly (samdark)
 - Enh #169: Allow to set AJAX request type for CListView and CGridView (klimov-paul)

--- a/framework/web/CUrlManager.php
+++ b/framework/web/CUrlManager.php
@@ -265,7 +265,11 @@ class CUrlManager extends CApplicationComponent
 		if(is_array($route) && isset($route['class']))
 			return $route;
 		else
-			return new $this->urlRuleClass($route,$pattern);
+		{
+			if(($pos=strrpos($urlRuleClass=$this->urlRuleClass,'.'))!==false)
+				$urlRuleClass=Yii::import($urlRuleClass,true);
+			return new $urlRuleClass($route,$pattern);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2406: CUrlManager::$urlRuleClass now supports path alias value
