### PR TITLE
yiiactiveform.getInputContainer only returns innermost container

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,6 +54,7 @@ Version 1.1.14 work in progress
 - Bug #2423: Fixed CHtml::button() enforces "value" attribute for the image buttons (klimov-paul)
 - Bug #2426: CDbCriteria::__wakeup() used to issue an error in case SQL containing fields were arrays and criteria parameters were specified (resurtm)
 - Bug #2449: CSqlDataProvider causes an error when CDbCommand with enabled PDO::FETCH_OBJ mode used as SQL source (resurtm)
+- Bug #2452: yiiactiveform.getInputContainer should only return innermost container (blueyed)
 - Enh: Better CFileLogRoute performance (Qiang, samdark)
 - Enh: Refactored CHttpRequest::getDelete and CHttpRequest::getPut not to use _restParams directly (samdark)
 - Enh #169: Allow to set AJAX request type for CListView and CGridView (klimov-paul)

--- a/framework/web/js/source/jquery.yiiactiveform.js
+++ b/framework/web/js/source/jquery.yiiactiveform.js
@@ -223,17 +223,14 @@
 	};
 
 	/**
-	 * Returns the container element of the specified attribute.
+	 * Returns the (innermost) container element of the specified attribute.
 	 * @param attribute object the configuration for a particular attribute.
 	 * @param form the form jQuery object
 	 * @return jQuery the jQuery representation of the container
 	 */
 	$.fn.yiiactiveform.getInputContainer = function (attribute, form) {
-		if (attribute.inputContainer === undefined) {
-			return form.find('#' + attribute.inputID).closest('div');
-		} else {
-			return form.find(attribute.inputContainer).filter(':has("#' + attribute.inputID + '")');
-		}
+		var container = attribute.inputContainer === undefined ? 'div' : attribute.inputContainer;
+		return form.find('#' + attribute.inputID).closest(container);
 	};
 
 	/**


### PR DESCRIPTION
$.fn.yiiactiveform.getInputContainer might return multiple containers
(e.g. when using yii-bootstrap, and div.control-group elements get
nested).

This causes too many containers being toggled (with success/error CSS
classes).

Fixes #2452.