### PR TITLE
Fix for failing number validation on floats for some locales #2806

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 
 Version 1.1.15 under development
 --------------------------------
+- Bug #2806: Fixed a failing CNumberValidator validation on floats with set locales that don't use '.' as decimal point (markusbaumer)
 - Bug #2756: Fixed applying condition twice during Active Record relation lazy loading (klimov-paul)
 - Bug #2778: Fixed throwing unnecessary exception in CFileValidator when validating MIME types for a file upload that failed (Rupert-RR)
 - Enh #182: CSort: allow arrays in asc/desc keys of virtual attributes (nineinchnick)

--- a/framework/validators/CNumberValidator.php
+++ b/framework/validators/CNumberValidator.php
@@ -96,11 +96,22 @@ class CNumberValidator extends CValidator
 		}
 		else
 		{
+			$oldLocale=null;
+			if (!is_string($value)) {
+				$oldLocale=setlocale(LC_NUMERIC,0);
+				$localeConv=localeconv();
+				if ($localeConv['decimal_point']=='.')
+					$oldLocale=null;
+				else
+					setlocale(LC_NUMERIC,'C','C.UTF-8','POSIX');
+			}
 			if(!preg_match($this->numberPattern,"$value"))
 			{
 				$message=$this->message!==null?$this->message:Yii::t('yii','{attribute} must be a number.');
 				$this->addError($object,$attribute,$message);
 			}
+			if ($oldLocale!==null)
+				setlocale(LC_NUMERIC,$oldLocale);
 		}
 		if($this->min!==null && $value<$this->min)
 		{


### PR DESCRIPTION
When validating a number with NumberValidator, it fails for non-string values, if a locale for LC_NUMERIC is set that doesn't use a dot as decimal separator.

See issue https://github.com/yiisoft/yii/issues/2806