### PR TITLE
Removed «поле» from 'Необходимо заполнить {attribute}.'

### DIFF
--- a/framework/messages/ru/yii.php
+++ b/framework/messages/ru/yii.php
@@ -225,7 +225,7 @@ return array (
   '{attribute} "{value}" has already been taken.' => '{attribute} "{value}" уже занят.',
   '{attribute} "{value}" is invalid.' => '{attribute} "{value}" неверно.',
   '{attribute} cannot accept more than {limit} files.' => '{attribute} не может принять более {limit} файлов.',
-  '{attribute} cannot be blank.' => 'Необходимо заполнить поле {attribute}.',
+  '{attribute} cannot be blank.' => 'Необходимо заполнить {attribute}.',
   '{attribute} is in the list.' => '{attribute} находится в списке.',
   '{attribute} is invalid.' => '{attribute} не верен.',
   '{attribute} is not a valid URL.' => '{attribute} не является правильным URL.',


### PR DESCRIPTION
Обычно поля называют в именительном падеже.

«Необходимо заполнить Наименование»
звучит лучше, чем
«Необходимо заполнить поле Наименование».

Если оставлять слово «поле», тогда лучше кавычки поставить:
«Необходимо заполнить поле „Наименование“»
Но это как-то слишком бюрократично звучит.
