### PR TITLE
Fixes #2426: CDbCriteria::__wakeup() used to issue an error in case SQL containing fields were arrays and criteria parameters were specified.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,6 +51,7 @@ Version 1.1.14 work in progress
 - Bug #2398: Fixed 'Undefined variable: results' E_NOTICE at CProfileLogRoute (klimov-paul)
 - Bug #2402: Fixed clientValidation incorrectly rendered as HTML attribute, when used in CActiveForm::error() (mdomba)
 - Bug #2406: CUrlManager::$urlRuleClass now supports path alias value (as it was described in its PHPDoc before this fix) (resurtm)
+- Bug #2426: CDbCriteria::__wakeup() used to issue an error in case SQL containing fields were arrays and criteria parameters were specified (resurtm)
 - Enh: Better CFileLogRoute performance (Qiang, samdark)
 - Enh: Refactored CHttpRequest::getDelete and CHttpRequest::getPut not to use _restParams directly (samdark)
 - Enh #169: Allow to set AJAX request type for CListView and CGridView (klimov-paul)

--- a/framework/db/schema/CDbCriteria.php
+++ b/framework/db/schema/CDbCriteria.php
@@ -183,7 +183,7 @@ class CDbCriteria extends CComponent
 		}
 		if (!empty($map))
 		{
-			$sqlContentFieldNames = array(
+			$sqlContentFieldNames=array(
 				'select',
 				'condition',
 				'order',
@@ -191,8 +191,14 @@ class CDbCriteria extends CComponent
 				'join',
 				'having',
 			);
-			foreach($sqlContentFieldNames as $fieldName)
-				$this->$fieldName=strtr($this->$fieldName,$map);
+			foreach($sqlContentFieldNames as $field)
+			{
+				if(is_array($this->$field))
+					foreach($this->$field as $k=>$v)
+						$this->{$field}[$k]=strtr($v,$map);
+				else
+					$this->$field=strtr($this->$field,$map);
+			}
 		}
 		$this->params=$params;
 	}

--- a/tests/framework/db/schema/CDbCriteriaTest.php
+++ b/tests/framework/db/schema/CDbCriteriaTest.php
@@ -615,4 +615,24 @@ class CDbCriteriaTest extends CTestCase {
 		$this->assertEquals(str_replace($paramName,$newParamName,$criteria->select),$unserializedCriteria->select,'Criteria select has not been updated!');
 	}
 
+	/**
+	 * https://github.com/yiisoft/yii/issues/2426
+	 */
+	public function testWakeupWhenSqlContainingFieldsAreArraysWithSpecifiedParams()
+	{
+		CDbCriteria::$paramCount=10;
+		$criteria=new CDbCriteria();
+		$criteria->select=array('id','title');
+		$criteria->condition='id=:postId';
+		$criteria->params['postId']=1;
+		$criteria->compare('authorId',2);
+
+		$oldCriteria=clone $criteria;
+
+		$criteria=serialize($criteria);
+		CDbCriteria::$paramCount=10;
+		$criteria=unserialize($criteria);
+
+		$this->assertEquals($oldCriteria,$criteria);
+	}
 }


### PR DESCRIPTION
Fixes #2426: CDbCriteria::__wakeup() used to issue an error in case SQL containing fields were arrays and criteria parameters were specified.
