### PR TITLE
use the preffered method of creating an unique index in postgresql 

### DIFF
--- a/framework/db/schema/pgsql/CPgsqlSchema.php
+++ b/framework/db/schema/pgsql/CPgsqlSchema.php
@@ -414,6 +414,41 @@ EOD;
 	}
 
 	/**
+	 * Builds a SQL statement for creating a new index.
+	 * @param string $name the name of the index. The name will be properly quoted by the method.
+	 * @param string $table the table that the new index will be created for. The table name will be properly quoted by the method.
+	 * @param string $column the column(s) that should be included in the index. If there are multiple columns, please separate them
+	 * by commas. Each column name will be properly quoted by the method, unless a parenthesis is found in the name.
+	 * @param boolean $unique whether to add UNIQUE constraint on the created index.
+	 * @return string the SQL statement for creating a new index.
+	 * @since 1.1.6
+	 */
+	public function createIndex($name, $table, $column, $unique=false)
+	{
+		$cols=array();
+		$columns=preg_split('/\s*,\s*/',$column,-1,PREG_SPLIT_NO_EMPTY);
+		foreach($columns as $col)
+		{
+			if(strpos($col,'(')!==false)
+				$cols[]=$col;
+			else
+				$cols[]=$this->quoteColumnName($col);
+		}
+		if ($unique)
+		{
+			return 'ALTER TABLE ONLY '
+				. $this->quoteTableName($table).' ADD CONSTRAINT '
+				. $this->quoteTableName($name).' UNIQUE ('.implode(', ',$cols).')';
+		}
+		else
+		{
+			return 'CREATE INDEX '
+				. $this->quoteTableName($name).' ON '
+				. $this->quoteTableName($table).' ('.implode(', ',$cols).')';
+		}
+	}
+
+	/**
 	 * Builds a SQL statement for dropping an index.
 	 * @param string $name the name of the index to be dropped. The name will be properly quoted by the method.
 	 * @param string $table the table whose index is to be dropped. The name will be properly quoted by the method.

--- a/tests/framework/db/schema/CPostgres2Test.php
+++ b/tests/framework/db/schema/CPostgres2Test.php
@@ -113,7 +113,7 @@ class CPostgres2Test extends CTestCase
 		$this->assertEquals($expect, $sql);
 
 		$sql=$this->db->schema->createIndex('id_pk','test','id1,id2',true);
-		$expect='CREATE UNIQUE INDEX "id_pk" ON "test" ("id1", "id2")';
+		$expect='ALTER TABLE ONLY "test" ADD CONSTRAINT "id_pk" UNIQUE ("id1", "id2")';
 		$this->assertEquals($expect, $sql);
 	}
 


### PR DESCRIPTION
As suggested by the manual. Fixes #788. All tests pass and tested it manually to ensure the syntax is correct.
