### PR TITLE
Minor cleanups to make the gii module more compatible with the clientscript.

### DIFF
--- a/framework/gii/views/layouts/main.php
+++ b/framework/gii/views/layouts/main.php
@@ -7,6 +7,8 @@ $cs->registerCoreScript('jquery');
 $cs->registerScriptFile($baseUrl.'/js/tooltip.js');
 $cs->registerScriptFile($baseUrl.'/js/fancybox/jquery.fancybox-1.3.1.pack.js');
 $cs->registerCssFile($baseUrl.'/js/fancybox/jquery.fancybox-1.3.1.css');
+
+$cs->registerScriptFile($baseUrl.'/js/main.js');
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
@@ -24,9 +26,6 @@ $cs->registerCssFile($baseUrl.'/js/fancybox/jquery.fancybox-1.3.1.css');
 	<link rel="stylesheet" type="text/css" href="<?php echo $this->module->assetsUrl; ?>/css/main.css" />
 
 	<title><?php echo CHtml::encode($this->pageTitle); ?></title>
-
-	<script type="text/javascript" src="<?php echo $this->module->assetsUrl; ?>/js/main.js"></script>
-
 </head>
 
 <body>

--- a/framework/gii/views/layouts/main.php
+++ b/framework/gii/views/layouts/main.php
@@ -17,13 +17,13 @@ $cs->registerScriptFile($baseUrl.'/js/main.js');
 	<meta name="language" content="en" />
 
 	<!-- blueprint CSS framework -->
-	<link rel="stylesheet" type="text/css" href="<?php echo $this->module->assetsUrl; ?>/css/screen.css" media="screen, projection" />
-	<link rel="stylesheet" type="text/css" href="<?php echo $this->module->assetsUrl; ?>/css/print.css" media="print" />
+	<link rel="stylesheet" type="text/css" href="<?php echo $baseUrl; ?>/css/screen.css" media="screen, projection" />
+	<link rel="stylesheet" type="text/css" href="<?php echo $baseUrl; ?>/css/print.css" media="print" />
 	<!--[if lt IE 8]>
-	<link rel="stylesheet" type="text/css" href="<?php echo $this->module->assetsUrl; ?>/css/ie.css" media="screen, projection" />
+	<link rel="stylesheet" type="text/css" href="<?php echo $baseUrl; ?>/css/ie.css" media="screen, projection" />
 	<![endif]-->
 
-	<link rel="stylesheet" type="text/css" href="<?php echo $this->module->assetsUrl; ?>/css/main.css" />
+	<link rel="stylesheet" type="text/css" href="<?php echo $baseUrl; ?>/css/main.css" />
 
 	<title><?php echo CHtml::encode($this->pageTitle); ?></title>
 </head>
@@ -40,7 +40,7 @@ $cs->registerScriptFile($baseUrl.'/js/main.js');
 			| <?php echo CHtml::link('logout',array('default/logout')); ?>
 		<?php endif; ?>
 		</div>
-		<div id="logo"><?php echo CHtml::link(CHtml::image($this->module->assetsUrl.'/images/logo.png'),array('default/index')); ?></div>
+		<div id="logo"><?php echo CHtml::link(CHtml::image($baseUrl.'/images/logo.png'),array('default/index')); ?></div>
 	</div><!-- header -->
 
 	<?php echo $content; ?>


### PR DESCRIPTION
gii breaks if clientscript inserts the scripts after the title tag. I changed the module a little bit to use the clientscript for loading it's script file, so it will always load after the jquery code regardless of being before or after the title tag.