### PR TITLE
Changes for #2516

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -68,6 +68,7 @@ Version 1.1.14 work in progress
 - Bug #2454: Fix CMysqlColumnSchema::extractLimit for ENUM values containing comma (blueyed)
 - Bug #2491: Prevent SQL exception being thrown when inserting a row into the session table whilst regenerating the session ID (mynameiszanders)
 - Bug #2502: Fix match controller in access rule, match uniqueId instead id (slavcodev)
+- Bug #2516: Fixed the bug that some $.fn.yiiGridView methods were not working always if a custom CGridView::template was used (buakos)
 - Enh: Better CFileLogRoute performance (Qiang, samdark)
 - Enh: Refactored CHttpRequest::getDelete and CHttpRequest::getPut not to use _restParams directly (samdark)
 - Enh #118: Proper support of namespaced models in forms (LastDragon-ru, Ekstazi, pgaultier)

--- a/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
+++ b/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
@@ -18,7 +18,7 @@
 	 */
 	selectCheckedRows = function (gridId) {
 		var settings = gridSettings[gridId],
-			table = $('#' + gridId).children('.' + settings.tableClass);
+			table = $('#' + gridId).find('.' + settings.tableClass);
 
 		table.children('tbody').find('input.select-on-check').filter(':checked').each(function () {
 			$(this).closest('tr').addClass('selected');
@@ -169,7 +169,7 @@
 							var $currentGrid = $('#' + id),
 								$checks = $('input.select-on-check', $currentGrid),
 								$checksAll = $('input.select-on-check-all', $currentGrid),
-								$rows = $currentGrid.children('.' + settings.tableClass).children('tbody').children();
+								$rows = $currentGrid.find('.' + settings.tableClass).children('tbody').children();
 							if (this.checked) {
 								$rows.addClass('selected');
 								$checks.prop('checked', true);
@@ -215,7 +215,7 @@
 		 */
 		getRow: function (row) {
 			var sClass = gridSettings[this.attr('id')].tableClass;
-			return this.children('.' + sClass).children('tbody').children('tr').eq(row).children();
+			return this.find('.' + sClass).children('tbody').children('tr').eq(row).children();
 		},
 
 		/**
@@ -225,7 +225,7 @@
 		 */
 		getColumn: function (column) {
 			var sClass = gridSettings[this.attr('id')].tableClass;
-			return this.children('.' + sClass).children('tbody').children('tr').children('td:nth-child(' + (column + 1) + ')');
+			return this.find('.' + sClass).children('tbody').children('tr').children('td:nth-child(' + (column + 1) + ')');
 		},
 
 		/**


### PR DESCRIPTION
#2516

Using `find` instead of `children` everywhere for finding the table in the grid.
So eg. `<div class="items-wrapper">{items}</div>` should always work now.
