### PR TITLE
Added 'media' attribute support for css files in CClientScript packages

### DIFF
--- a/framework/web/CClientScript.php
+++ b/framework/web/CClientScript.php
@@ -353,8 +353,15 @@ class CClientScript extends CApplicationComponent
 			}
 			if(!empty($package['css']))
 			{
-				foreach($package['css'] as $css)
-					$cssFiles[$baseUrl.'/'.$css]='';
+				foreach($package['css'] as $media => $css) {
+					if (is_array($css) && !is_numeric($media)) {
+						foreach($css as $cssFileByMedia) {
+							$cssFiles[$baseUrl.'/'.$cssFileByMedia]=$media;
+						}
+					} else {
+						$cssFiles[$baseUrl.'/'.$css]='';
+					}
+				}
 			}
 		}
 		// merge in place


### PR DESCRIPTION
'components' => array(
    'clientScript'=>array(
        ...
        'package_all_css' => array(
            'css'       =>      array(
                'screen' => array(
                    'global.css', 'layout.css',
                ),
                'print' => array(
                    'homepage.css', 'notifier.css'
                ),
                'simple.css', 'another.css'
            ),
        ),
    ),
),
