### PR TITLE
Added the event afterFindWithAttributes to CActiveRecord.php and an asso...

### DIFF
--- a/framework/db/ar/CActiveRecordBehavior.php
+++ b/framework/db/ar/CActiveRecordBehavior.php
@@ -36,6 +36,7 @@ class CActiveRecordBehavior extends CModelBehavior
 			'onBeforeFind'=>'beforeFind',
 			'onAfterFind'=>'afterFind',
 			'onBeforeCount'=>'beforeCount',
+			'onAfterFindWithAttributes'=>'afterFindWithAttributes',
 		));
 	}
 
@@ -109,6 +110,17 @@ class CActiveRecordBehavior extends CModelBehavior
 	 * @since 1.1.14
 	 */
 	protected function beforeCount($event)
+	{
+	}
+
+	/**
+	 * Responds to {@link CActiveRecord::onAfterFindWithAttributes} event.
+	 * Override this method and make it public if you want to handle the corresponding event
+	 * of the {@link CBehavior::owner owner}.
+	 * @param CEvent $event event parameter
+	 * @since 1.1.14
+	 */
+	protected function afterFindWithAttributes($event)
 	{
 	}
 }


### PR DESCRIPTION
This PR adds a new event to CActiveRecord called onAfterFindWithAttributes and an associated event handler in CActiveRecordBehavior. This event is identical to onAfterFind except that the CEvent's params property is set to the value of the argument of the parameter called arguments of populateRecord method of CActiveRecord. It would be cleaner if this was done using the onAfterFind method, but that would have broken BC.

Normally additional attributes passed to the populateRecord method are ignored and there is no way to hook these attributes without extending CActiveRecord and overriding either the populateRecord method or instantiate method of CActiveRecord. The onAfterFindWithAttributes event creates this missing hook.

In my case I have several queries which select additional values from either joined tables or sub queries that do not have attributes in the CActiveRecord and are therefor silently ignored by populateRecord. However, those additional values are important to the configuration of the CActiveRecord instance. Using this implementation it is possible to appropriately configure a CActiveRecord instance based on values returned by a find query that are not defined as table columns, properties or getters/setters in the CActiveRecord.