### PR TITLE
Fixes #627: CActiveRecord not respecting attributeNames() overrides

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -57,7 +57,7 @@ abstract class CActiveRecord extends CModel
 	private static $_attributeNames=array();	// class name => attribute names
 
 	private $_new=false;						// whether this instance is new or not
-	private $_attributes=array();				// attribute name => attribute value
+	private $_dbAttributes=array();				// attribute name => attribute value
 	private $_related=array();					// attribute name => related objects
 	private $_c;								// query criteria (used by finder only)
 	private $_pk;								// old primary key value
@@ -77,7 +77,7 @@ abstract class CActiveRecord extends CModel
 
 		$this->setScenario($scenario);
 		$this->setIsNewRecord(true);
-		$this->_attributes=$this->getMetaData()->attributeDefaults;
+		$this->_dbAttributes=$this->getMetaData()->attributeDefaults;
 
 		$this->init();
 
@@ -134,8 +134,8 @@ abstract class CActiveRecord extends CModel
 	 */
 	public function __get($name)
 	{
-		if(isset($this->_attributes[$name]))
-			return $this->_attributes[$name];
+		if(isset($this->_dbAttributes[$name]))
+			return $this->_dbAttributes[$name];
 		elseif(isset($this->getMetaData()->columns[$name]))
 			return null;
 		elseif(isset($this->_related[$name]))
@@ -172,7 +172,7 @@ abstract class CActiveRecord extends CModel
 	 */
 	public function __isset($name)
 	{
-		if(isset($this->_attributes[$name]))
+		if(isset($this->_dbAttributes[$name]))
 			return true;
 		elseif(isset($this->getMetaData()->columns[$name]))
 			return false;
@@ -193,7 +193,7 @@ abstract class CActiveRecord extends CModel
 	public function __unset($name)
 	{
 		if(isset($this->getMetaData()->columns[$name]))
-			unset($this->_attributes[$name]);
+			unset($this->_dbAttributes[$name]);
 		elseif(isset($this->getMetaData()->relations[$name]))
 			unset($this->_related[$name]);
 		else
@@ -712,8 +712,8 @@ abstract class CActiveRecord extends CModel
 	{
 		if(property_exists($this,$name))
 			return $this->$name;
-		elseif(isset($this->_attributes[$name]))
-			return $this->_attributes[$name];
+		elseif(isset($this->_dbAttributes[$name]))
+			return $this->_dbAttributes[$name];
 	}
 
 	/**
@@ -729,7 +729,7 @@ abstract class CActiveRecord extends CModel
 		if(property_exists($this,$name))
 			$this->$name=$value;
 		elseif(isset($this->getMetaData()->columns[$name]))
-			$this->_attributes[$name]=$value;
+			$this->_dbAttributes[$name]=$value;
 		else
 			return false;
 		return true;
@@ -773,7 +773,7 @@ abstract class CActiveRecord extends CModel
 	 */
 	public function getAttributes($names=true)
 	{
-		$attributes=$this->_attributes;
+		$attributes=$this->_dbAttributes;
 		foreach($this->getMetaData()->columns as $name=>$column)
 		{
 			if(property_exists($this,$name))
@@ -1259,14 +1259,14 @@ abstract class CActiveRecord extends CModel
 		Yii::trace(get_class($this).'.refresh()','system.db.ar.CActiveRecord');
 		if(($record=$this->findByPk($this->getPrimaryKey()))!==null)
 		{
-			$this->_attributes=array();
+			$this->_dbAttributes=array();
 			$this->_related=array();
 			foreach($this->getMetaData()->columns as $name=>$column)
 			{
 				if(property_exists($this,$name))
 					$this->$name=$record->$name;
 				else
-					$this->_attributes[$name]=$record->$name;
+					$this->_dbAttributes[$name]=$record->$name;
 			}
 			return true;
 		}
@@ -1878,7 +1878,7 @@ abstract class CActiveRecord extends CModel
 				if(property_exists($record,$name))
 					$record->$name=$value;
 				elseif(isset($md->columns[$name]))
-					$record->_attributes[$name]=$value;
+					$record->_dbAttributes[$name]=$value;
 			}
 			$record->_pk=$record->getPrimaryKey();
 			$record->attachBehaviors($record->behaviors());

--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -54,6 +54,7 @@ abstract class CActiveRecord extends CModel
 
 	private static $_models=array();			// class name => model
 	private static $_md=array();				// class name => meta data
+	private static $_attributeNames=array();	// class name => attribute names
 
 	private $_new=false;						// whether this instance is new or not
 	private $_attributes=array();				// attribute name => attribute value
@@ -424,7 +425,10 @@ abstract class CActiveRecord extends CModel
 	{
 		$className=get_class($this);
 		if(array_key_exists($className,self::$_md))
+		{
 			unset(self::$_md[$className]);
+			unset(self::$_attributeNames[$className]);
+		}
 	}
 
 	/**
@@ -580,7 +584,23 @@ abstract class CActiveRecord extends CModel
 	 */
 	public function attributeNames()
 	{
-		return array_keys($this->getMetaData()->columns);
+		$className=get_class($this);
+		if(!isset(self::$_attributeNames[$className]))
+		{
+			$class=new ReflectionClass(get_class($this));
+			$names=array();
+			foreach($class->getProperties() as $property)
+			{
+				$name=$property->getName();
+				if($property->isPublic() && !$property->isStatic())
+					$names[]=$name;
+			}
+			$dbAttributeNames = array_keys($this->getMetaData()->columns);
+			self::$_attributeNames = array_merge(self::$_attributeNames, $dbAttributeNames);
+			return self::$_attributeNames[$className]=$names;
+		}
+		else
+			return self::$_attributeNames[$className];
 	}
 
 	/**

--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -769,33 +769,6 @@ abstract class CActiveRecord extends CModel
 	}
 
 	/**
-	 * Returns all column attribute values.
-	 * Note, related objects are not returned.
-	 * @param mixed $names names of attributes whose value needs to be returned.
-	 * If this is true (default), then all attribute values will be returned, including
-	 * those that are not loaded from DB (null will be returned for those attributes).
-	 * If this is null, all attributes except those that are not loaded from DB will be returned.
-	 * @return array attribute values indexed by attribute names.
-	 */
-	public function getAttributes($names=true)
-	{
-		$attributes=array();
-		foreach($this->attributeNames() as $name)
-		{
-			$attributes[$name] = $this->getAttribute($name);
-		}
-		if(is_array($names))
-		{
-			$attrs=array();
-			foreach($names as $name)
-				$attrs[$name]=isset($attributes[$name])?$attributes[$name]:null;
-			return $attrs;
-		}
-		else
-			return $attributes;
-	}
-
-	/**
 	 * Saves the current record.
 	 *
 	 * The record is inserted as a row into the database table if its {@link isNewRecord}

--- a/tests/framework/db/ar/CActiveRecord2Test.php
+++ b/tests/framework/db/ar/CActiveRecord2Test.php
@@ -77,7 +77,16 @@ class CActiveRecord2Test extends CTestCase
 		$this->assertTrue($model->hasAttribute('id'));
 		$this->assertFalse($model->hasAttribute('comments'));
 		$this->assertFalse($model->hasAttribute('foo'));
-		$this->assertEquals(array(),$model->getAttributes(false));
+		$this->assertEquals(
+			array(
+				'id'=>null,
+				'title'=>null,
+				'create_time'=>null,
+				'author_id'=>null,
+				'content'=>null
+			),
+			$model->getAttributes(false)
+		);
 
 		$post=new Post2;
 		$this->assertNull($post->id);
@@ -182,7 +191,16 @@ class CActiveRecord2Test extends CTestCase
 	public function testInsert()
 	{
 		$post=new Post2;
-		$this->assertEquals(array(),$post->getAttributes(false));
+		$this->assertEquals(
+			array(
+				'id'=>null,
+				'title'=>null,
+				'create_time'=>null,
+				'author_id'=>null,
+				'content'=>null
+			),
+			$post->getAttributes(false)
+		);
 		$post->title='test post 1';
 		$post->create_time='2004-10-19 10:23:54';
 		$post->author_id=1;
@@ -190,12 +208,16 @@ class CActiveRecord2Test extends CTestCase
 		$this->assertTrue($post->isNewRecord);
 		$this->assertNull($post->id);
 		$this->assertTrue($post->save());
-		$this->assertEquals(array(
-			'id'=>6,
-			'title'=>'test post 1',
-			'create_time'=>$post->create_time,
-			'author_id'=>1,
-			'content'=>'test post content 1'),$post->getAttributes());
+		$this->assertEquals(
+			array(
+				'id'=>6,
+				'title'=>'test post 1',
+				'create_time'=>$post->create_time,
+				'author_id'=>1,
+				'content'=>'test post content 1'
+			),
+			$post->getAttributes()
+		);
 		$this->assertFalse($post->isNewRecord);
 		$this->assertEquals($post->getAttributes(false),Post2::model()->findByPk($post->id)->getAttributes(false));
 	}
@@ -322,7 +344,16 @@ class CActiveRecord2Test extends CTestCase
 	public function testPublicAttribute()
 	{
 		$post=new PostExt2;
-		$this->assertEquals(array('id'=>null,'title'=>'default title'),$post->getAttributes(false));
+		$this->assertEquals(
+			array(
+				'id'=>null,
+				'title'=>'default title',
+				'create_time'=>null,
+				'author_id'=>null,
+				'content'=>null
+			),
+			$post->getAttributes(false)
+		);
 		$post=Post2::model()->findByPk(1);
 		$this->assertEquals(array(
 			'id'=>1,

--- a/tests/framework/db/ar/CActiveRecordTest.php
+++ b/tests/framework/db/ar/CActiveRecordTest.php
@@ -161,12 +161,16 @@ class CActiveRecordTest extends CTestCase
 		$this->assertTrue($post->isNewRecord);
 		$this->assertNull($post->id);
 		$this->assertTrue($post->save());
-		$this->assertEquals(array(
-			'id'=>6,
-			'title'=>'test post 1',
-			'create_time'=>$post->create_time,
-			'author_id'=>1,
-			'content'=>'test post content 1'),$post->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>6,
+				'title'=>'test post 1',
+				'create_time'=>$post->create_time,
+				'author_id'=>1,
+				'content'=>'test post content 1'
+			),
+			$post->attributes
+		);
 		$this->assertFalse($post->isNewRecord);
 		$this->assertEquals($post->attributes,Post::model()->findByPk($post->id)->attributes);
 	}
@@ -310,12 +314,16 @@ class CActiveRecordTest extends CTestCase
 		$post=new PostExt;
 		$this->assertEquals(array('id'=>null,'title'=>'default title','create_time'=>null,'author_id'=>null,'content'=>null),$post->attributes);
 		$post=Post::model()->findByPk(1);
-		$this->assertEquals(array(
-			'id'=>1,
-			'title'=>'post 1',
-			'create_time'=>100000,
-			'author_id'=>1,
-			'content'=>'content 1'),$post->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>1,
+				'title'=>'post 1',
+				'create_time'=>100000,
+				'author_id'=>1,
+				'content'=>'content 1'
+			),
+			$post->attributes
+		);
 
 		$post=new PostExt;
 		$post->title='test post';
@@ -323,12 +331,16 @@ class CActiveRecordTest extends CTestCase
 		$post->author_id=1;
 		$post->content='test';
 		$post->save();
-		$this->assertEquals(array(
-			'id'=>6,
-			'title'=>'test post',
-			'create_time'=>1000000,
-			'author_id'=>1,
-			'content'=>'test'),$post->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>6,
+				'title'=>'test post',
+				'create_time'=>1000000,
+				'author_id'=>1,
+				'content'=>'test'
+			),
+			$post->attributes
+		);
 	}
 
 	public function testLazyRelation()
@@ -336,50 +348,75 @@ class CActiveRecordTest extends CTestCase
 		// test belongsTo
 		$post=Post::model()->findByPk(2);
 		$this->assertTrue($post->author instanceof User);
-		$this->assertEquals(array(
-			'id'=>2,
-			'username'=>'user2',
-			'password'=>'pass2',
-			'email'=>'email2'),$post->author->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>2,
+				'username'=>'user2',
+				'password'=>'pass2',
+				'email'=>'email2',
+				'username2'=>null,
+			),
+			$post->author->attributes
+		);
 
 		// test hasOne
 		$post=Post::model()->findByPk(2);
 		$this->assertTrue($post->firstComment instanceof Comment);
-		$this->assertEquals(array(
-			'id'=>4,
-			'content'=>'comment 4',
-			'post_id'=>2,
-			'author_id'=>2),$post->firstComment->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>4,
+				'content'=>'comment 4',
+				'post_id'=>2,
+				'author_id'=>2
+			),
+			$post->firstComment->attributes
+		);
 		$post=Post::model()->findByPk(4);
 		$this->assertNull($post->firstComment);
 
 		// test hasMany
 		$post=Post::model()->findByPk(2);
 		$this->assertEquals(2,count($post->comments));
-		$this->assertEquals(array(
-			'id'=>5,
-			'content'=>'comment 5',
-			'post_id'=>2,
-			'author_id'=>2),$post->comments[0]->attributes);
-		$this->assertEquals(array(
-			'id'=>4,
-			'content'=>'comment 4',
-			'post_id'=>2,
-			'author_id'=>2),$post->comments[1]->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>5,
+				'content'=>'comment 5',
+				'post_id'=>2,
+				'author_id'=>2
+			),
+			$post->comments[0]->attributes
+		);
+		$this->assertEquals(
+			array(
+				'id'=>4,
+				'content'=>'comment 4',
+				'post_id'=>2,
+				'author_id'=>2
+			),
+			$post->comments[1]->attributes
+		);
 		$post=Post::model()->findByPk(4);
 		$this->assertEquals(array(),$post->comments);
 
 		// test manyMany
 		$post=Post::model()->findByPk(2);
 		$this->assertEquals(2,count($post->categories));
-		$this->assertEquals(array(
-			'id'=>4,
-			'name'=>'cat 4',
-			'parent_id'=>1),$post->categories[0]->attributes);
-		$this->assertEquals(array(
-			'id'=>1,
-			'name'=>'cat 1',
-			'parent_id'=>null),$post->categories[1]->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>4,
+				'name'=>'cat 4',
+				'parent_id'=>1
+			),
+			$post->categories[0]->attributes
+		);
+		$this->assertEquals(
+			array(
+				'id'=>1,
+				'name'=>'cat 1',
+				'parent_id'=>null
+			),
+			$post->categories[1]->attributes
+		);
 		$post=Post::model()->findByPk(4);
 		$this->assertEquals(array(),$post->categories);
 
@@ -387,19 +424,31 @@ class CActiveRecordTest extends CTestCase
 		$category=Category::model()->findByPk(5);
 		$this->assertEquals(array(),$category->posts);
 		$this->assertEquals(2,count($category->children));
-		$this->assertEquals(array(
-			'id'=>6,
-			'name'=>'cat 6',
-			'parent_id'=>5),$category->children[0]->attributes);
-		$this->assertEquals(array(
-			'id'=>7,
-			'name'=>'cat 7',
-			'parent_id'=>5),$category->children[1]->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>6,
+				'name'=>'cat 6',
+				'parent_id'=>5
+			),
+			$category->children[0]->attributes
+		);
+		$this->assertEquals(
+			array(
+				'id'=>7,
+				'name'=>'cat 7',
+				'parent_id'=>5
+			),
+			$category->children[1]->attributes
+		);
 		$this->assertTrue($category->parent instanceof Category);
-		$this->assertEquals(array(
-			'id'=>1,
-			'name'=>'cat 1',
-			'parent_id'=>null),$category->parent->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>1,
+				'name'=>'cat 1',
+				'parent_id'=>null
+			),
+			$category->parent->attributes
+		);
 
 		$category=Category::model()->findByPk(2);
 		$this->assertEquals(1,count($category->posts));
@@ -413,10 +462,14 @@ class CActiveRecordTest extends CTestCase
 		$this->assertEquals(0,count($order->items));
 		$item=Item::model()->findByPk(4);
 		$this->assertTrue($item->order instanceof Order);
-		$this->assertEquals(array(
-			'key1'=>2,
-			'key2'=>2,
-			'name'=>'order 22'),$item->order->attributes);
+		$this->assertEquals(
+			array(
+				'key1'=>2,
+				'key2'=>2,
+				'name'=>'order 22'
+			),
+			$item->order->attributes
+		);
 	}
 
 	public function testEagerRelation2()
@@ -426,37 +479,62 @@ class CActiveRecordTest extends CTestCase
 
 	private function checkEagerLoadedModel($post)
 	{
-		$this->assertEquals(array(
-			'id'=>2,
-			'username'=>'user2',
-			'password'=>'pass2',
-			'email'=>'email2'),$post->author->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>2,
+				'username'=>'user2',
+				'password'=>'pass2',
+				'email'=>'email2',
+				'username2'=>null,
+			),
+			$post->author->attributes
+		);
 		$this->assertTrue($post->firstComment instanceof Comment);
-		$this->assertEquals(array(
-			'id'=>4,
-			'content'=>'comment 4',
-			'post_id'=>2,
-			'author_id'=>2),$post->firstComment->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>4,
+				'content'=>'comment 4',
+				'post_id'=>2,
+				'author_id'=>2
+			),
+			$post->firstComment->attributes
+		);
 		$this->assertEquals(2,count($post->comments));
-		$this->assertEquals(array(
-			'id'=>5,
-			'content'=>'comment 5',
-			'post_id'=>2,
-			'author_id'=>2),$post->comments[0]->attributes);
-		$this->assertEquals(array(
-			'id'=>4,
-			'content'=>'comment 4',
-			'post_id'=>2,
-			'author_id'=>2),$post->comments[1]->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>5,
+				'content'=>'comment 5',
+				'post_id'=>2,
+				'author_id'=>2
+			),
+			$post->comments[0]->attributes
+		);
+		$this->assertEquals(
+			array(
+				'id'=>4,
+				'content'=>'comment 4',
+				'post_id'=>2,
+				'author_id'=>2
+			),
+			$post->comments[1]->attributes
+		);
 		$this->assertEquals(2,count($post->categories));
-		$this->assertEquals(array(
-			'id'=>4,
-			'name'=>'cat 4',
-			'parent_id'=>1),$post->categories[0]->attributes);
-		$this->assertEquals(array(
-			'id'=>1,
-			'name'=>'cat 1',
-			'parent_id'=>null),$post->categories[1]->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>4,
+				'name'=>'cat 4',
+				'parent_id'=>1
+			),
+			$post->categories[0]->attributes
+		);
+		$this->assertEquals(
+			array(
+				'id'=>1,
+				'name'=>'cat 1',
+				'parent_id'=>null
+			),
+			$post->categories[1]->attributes
+		);
 	}
 
 	public function testEagerRelation()
@@ -469,11 +547,16 @@ class CActiveRecordTest extends CTestCase
 		$this->checkEagerLoadedModel($post);
 
 		$post=Post::model()->with('author','firstComment','comments','categories')->findByPk(4);
-		$this->assertEquals(array(
-			'id'=>2,
-			'username'=>'user2',
-			'password'=>'pass2',
-			'email'=>'email2'),$post->author->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>2,
+				'username'=>'user2',
+				'password'=>'pass2',
+				'email'=>'email2',
+				'username2'=>null
+			),
+			$post->author->attributes
+		);
 		$this->assertNull($post->firstComment);
 		$this->assertEquals(array(),$post->comments);
 		$this->assertEquals(array(),$post->categories);
@@ -603,44 +686,74 @@ class CActiveRecordTest extends CTestCase
 	{
 		$post=Post::model()->with('author','firstComment','comments','categories')->findByPk(2);
 		$comments=$post->comments;
-		$this->assertEquals(array(
-			'id'=>2,
-			'username'=>'user2',
-			'password'=>'pass2',
-			'email'=>'email2'),$post->author->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>2,
+				'username'=>'user2',
+				'password'=>'pass2',
+				'email'=>'email2',
+				'username2'=>null
+			),
+			$post->author->attributes
+		);
 		$this->assertTrue($post->firstComment instanceof Comment);
-		$this->assertEquals(array(
-			'id'=>4,
-			'content'=>'comment 4',
-			'post_id'=>2,
-			'author_id'=>2),$post->firstComment->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>4,
+				'content'=>'comment 4',
+				'post_id'=>2,
+				'author_id'=>2,
+			),
+			$post->firstComment->attributes
+		);
 		$this->assertEquals(2,count($post->comments));
-		$this->assertEquals(array(
-			'id'=>5,
-			'content'=>'comment 5',
-			'post_id'=>2,
-			'author_id'=>2),$post->comments[0]->attributes);
-		$this->assertEquals(array(
-			'id'=>4,
-			'content'=>'comment 4',
-			'post_id'=>2,
-			'author_id'=>2),$post->comments[1]->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>5,
+				'content'=>'comment 5',
+				'post_id'=>2,
+				'author_id'=>2
+			),
+			$post->comments[0]->attributes
+		);
+		$this->assertEquals(
+			array(
+				'id'=>4,
+				'content'=>'comment 4',
+				'post_id'=>2,
+				'author_id'=>2
+			),
+			$post->comments[1]->attributes
+		);
 		$this->assertEquals(2,count($post->categories));
-		$this->assertEquals(array(
-			'id'=>4,
-			'name'=>'cat 4',
-			'parent_id'=>1),$post->categories[0]->attributes);
-		$this->assertEquals(array(
-			'id'=>1,
-			'name'=>'cat 1',
-			'parent_id'=>null),$post->categories[1]->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>4,
+				'name'=>'cat 4',
+				'parent_id'=>1
+			),
+			$post->categories[0]->attributes
+		);
+		$this->assertEquals(
+			array(
+				'id'=>1,
+				'name'=>'cat 1',
+				'parent_id'=>null
+			),
+			$post->categories[1]->attributes
+		);
 
 		$post=Post::model()->with('author','firstComment','comments','categories')->findByPk(4);
-		$this->assertEquals(array(
-			'id'=>2,
-			'username'=>'user2',
-			'password'=>'pass2',
-			'email'=>'email2'),$post->author->attributes);
+		$this->assertEquals(
+			array(
+				'id'=>2,
+				'username'=>'user2',
+				'password'=>'pass2',
+				'email'=>'email2',
+				'username2'=>null
+			),
+			$post->author->attributes
+		);
 		$this->assertNull($post->firstComment);
 		$this->assertEquals(array(),$post->comments);
 		$this->assertEquals(array(),$post->categories);


### PR DESCRIPTION
Fixes #627: CActiveRecord not respecting attributeNames() overrides

Note: need to be very carefull with this one!