### PR TITLE
Form error messages were not encoded when rendered

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2004,7 +2004,7 @@ EOD;
 				foreach($errors as $error)
 				{
 					if($error!='')
-						$content.="<li>$error</li>\n";
+						$content.='<li>'.self::encode($error)."</li>\n";
 					if($firstError)
 						break;
 				}
@@ -2040,7 +2040,7 @@ EOD;
 		{
 			if(!isset($htmlOptions['class']))
 				$htmlOptions['class']=self::$errorMessageCss;
-			return self::tag(self::$errorContainerTag,$htmlOptions,$error);
+			return self::tag(self::$errorContainerTag,$htmlOptions,self::encode($error));
 		}
 		else
 			return '';


### PR DESCRIPTION
Error messages should be encoded as they may contain html.
CHtml::error() and CHtml::errorSummary() were outputting them as is
