### PR TITLE
(CModel::prependValidator(), CModel::appendValidator()) (Enh #2259 rework)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -120,7 +120,7 @@ Version 1.1.14 work in progress
 - Enh #2213: Added comment with hint on ajax validaton which may lead to duplicate entries in the database to gii form template (elmig, cebe)
 - Enh #2217: Support of the empty option for CHtml::radioButtonList() has been introduced (resurtm)
 - Enh #2254: CForm::$showErrors property has been added, it controls whether error elements of the form attributes should be rendered (resurtm)
-- Enh #2259: Allow append and prepend new validators on the fly (gusnips, creocoder)
+- Enh #2259: Allow appending and prepending new validators on the fly (gusnips, creocoder)
 - Enh #2275: Added primary log rotation by copy and truncate to CFileLogRoute (bdstevens)
 - Enh #2415: Cancel current ajax request before create a new one in CGridView and CListView (gusnips)
 - Enh #2416: Avoid instantiating HTMLPurifier on each CHtmlPurifier::purify() call. Allow to pass array as argument of CHtmlPurifier::purify() (twisted1919)

--- a/framework/base/CModel.php
+++ b/framework/base/CModel.php
@@ -304,7 +304,7 @@ abstract class CModel extends CComponent implements IteratorAggregate, ArrayAcce
 	public function prependValidator($name,$attributes,$params=array())
 	{
 		$validator=CValidator::createValidator($name,$this,$attributes,$params);
-		$this->getValidatorList()->insertAt(0, $validator);
+		$this->getValidatorList()->insertAt(0,$validator);
 		return $this;
 	}
 

--- a/tests/framework/base/CModelTest.php
+++ b/tests/framework/base/CModelTest.php
@@ -241,9 +241,26 @@ class CModelTest extends CTestCase
 	}
 
 	/**
-	 * @see https://github.com/yiisoft/yii/pull/2259
+	 * @see https://github.com/yiisoft/yii/pull/2607
 	 */
-	public function testAddValidator()
+	public function testPrependValidator()
+	{
+		$model=new NewModel();
+		$scenario='test';
+		$model->scenario=$scenario;
+		$model->addValidator('required','firstName',array('on'=>$scenario));
+		$this->assertTrue($model->isAttributeRequired('firstName'));
+		$validators = $model->getValidatorList();
+		//gets first validator in the list
+		$validator = $validators->itemAt(0);
+		$this->assertInstanceOf('CRequiredValidator',$validator);
+		$this->assertSame($validator->attributes[0],'firstName');
+	}
+
+	/**
+	 * @see https://github.com/yiisoft/yii/pull/2607
+	 */
+	public function testAppendValidator()
 	{
 		$model=new NewModel();
 		$scenario='test';


### PR DESCRIPTION
Previously there was added `CModel::addValidator()`. This is absolluttley wrong from API point of view. If we allow append validator to the list we should allow prepend validator in the list. Because validator order sometimes is very important thing. Also prepend need for behaviors like this:

``` php
namespace common\components;

class DefaultNullBehavior extends \CModelBehavior
{
    public function beforeValidate($event)
    {
        $this->owner->prependValidator('default', $this->owner->safeAttributeNames, array('value' => null));
    }
}

```
