### PR TITLE
Namespace in the component configuration

### DIFF
--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -192,7 +192,7 @@ class YiiBase
 		else
 			throw new CException(Yii::t('yii','Object configuration must be an array containing a "class" element.'));
 
-		if(!class_exists($type,false))
+		if(!class_exists($type))
 			$type=Yii::import($type,true);
 
 		if(($n=func_num_args())>1)

--- a/framework/yiilite.php
+++ b/framework/yiilite.php
@@ -83,7 +83,7 @@ class YiiBase
 		}
 		else
 			throw new CException(Yii::t('yii','Object configuration must be an array containing a "class" element.'));
-		if(!class_exists($type,false))
+		if(!class_exists($type))
 			$type=Yii::import($type,true);
 		if(($n=func_num_args())>1)
 		{


### PR DESCRIPTION
Hello!

I use in projects Composer to manage dependencies vendors and also for **autoload classes**.

I can use the namespace to create yii application:

``` php
Yii::createApplication('\MyNamespace\WebApplication', $config)->run();
```

But can not use the namespace in the component configuration:

``` php
'behaviors' => array(
     'mybehavior' => array(
         'class' =>  '\MyNamespace\Class',
     ),
 ),
```

I can not find a more elegant solution .. May have any thoughts?
