### PR TITLE
[proposal/idea] Fixes #2517: ability to reverse DB criteria order merge.

### DIFF
--- a/framework/db/schema/CDbCriteria.php
+++ b/framework/db/schema/CDbCriteria.php
@@ -153,7 +153,7 @@ class CDbCriteria extends CComponent
 	 * @var string
 	 * @since 1.1.14
 	 */
-	public $reverseOrderMerge=true;
+	public $reverseOrderMerge=false;
 
 	/**
 	 * Constructor.


### PR DESCRIPTION
Fixes #2517. How to use it:

``` php
class ActiveRecord extends CActiveRecord
{
    public function getDbCriteria($createIfNull=true)
    {
        if(($criteria=parent::getDbCriteria($createIfNull))!==null)
            $criteria->reverseOrderMerge=true;
        return $criteria;
    }
}

class Test extends ActiveRecord
{
    public static function model($className=__CLASS__)
    {
        return parent::model($className);
    }

    public function scopes()
    {
        $ta=$this->tableAlias;
        return array(
            'order1'=>array(
                'order'=>$ta.'.order1 DESC',
            ),
            'order2'=>array(
                'order'=>$ta.'.order2 DESC',
            ),
        );
    }
}

$criteria=new CDbCriteria(array(
    'scopes'=>array('order1','order2'),
));
$models=Test::model()->findAll($criteria);
```

@creocoder, your opinion on this?
