### PR TITLE
Update CBehavior.php

### DIFF
--- a/framework/base/CBehavior.php
+++ b/framework/base/CBehavior.php
@@ -61,8 +61,12 @@ class CBehavior extends CComponent implements IBehavior
 	 */
 	public function detach($owner)
 	{
-		foreach($this->events() as $event=>$handler)
-			$owner->detachEventHandler($event,array($this,$handler));
+		foreach($this->events() as $events )
+		{
+			foreach( $events as $event => $handler ){
+				$owner->detachEventHandler($event,array($this,$handler));
+			}
+		}
 		$this->_owner=null;
 		$this->_enabled=false;
 	}
@@ -95,8 +99,13 @@ class CBehavior extends CComponent implements IBehavior
 				$this->_attachEventHandlers();
 			else
 			{
-				foreach($this->events() as $event=>$handler)
-					$this->_owner->detachEventHandler($event,array($this,$handler));
+				foreach($this->events() as $events )
+				{
+					foreach( $events as $envent => $handler )
+					{
+						$this->_owner->detachEventHandler($event,array($this,$handler));
+					}
+				}
 			}
 		}
 		$this->_enabled=$value;
@@ -105,10 +114,13 @@ class CBehavior extends CComponent implements IBehavior
 	private function _attachEventHandlers()
 	{
 		$class=new ReflectionClass($this);
-		foreach($this->events() as $event=>$handler)
+		foreach($this->events() as $events )
 		{
-			if($class->getMethod($handler)->isPublic())
-				$this->_owner->attachEventHandler($event,array($this,$handler));
+			foreach( $events as $event=>$handler )
+			{
+				if($class->getMethod($handler)->isPublic())
+					$this->_owner->attachEventHandler($event,array($this,$handler));
+			}
 		}
 	}
 }


### PR DESCRIPTION
这个改动 能使在 events 函数中 对 同一个 envent 绑定多个 handler
如 function events(){
             return array(
                             array('onBeforeSave' => 'handler1'),
                             array('onBeforeSave' => 'handler2')
              );
}
