### PR TITLE
in CPgsqlColumnSchema don't set size for time types with precision

### DIFF
--- a/framework/db/schema/pgsql/CPgsqlColumnSchema.php
+++ b/framework/db/schema/pgsql/CPgsqlColumnSchema.php
@@ -36,6 +36,28 @@ class CPgsqlColumnSchema extends CDbColumnSchema
 	}
 
 	/**
+	 * Extracts size, precision and scale information from column's DB type.
+	 * @param string $dbType the column's DB type
+	 */
+	protected function extractLimit($dbType)
+	{
+		if(strpos($dbType,'('))
+		{
+			if (preg_match('/^time.*\((.*)\)/',$dbType,$matches))
+			{
+				$this->precision=(int)$matches[1];
+			}
+			elseif (preg_match('/\((.*)\)/',$dbType,$matches))
+			{
+				$values=explode(',',$matches[1]);
+				$this->size=$this->precision=(int)$values[0];
+				if(isset($values[1]))
+					$this->scale=(int)$values[1];
+			}
+		}
+	}
+
+	/**
 	 * Extracts the default value for the column.
 	 * The value is typecasted to correct PHP type.
 	 * @param mixed $defaultValue the default value obtained from metadata

--- a/tests/framework/db/data/postgres.sql
+++ b/tests/framework/db/data/postgres.sql
@@ -174,6 +174,7 @@ CREATE TABLE public.yii_types
 	real_col REAL DEFAULT 1.23,
 	blob_col BYTEA,
 	time TIMESTAMP,
+	time2 TIMESTAMP(4),
 	bool_col BOOL NOT NULL,
 	bool_col2 BOOLEAN DEFAULT TRUE
 );

--- a/tests/framework/db/schema/CPostgresTest.php
+++ b/tests/framework/db/schema/CPostgresTest.php
@@ -102,15 +102,15 @@ class CPostgresTest extends CTestCase
 		$this->checkColumns('test.posts',$values);
 		$values=array
 		(
-			'name'=>array('int_col', 'int_col2', 'char_col', 'char_col2', 'char_col3', 'numeric_col', 'real_col', 'blob_col', 'time', 'bool_col', 'bool_col2'),
-			'rawName'=>array('"int_col"', '"int_col2"', '"char_col"', '"char_col2"', '"char_col3"', '"numeric_col"', '"real_col"', '"blob_col"', '"time"', '"bool_col"', '"bool_col2"'),
-			'defaultValue'=>array(null, 1, null, 'something', null, null, '1.23', null, null, null, true),
-			'size'=>array(null, null, 100, 100, null, 4, null, null, null, null, null),
-			'precision'=>array(null, null, 100, 100, null, 4, null, null, null, null, null),
-			'scale'=>array(null, null, null, null, null, 3, null, null, null, null, null),
-			'type'=>array('integer','integer','string','string','string','string','double','string','string','boolean','boolean'),
-			'isPrimaryKey'=>array(false,false,false,false,false,false,false,false,false,false,false),
-			'isForeignKey'=>array(false,false,false,false,false,false,false,false,false,false,false),
+			'name'=>array('int_col', 'int_col2', 'char_col', 'char_col2', 'char_col3', 'numeric_col', 'real_col', 'blob_col', 'time', 'time2', 'bool_col', 'bool_col2'),
+			'rawName'=>array('"int_col"', '"int_col2"', '"char_col"', '"char_col2"', '"char_col3"', '"numeric_col"', '"real_col"', '"blob_col"', '"time"', '"time2"', '"bool_col"', '"bool_col2"'),
+			'defaultValue'=>array(null, 1, null, 'something', null, null, '1.23', null, null, null, null, true),
+			'size'=>array(null, null, 100, 100, null, 4, null, null, null, null, null, null),
+			'precision'=>array(null, null, 100, 100, null, 4, null, null, null, 4, null, null),
+			'scale'=>array(null, null, null, null, null, 3, null, null, null, null, null, null),
+			'type'=>array('integer','integer','string','string','string','string','double','string','string','string','boolean','boolean'),
+			'isPrimaryKey'=>array(false,false,false,false,false,false,false,false,false,false,false,false),
+			'isForeignKey'=>array(false,false,false,false,false,false,false,false,false,false,false,false),
 		);
 		$this->checkColumns('yii_types',$values);
 	}


### PR DESCRIPTION
Fixes #264. The time\* fields in PostgreSQL do get an optional precision setting but this is not their size, it's the precision of the miliseconds part.
I also checked all other types and it's all good.
