### PR TITLE
Include exception message in dbconnection failed to open scenario

### DIFF
--- a/framework/yiilite.php
+++ b/framework/yiilite.php
@@ -8430,7 +8430,7 @@ class CDbConnection extends CApplicationComponent
 				else
 				{
 					Yii::log($e->getMessage(),CLogger::LEVEL_ERROR,'exception.CDbException');
-					throw new CDbException('CDbConnection failed to open the DB connection.',(int)$e->getCode(),$e->errorInfo);
+					throw new CDbException('CDbConnection failed to open the DB connection: '.$e->getMessage(), (int)$e->getCode(),$e->errorInfo);
 				}
 			}
 		}


### PR DESCRIPTION
A lot of times when this error happens. The message "CDbConnection failed to open the DB connection" is not enough for us to figure out the reason why it happened, especially in Production environments. 

Different examples of reasons this error is thrown would be "Deadlocks", "Transaction wait timeouts"  or "Too many connections". 

Its a simple fix. Helps devs debug the problem faster. 
