### PR TITLE
Implements delete cache by tag Issue #305

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -86,6 +86,7 @@ Version 1.1.14 work in progress
 - New #1785: Added CPasswordHelper (tom--)
 - New #2178: Added Catalan Translation (ArnauAregall)
 - New #2370: New template placeholders for CHtml::radioButtonList() and CHtml::checkBoxList() (creocoder)
+- Enh #305: Implemented cache->deleteByTag extending cache->delete() (alexgt9)
 
 Version 1.1.13 December 30, 2012
 --------------------------------

--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -666,6 +666,7 @@ class YiiBase
 		'CExpressionDependency' => '/caching/dependencies/CExpressionDependency.php',
 		'CFileCacheDependency' => '/caching/dependencies/CFileCacheDependency.php',
 		'CGlobalStateCacheDependency' => '/caching/dependencies/CGlobalStateCacheDependency.php',
+		'CTagCacheDependency' => '/caching/dependencies/CTagCacheDependency.php',
 		'CAttributeCollection' => '/collections/CAttributeCollection.php',
 		'CConfiguration' => '/collections/CConfiguration.php',
 		'CList' => '/collections/CList.php',

--- a/framework/caching/CCache.php
+++ b/framework/caching/CCache.php
@@ -55,6 +55,11 @@ abstract class CCache extends CApplicationComponent implements ICache, ArrayAcce
 	 */
 	public $keyPrefix;
 	/**
+	 * Id of the key containing tag dependency. We search the version of the tags in cache with this id.
+	 * @var string
+	 */
+	public $tagsDependencyId = 'tags_dependency_cache';
+	/**
 	 * @var boolean whether to md5-hash the cache key for normalization purposes. Defaults to true. Setting this property to false makes sure the cache
 	 * key will not be tampered when calling the relevant methods {@link get()}, {@link set()}, {@link add()} and {@link delete()}. This is useful if a Yii
 	 * application as well as an external application need to access the same cache pool (also see description of {@link keyPrefix} regarding this use case).
@@ -218,6 +223,25 @@ abstract class CCache extends CApplicationComponent implements ICache, ArrayAcce
 	{
 		Yii::trace('Deleting "'.$id.'" from cache','system.caching.'.get_class($this));
 		return $this->deleteValue($this->generateUniqueKey($id));
+	}
+	
+	/**
+	 * Increments the version of the tag in cache.
+	 * @param  string $tag The name of the tag.
+	 * @return boolean      True if succes, false if no tag with that name in cache.
+	 */
+	public function deleteByTag( $tag )
+	{
+		$tagVersions = $this->get( $this->tagsDependencyId );
+		if ( $tagVersions !== false && array_key_exists( $tag, $tagVersions ) ) 
+		{
+			$tagVersions[$tag]++;
+			$this->set( $this->tagsDependencyId, $tagVersions );
+
+			return true;
+		}
+		
+		return false;
 	}
 
 	/**

--- a/framework/caching/dependencies/CTagCacheDependency.php
+++ b/framework/caching/dependencies/CTagCacheDependency.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * CTagCacheDependency class file.
+ *
+ * @author Alejandro Pérez <alexgt9@gmail.com>
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright &copy; 2008-2011 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+/**
+ * CTagCacheDependency represents a dependency based on tags.
+ *
+ * CTagCacheDependency performs dependency checking if the tags selected
+ * are still valid.
+ * The dependency is reported as unchanged if and only if the tags has not been changed.
+ *
+ * @author Alejandro Pérez <alexgt9@gmail.com>
+ * @package system.caching.dependencies
+ * @since 1.0
+ */
+class CTagCacheDependency extends CCacheDependency
+{
+	/**
+	 * Tags that depends of.
+	 * @var array
+	 */
+	public $tags;
+
+	/**
+	 * Constructor.
+	 * @param array $tags to be dependant of.
+	 */
+	public function __construct( array $tags )
+	{
+		$this->tags = array_fill_keys( $tags, 1 );
+	}
+
+	/**
+	 * Generates the data needed to determine if dependency has been changed.
+	 * This method returns the array with the version of every tag.
+	 * @return mixed the data needed to determine if dependency has been changed.
+	 */
+	protected function generateDependentData()
+	{
+		$cache = Yii::app()->cache;
+		$tagsVersion = $cache->get( $cache->tagsDependencyId );
+
+		if ( $tagsVersion == false ) 
+		{
+			$tagsVersion = array();
+		}
+		$present = array_intersect_key( $tagsVersion, $this->tags );
+		$missing = array_diff_key( $this->tags, $tagsVersion );
+
+		if ( !empty( $missing ) ) 
+		{
+			$cache->set( $cache->tagsDependencyId, array_merge( $tagsVersion, $missing ) );
+		}
+
+		return array_merge( $present, $missing );
+	}
+}


### PR DESCRIPTION
Implements the option to delete cache depending with a tag. 
Added new CTagCacheDependency class that recives an array with the tags related.

And a method added to CCache, "deleteByTag" that delete all caches related with the tag.

This work with tag version. When a cache is set with tag dependency, it saves the actual version of each tag, initialy 1, then if you deleteByTag a especified tag, the version of that tag is incremented and invalidate all caches related with that tag.

Example te set dependency
```php
Yii::app()->cache->set( 'any_id', 'value', 0, new CTagCacheDependency( array( 'post', 'user' ) ) );
```

Deleting a tag
```php
Yii::app()->cache->deleteByTag( 'user' );
```