### PR TITLE
detect properly if criteria->select starts with a count() expression

### DIFF
--- a/framework/db/ar/CActiveFinder.php
+++ b/framework/db/ar/CActiveFinder.php
@@ -744,7 +744,7 @@ class CJoinElement
 		else
 		{
 			$select=is_array($criteria->select) ? implode(',',$criteria->select) : $criteria->select;
-			if($select!=='*' && !strncasecmp($select,'count',5))
+			if($select!=='*' && preg_match('/^count\s*\(/',trim($select)))
 				$query->selects=array($select);
 			elseif(is_string($this->_table->primaryKey))
 			{

--- a/tests/framework/db/ar/CActiveRecordTest.php
+++ b/tests/framework/db/ar/CActiveRecordTest.php
@@ -1370,6 +1370,16 @@ class CActiveRecordTest extends CTestCase
 	}
 
 	/**
+	 * @see github issue 268
+	 * CActiveRecord->count() returns contry name instead of records count
+	 */
+	public function testIssue268()
+	{
+		$result = User::model()->with('profiles')->count(array('select'=>'country AS country','condition'=>'t.id=2'));
+		$this->assertEquals(1,$result);
+	}
+
+	/**
 	 * verify https://github.com/yiisoft/yii/issues/2756
 	 */
 	public function testLazyFindCondition()

--- a/tests/framework/db/data/models.php
+++ b/tests/framework/db/data/models.php
@@ -33,6 +33,7 @@ class User extends CActiveRecord
 			'groups'=>array(self::HAS_MANY,'Group',array('group_id'=>'id'),'through'=>'roles'),
 			'mentorships'=>array(self::HAS_MANY,'Mentorship','teacher_id','joinType'=>'INNER JOIN'),
 			'students'=>array(self::HAS_MANY,'User',array('student_id'=>'id'),'through'=>'mentorships','joinType'=>'INNER JOIN'),
+			'profiles'=>array(self::HAS_MANY,'Profile','user_id'),
 			'posts'=>array(self::HAS_MANY,'Post','author_id'),
 			'postsCondition'=>array(self::HAS_MANY,'Post','author_id', 'condition'=>'postsCondition.id IN (2,3)'),
 			'postsOrderDescFormat1'=>array(self::HAS_MANY,'Post','author_id','scopes'=>'orderDesc'),
@@ -143,6 +144,26 @@ class Role extends CActiveRecord
 	public function tableName()
 	{
 		return 'roles';
+	}
+}
+
+/**
+ * @property integer $id
+ * @property string $first_name
+ * @property string $last_name
+ * @property string $country
+ * @property integer $user_id
+ */
+class Profile extends CActiveRecord
+{
+	public static function model($class=__CLASS__)
+	{
+		return parent::model($class);
+	}
+
+	public function tableName()
+	{
+		return 'profiles';
 	}
 }
 

--- a/tests/framework/db/data/sqlite.sql
+++ b/tests/framework/db/data/sqlite.sql
@@ -64,13 +64,14 @@ CREATE TABLE profiles
 	id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
 	first_name VARCHAR(128) NOT NULL,
 	last_name VARCHAR(128) NOT NULL,
+	country VARCHAR(128),
 	user_id INTEGER NOT NULL,
 	CONSTRAINT FK_profile_user FOREIGN KEY (user_id)
 		REFERENCES users (id) ON DELETE CASCADE ON UPDATE RESTRICT
 );
 
-INSERT INTO profiles (first_name, last_name, user_id) VALUES ('first 1','last 1',1);
-INSERT INTO profiles (first_name, last_name, user_id) VALUES ('first 2','last 2',2);
+INSERT INTO profiles (first_name, last_name, country, user_id) VALUES ('first 1','last 1','country 1',1);
+INSERT INTO profiles (first_name, last_name, country, user_id) VALUES ('first 2','last 2','country 2',2);
 
 CREATE TABLE posts
 (


### PR DESCRIPTION
Fixes #268. Detect properly if criteria->select starts with a count() expression in CActiveFinder->count() method.

Previously it tested only if the select part of the statement starts with the string 'count'. This could be part of an alias or column name (like 'country'). It should test if count is followed by (spaces and) a left parenthesis.
