### PR TITLE
Repeated message with different punctuation and case

### DIFF
--- a/framework/db/ar/CActiveFinder.php
+++ b/framework/db/ar/CActiveFinder.php
@@ -1517,7 +1517,7 @@ class CStatElement
 		$tableAlias=$model->getTableAlias(true);
 
 		if(($joinTable=$builder->getSchema()->getTable($joinTableName))===null)
-			throw new CDbException(Yii::t('yii','The relation "{relation}" in active record class "{class}" is not specified correctly. The join table "{joinTable}" given in the foreign key cannot be found in the database.',
+			throw new CDbException(Yii::t('yii','The relation "{relation}" in active record class "{class}" is not specified correctly: the join table "{joinTable}" given in the foreign key cannot be found in the database.',
 				array('{class}'=>get_class($this->_parent->model), '{relation}'=>$relation->name, '{joinTable}'=>$joinTableName)));
 
 		$fks=preg_split('/\s*,\s*/',$keys,-1,PREG_SPLIT_NO_EMPTY);


### PR DESCRIPTION
The message in line 1520 is different from the ones in lines 542 and 1034, only differ in punctuation and case. Changed 1520 to match 542 and 1034. Message from 1520 should disappear in next "build message" command run.
