### PR TITLE
CApplication allow successfully use $this inside config file

### DIFF
--- a/framework/base/CApplication.php
+++ b/framework/base/CApplication.php
@@ -127,8 +127,9 @@ abstract class CApplication extends CModule
 	public function __construct($config=null)
 	{
 		Yii::setApplication($this);
+		$this->initSystemHandlers();
+		$this->registerCoreComponents();
 
-		// set basePath at early as possible to avoid trouble
 		if(is_string($config))
 			$config=require($config);
 		if(isset($config['basePath']))
@@ -143,14 +144,9 @@ abstract class CApplication extends CModule
 		Yii::setPathOfAlias('ext',$this->getBasePath().DIRECTORY_SEPARATOR.'extensions');
 
 		$this->preinit();
-
-		$this->initSystemHandlers();
-		$this->registerCoreComponents();
-
 		$this->configure($config);
 		$this->attachBehaviors($this->behaviors);
 		$this->preloadComponents();
-
 		$this->init();
 	}
 


### PR DESCRIPTION
Compare this `config/main.php`:

``` php
$request = Yii::createComponent(array('class' => 'CHttpRequest'));

return array(
    ...
    'components' => array(
        ...
        'thumbnail' => array(
            'class' => 'Thumbnail',
            'basePath' => dirname(dirname($request->scriptFile)) . DIRECTORY_SEPARATOR . 'thumbs',
            'baseUrl' => dirname($request->baseUrl) . '/thumbs',
            'uploadPath' => dirname(dirname($request->scriptFile)) . DIRECTORY_SEPARATOR . 'uploads',
            'uploadUrl' => dirname($request->baseUrl) . '/uploads',
        ),
        ...
    ),
    ...
);
```

And this `config/main.php`:

``` php
return array(
    ...
    'components' => array(
        ...
        'thumbnail' => array(
            'class' => 'Thumbnail',
            'basePath' => dirname(dirname($this->request->scriptFile)) . DIRECTORY_SEPARATOR . 'thumbs',
            'baseUrl' => dirname($this->request->baseUrl) . '/thumbs',
            'uploadPath' => dirname(dirname($this->request->scriptFile)) . DIRECTORY_SEPARATOR . 'uploads',
            'uploadUrl' => dirname($this->request->baseUrl) . '/uploads',
        ),
        ...
    ),
    ...
);
```

This change allow use core components in config file without use `Yii::createComponent()` hack.

> // set basePath at early as possible to avoid trouble 

There is no any troubles to set basePath a little later ;)
