### PR TITLE
Fixed DB interactive=false bug (#2558)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -77,6 +77,7 @@ Version 1.1.14 work in progress
 - Bug #2524: Fixed incorrect HTTPS detection (resurtm)
 - Bug #2551: CWebUser::loginRequired() AJAX response now properly sends 403 (creocoder)
 - Bug #2554: Fixed CRangeValidator when allowEmpty is false (samdark, creocoder)
+- Bug #2555: Fixed DB migration --interactive=false bug (acorncom)
 - Enh: Better CFileLogRoute performance (Qiang, samdark)
 - Enh: Refactored CHttpRequest::getDelete and CHttpRequest::getPut not to use _restParams directly (samdark)
 - Enh #118: Proper support of namespaced models in forms (LastDragon-ru, Ekstazi, pgaultier)

--- a/framework/cli/commands/MigrateCommand.php
+++ b/framework/cli/commands/MigrateCommand.php
@@ -369,7 +369,7 @@ class MigrateCommand extends CConsoleCommand
 
 	public function confirm($message,$default=false)
 	{
-		if(!$this->interactive)
+        if ($this->interactive == 'false' || !$this->interactive)
 			return true;
 		return parent::confirm($message,$default);
 	}


### PR DESCRIPTION
Apparently if you pass in:

```
--interactive=false
```

the interactive variable is used as a string.  Using a 0 gets around it, but this makes our docs consistent with the code ;-)
