### PR TITLE
CJavaScript: fix range() warning bug on 5.3.5 for win

### DIFF
--- a/framework/web/helpers/CJavaScript.php
+++ b/framework/web/helpers/CJavaScript.php
@@ -87,7 +87,11 @@ class CJavaScript
 		elseif(is_array($value))
 		{
 			$es=array();
-			if(($n=count($value))>0 && array_keys($value)!==range(0,$n-1))
+
+			/* false warning on PHP 5.3.5 win */
+			$n=count($value); $nkeys=@range(0,$n-1);
+
+			if($n>0 && array_keys($value)!==$nkeys)
 			{
 				foreach($value as $k=>$v)
 					$es[]="'".self::quote($k)."':".self::encode($v,$safe);


### PR DESCRIPTION
Warning: range() [function.range]: step exceeds the specified range

Bug resolved in 5.3.6, but 5.3.5 is a common PHP version.
