### PR TITLE
Doc of cryptoStrong in CSecMan::generateRandomBytes

### DIFF
--- a/framework/base/CSecurityManager.php
+++ b/framework/base/CSecurityManager.php
@@ -404,8 +404,7 @@ class CSecurityManager extends CApplicationComponent
 
 	/**
 	 * Generate a pseudo random block of data using several sources. On some systems this may be a bit
-	 * better than PHP's {@link mt_rand} built-in function, which is not really random. Users should
-     * review the
+	 * better than PHP's {@link mt_rand} built-in function, which is not really random.
 	 * @return string of 64 pseudo random bytes.
 	 * @since 1.1.14
 	 */


### PR DESCRIPTION
As promised, documentation explaining exactly what a user can expect from CSecurityManager::generateRandomBytes() with in either case of $cryptographicallyStrong true or false.

I left out a warning of possible confusion between empty string result and bool false.
