### PR TITLE
Fixes issue #2429 - use a stable sort when sorting Accept and Accept-Language headers.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 
 Version 1.1.15 under development
 --------------------------------
+- Bug #2429: CHttpRequest now properly takes into account original items order when sorting parsed Accept headers (Rupert-RR)
 - Bug #2756: Fixed applying condition twice during Active Record relation lazy loading (klimov-paul)
 - Enh #182: CSort: allow arrays in asc/desc keys of virtual attributes (nineinchnick)
 

--- a/framework/web/CHttpRequest.php
+++ b/framework/web/CHttpRequest.php
@@ -869,7 +869,7 @@ class CHttpRequest extends CApplicationComponent
 							if($q>1)
 								$q=(double)1;
 							elseif($q<0)
-							$q=(double)0;
+								$q=(double)0;
 							$accept['params'][$matches[4][$i]]=$q;
 						}
 						else


### PR DESCRIPTION
Accept-Language headers, similar to those for Accept headers, and added
a position paramter to the array maps produced so as to take into
account original position when sorting items in order of preference.
Updated CHttpeRequestTest to reflect and validate these changes.
Updated CHANGELOG to include this bug fix.

This PR is to replace PR #2431, which I could not merge properly.