### PR TITLE
Fix autoloading namespaced classes

### DIFF
--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -270,6 +270,8 @@ class YiiBase
 
 		if(($pos=strrpos($alias,'\\'))!==false) // a class name in PHP 5.3 namespace format
 		{
+			if(class_exists($alias, true)) // check if there's an autoloader that can find this
+				return $alias;
 			$namespace=str_replace('\\','.',ltrim(substr($alias,0,$pos),'\\'));
 			if(($path=self::getPathOfAlias($namespace))!==false)
 			{


### PR DESCRIPTION
This is a proper fix for #2556. It makes it possible to use e.g. `'class'=>'\namespace\folder\ClassName'` in a component configuration.

As far as I can tell this change has no side effects.
