### PR TITLE
Fixes issue #2613 where CButtonColumn click is broken when options['class']='myclass'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -82,6 +82,7 @@ Version 1.1.14 work in progress
 - Bug #2565: CCaptchaAction in ImageMagick mode used to issue an exception in case $backColor or $foreColor have had leading zeros (resurtm)
 - Bug #2581: Fixed the bug with empty ajaxVar in jquery.yiilistview.js and jquery.yiigridview.js (seregagl)
 - Bug #2602: CUrlValidator and CEmailValidator now works correctly with display_errors = on and validateIDN = true (creocoder)
+- Bug #2613: CButtonColumn breaks "click" when you set option['class'] = "myclass" (luislobo)
 - Enh: Better CFileLogRoute performance (Qiang, samdark)
 - Enh: Refactored CHttpRequest::getDelete and CHttpRequest::getPut not to use _restParams directly (samdark)
 - Enh #100: CLogFilter::$logVars can now be array of arrays intended for designating particular items of the $GLOBALS (resurtm, tomtomsen)

--- a/framework/zii/widgets/grid/CButtonColumn.php
+++ b/framework/zii/widgets/grid/CButtonColumn.php
@@ -199,8 +199,6 @@ class CButtonColumn extends CGridColumn
 				unset($this->buttons[$id]);
 			elseif(isset($button['click']))
 			{
-				if(!isset($button['options']['class']))
-					$this->buttons[$id]['options']['class']=$id;
 				if(!($button['click'] instanceof CJavaScriptExpression))
 					$this->buttons[$id]['click']=new CJavaScriptExpression($button['click']);
 			}
@@ -295,8 +293,7 @@ EOD;
 			if(isset($button['click']))
 			{
 				$function=CJavaScript::encode($button['click']);
-				$class=preg_replace('/\s+/','.',$button['options']['class']);
-				$js[]="jQuery(document).on('click','#{$this->grid->id} a.{$class}',$function);";
+				$js[]="jQuery(document).on('click','#{$this->grid->id} a#{$id}',$function);";
 			}
 		}
 
@@ -339,6 +336,8 @@ EOD;
 		$label=isset($button['label']) ? $button['label'] : $id;
 		$url=isset($button['url']) ? $this->evaluateExpression($button['url'],array('data'=>$data,'row'=>$row)) : '#';
 		$options=isset($button['options']) ? $button['options'] : array();
+		if(!isset($options['id']))
+			$options['id']=$id;
 		if(!isset($options['title']))
 			$options['title']=$label;
 		if(isset($button['imageUrl']) && is_string($button['imageUrl']))

--- a/tests/framework/zii/widgets/grid/CButtonColumnTest.php
+++ b/tests/framework/zii/widgets/grid/CButtonColumnTest.php
@@ -6,7 +6,7 @@ class CButtonColumnTest extends CTestCase
 {
 	public function testCallbackEncoding()
 	{
-		$expected = "jQuery(document).on('click','#grid1 a.view',function() { /* callback */ });";
+		$expected = "jQuery(document).on('click','#grid1 a#view',function() { /* callback */ });";
 
 		$out=$this->getWidgetScript('js:function() { /* callback */ }');
 		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);


### PR DESCRIPTION
Fixes issue #2613 where CButtonColumn click is broken when options['class']='myclass'
This was noticed when adding several custom button columns with their click property was set and also a custom class was set for the button.