### PR TITLE
Fix bug of CRedisCache.php.

### DIFF
--- a/framework/caching/CRedisCache.php
+++ b/framework/caching/CRedisCache.php
@@ -148,8 +148,16 @@ class CRedisCache extends CCache
 			case '$': // Bulk replies
 				if($line=='-1')
 					return null;
-				if(($data=fread($this->_socket,$line+2))===false)
-					throw new CException('Failed reading data from redis connection socket.');
+                $lengthToRead = $line + 2;
+                $data = '';
+                while (!feof($this->_socket) && $lengthToRead > 0) {
+                    $block = fread($this->_socket, $lengthToRead);
+                    if($block===false) {
+                        throw new CException('Failed reading data from redis connection socket.');
+                    }
+                    $data .= $block;
+                    $lengthToRead -= strlen($block);
+                }
 				return substr($data,0,-2);
 			case '*': // Multi-bulk replies
 				$count=(int)$line;


### PR DESCRIPTION
Bug of using fread php function. Text from doc: http://www.php.net/manual/en/function.fread.php

if the stream is read buffered and it does not represent a plain file, at most one read of up to a number of bytes equal to the chunk size (usually 8192) is made; depending on the previously buffered data, the size of the returned data may be larger than the chunk size.

The result is that in some cases app read from redis only 8192 byte not all data.
