### PR TITLE
Yii Framework duplicates javascript event , when using ajax to load view which contains javascript (js:)

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2437,9 +2437,9 @@ EOD;
 		}
 
 		if($live)
-			$cs->registerScript('Yii.CHtml.#' . $id,"jQuery('body').on('$event','#$id',function(){{$handler}});");
+			$cs->registerScript('Yii.CHtml.#' . $id,"jQuery('body').off('$event','#$id').on('$event','#$id',function(){{$handler}});");
 		else
-			$cs->registerScript('Yii.CHtml.#' . $id,"jQuery('#$id').on('$event', function(){{$handler}});");
+			$cs->registerScript('Yii.CHtml.#' . $id,"jQuery('#$id').off('$event').on('$event', function(){{$handler}});");
 		unset($htmlOptions['params'],$htmlOptions['submit'],$htmlOptions['ajax'],$htmlOptions['confirm'],$htmlOptions['return'],$htmlOptions['csrf']);
 	}
 

--- a/framework/web/widgets/captcha/CCaptcha.php
+++ b/framework/web/widgets/captcha/CCaptcha.php
@@ -136,7 +136,7 @@ class CCaptcha extends CWidget
 			return;
 
 		$js.="
-jQuery(document).on('click', '$selector', function(){
+jQuery(document).off('click', '$selector').on('click', '$selector', function(){
 	jQuery.ajax({
 		url: ".CJSON::encode($url).",
 		dataType: 'json',

--- a/framework/zii/widgets/grid/CButtonColumn.php
+++ b/framework/zii/widgets/grid/CButtonColumn.php
@@ -296,7 +296,7 @@ EOD;
 			{
 				$function=CJavaScript::encode($button['click']);
 				$class=preg_replace('/\s+/','.',$button['options']['class']);
-				$js[]="jQuery(document).on('click','#{$this->grid->id} a.{$class}',$function);";
+				$js[]="jQuery(document).off('click','#{$this->grid->id} a.{$class}').on('click','#{$this->grid->id} a.{$class}',$function);";
 			}
 		}
 

--- a/framework/zii/widgets/grid/CCheckBoxColumn.php
+++ b/framework/zii/widgets/grid/CCheckBoxColumn.php
@@ -165,7 +165,7 @@ class CCheckBoxColumn extends CGridColumn
 		{
 			//.. process check/uncheck all
 			$cball=<<<CBALL
-jQuery(document).on('click','#{$this->id}_all',function() {
+jQuery(document).off('click','#{$this->id}_all').on('click','#{$this->id}_all',function() {
 	var checked=this.checked;
 	jQuery("input[name='$name']:enabled").each(function() {this.checked=checked;});
 });
@@ -178,7 +178,7 @@ CBALL;
 		{
 			$js=$cball;
 			$js.=<<<EOD
-jQuery(document).on('click', "input[name='$name']", function() {
+jQuery(document).off('click', "input[name='$name']").on('click', "input[name='$name']", function() {
 	$cbcode
 });
 EOD;

--- a/tests/framework/zii/widgets/grid/CButtonColumnTest.php
+++ b/tests/framework/zii/widgets/grid/CButtonColumnTest.php
@@ -6,7 +6,7 @@ class CButtonColumnTest extends CTestCase
 {
 	public function testCallbackEncoding()
 	{
-		$expected = "jQuery(document).on('click','#grid1 a.view',function() { /* callback */ });";
+		$expected = "jQuery(document).off('click','#grid1 a.view').on('click','#grid1 a.view',function() { /* callback */ });";
 
 		$out=$this->getWidgetScript('js:function() { /* callback */ }');
 		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);


### PR DESCRIPTION
Yii Framework duplicates javascript event , when using ajax to load view which contains javascript (js:)

$(body).on('click',... jquery will add new script will run multiple times, +1 on each request , because it is registered on body tag which static in page

changed to
$(body).off('event','#id').on('event','#id')
to force jquery to replace the event on each ajax request
