### PR TITLE
fix issue #2484,call afterRender() after processOutput() in render()

### DIFF
--- a/framework/web/CController.php
+++ b/framework/web/CController.php
@@ -783,9 +783,9 @@ class CController extends CBaseController
 			if(($layoutFile=$this->getLayoutFile($this->layout))!==false)
 				$output=$this->renderFile($layoutFile,array('content'=>$output),true);
 
-			$this->afterRender($view,$output);
-
 			$output=$this->processOutput($output);
+
+			$this->afterRender($view,$output);
 
 			if($return)
 				return $output;


### PR DESCRIPTION
I use afterRender() to collect html contents then put it to .html file.

the comments of render() says:

> At the end, it calls {@link processOutput} to insert scripts and dynamic contents if they are available.
> The question is I can't collect these assets content generated by processOutput().

So I suggest that you can exchange the two call.Thus contents proocessed by processOutput() would convey to afterRender().

Thank you.
