### PR TITLE
Fix Yii compatibility with AspectMock

### DIFF
--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -866,5 +866,4 @@ class YiiBase
 	);
 }
 
-spl_autoload_register(array('YiiBase','autoload'));
 require(YII_PATH.'/base/interfaces.php');

--- a/framework/yii.php
+++ b/framework/yii.php
@@ -25,3 +25,5 @@ require(dirname(__FILE__).'/YiiBase.php');
 class Yii extends YiiBase
 {
 }
+
+spl_autoload_register(array('Yii','autoload'));


### PR DESCRIPTION
Without this change testing with codeception & AspectMock aborts with following error `Passed array does not specify an existing static method (class 'YiiBase' not found)`
