### PR TITLE
Fix CMysqlColumnSchema::extractLimit for ENUM values containing comma

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -55,6 +55,7 @@ Version 1.1.14 work in progress
 - Bug #2423: Fixed CHtml::button() enforces "value" attribute for the image buttons (klimov-paul)
 - Bug #2426: CDbCriteria::__wakeup() used to issue an error in case SQL containing fields were arrays and criteria parameters were specified (resurtm)
 - Bug #2449: CSqlDataProvider causes an error when CDbCommand with enabled PDO::FETCH_OBJ mode used as SQL source (resurtm)
+- Bug #2454: Fix CMysqlColumnSchema::extractLimit for ENUM values containing comma (blueyed)
 - Enh: Better CFileLogRoute performance (Qiang, samdark)
 - Enh: Refactored CHttpRequest::getDelete and CHttpRequest::getPut not to use _restParams directly (samdark)
 - Enh #169: Allow to set AJAX request type for CListView and CGridView (klimov-paul)

--- a/framework/db/schema/mysql/CMysqlColumnSchema.php
+++ b/framework/db/schema/mysql/CMysqlColumnSchema.php
@@ -54,16 +54,17 @@ class CMysqlColumnSchema extends CDbColumnSchema
 	 */
 	protected function extractLimit($dbType)
 	{
-		if (strncmp($dbType, 'enum', 4)===0 && preg_match('/\((.*)\)/',$dbType,$matches))
+		if (strncmp($dbType, 'enum', 4)===0 && preg_match('/\(([\'"])(.*)\\1\)/',$dbType,$matches))
 		{
-			$values = explode(',', $matches[1]);
+			// explode by (single or double) quote and comma (ENUM values may contain commas)
+			$values = explode($matches[1].','.$matches[1], $matches[2]);
 			$size = 0;
 			foreach($values as $value)
 			{
 				if(($n=strlen($value)) > $size)
 					$size=$n;
 			}
-			$this->size = $this->precision = $size-2;
+			$this->size = $this->precision = $size;
 		}
 		else
 			parent::extractLimit($dbType);


### PR DESCRIPTION
Fixes #2454.
