### PR TITLE
Support third party autoloaders in Yii::import()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -133,6 +133,7 @@ Version 1.1.14
 - Enh #2494: Allow to configure CBaseListView emptyText container tag name (ifdattic)
 - Enh #2529: Silenced all chmod calls to prevent "chmod() operation not allowed" error on NTFS (samdark)
 - Enh #2602: CEmailValidator and CUrlValidator now uses native PHP `idn` extension in case it is available (`idn_to_ascii` and `idn_ to_ utf8` functions) and Net_IDNA2 otherwise (resurtm, creocoder)
+- Enh #2642: Support third party autoloaders when importing classes via Yii::import() (phpnode)
 - Chg: Upgraded HTMLPurifier to v4.5.0 (samdark)
 - Chg #645: CDbConnection now throws CDbException when failed to open DB connection instead of failing with a warning (kidol, eirikhm, samdark, cebe)
 - Chg #895: Add second argument $params to client validation function (slavcodev)

--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -286,9 +286,17 @@ class YiiBase
 					self::$classMap[$alias]=$classFile;
 				return $alias;
 			}
-			else
-				throw new CException(Yii::t('yii','Alias "{alias}" is invalid. Make sure it points to an existing directory.',
-					array('{alias}'=>$namespace)));
+			else {
+				try
+				{
+					new ReflectionClass($alias); // autoload the class without instantiation
+					return $alias;
+				}
+				catch (ReflectionException $e) {
+					throw new CException(Yii::t('yii','Alias "{alias}" is invalid. Make sure it points to an existing directory.',
+						array('{alias}'=>$namespace)));
+				}
+			}
 		}
 
 		if(($pos=strrpos($alias,'.'))===false)  // a simple class name


### PR DESCRIPTION
This commit adds support for loading namespaced classes
with third party autoloaders when using `Yii::import()`
and `Yii::createComponent()`. It means that you no longer
need to explicitly set aliases for each and every root
namespace you want to use in your app, which makes working
with composer much easier.

It uses reflection to autoload the class, preserving backwards
compatibility.

Fixes #2642
