### PR TITLE
Prevent SQL Exception

### DIFF
--- a/framework/web/CDbHttpSession.php
+++ b/framework/web/CDbHttpSession.php
@@ -126,6 +126,7 @@ class CDbHttpSession extends CHttpSession
 			$db->createCommand()->insert($this->sessionTableName, array(
 				'id'=>$newID,
 				'expire'=>time()+$this->getTimeout(),
+                'data'=>'',
 			));
 		}
 	}


### PR DESCRIPTION
RE: yiisoft/yii#2491

Added a value (empty string) for the `data` column when inserting a new row into the session table via `CDbHttpSession::regenerateID()`; the `data` column does not allow null values nor does it have a default value assigned so the CDbCommand::insert() method was throwing an exception when the SQL command failed.
