### PR TITLE
Fixes problem when session is not closed

### DIFF
--- a/framework/web/CHttpSession.php
+++ b/framework/web/CHttpSession.php
@@ -90,7 +90,7 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 
 		if($this->autoStart)
 			$this->open();
-		register_shutdown_function(array($this,'close'));
+		Yii::app()->attachEventHandler('onEndRequest', array($this,'close'));
 	}
 
 	/**


### PR DESCRIPTION
CApplication::end() may call exit which stops propagation and makes the other callbacks in register_shutdown_function to never run.
If the session needs to be closed always on the end of the request, which is my case using a custom session component, then whenever you call Yii::app()->end(0,true) cancel the session::close registered callback in register_shutdown_function by calling exit
This fix will fix it.