### PR TITLE
Update doc block for getRelated method in CActiveRecord class.

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -235,8 +235,15 @@ abstract class CActiveRecord extends CModel
 	 * If the relation is HAS_MANY or MANY_MANY, it will return an array of objects
 	 * or an empty array.
 	 * @param string $name the relation name (see {@link relations})
-	 * @param boolean $refresh whether to reload the related objects from database. Defaults to false. If the current record is not a new record and it does not have the related objects loaded they will be retrieved from the database even if this is set to false. If the current record is a new record and this value is false, the related objects will not be retrieved from the database.
-	 * @param mixed $params array or CDbCriteria object with additional parameters that customize the query conditions as specified in the relation declaration. If this is supplied the related record(s) will be retrieved from the database regardless of the value or {@link $refresh}. The related record(s) retrieved when this is supplied will only be returned by this method and will not be loaded into the current record's relation. The value of the relation prior to running this method will still be available for the current record.
+	 * @param boolean $refresh whether to reload the related objects from database. Defaults to false.
+	 * If the current record is not a new record and it does not have the related objects loaded they
+	 * will be retrieved from the database even if this is set to false.
+	 * If the current record is a new record and this value is false, the related objects will not be
+	 * retrieved from the database.
+	 * @param mixed $params array or CDbCriteria object with additional parameters that customize the query conditions as specified in the relation declaration.
+	 * If this is supplied the related record(s) will be retrieved from the database regardless of the value or {@link $refresh}.
+	 * The related record(s) retrieved when this is supplied will only be returned by this method and will not be loaded into the current record's relation.
+	 * The value of the relation prior to running this method will still be available for the current record if this is supplied.
 	 * @return mixed the related object(s).
 	 * @throws CDbException if the relation is not specified in {@link relations}.
 	 */


### PR DESCRIPTION
The documentation for getRelated did not reflect some of the behavior of the method.
