### PR TITLE
Updated CHttpRequest::getUserHostAddress()

### DIFF
--- a/framework/web/CHttpRequest.php
+++ b/framework/web/CHttpRequest.php
@@ -666,7 +666,7 @@ class CHttpRequest extends CApplicationComponent
 	 */
 	public function getUserHostAddress()
 	{
-		return isset($_SERVER['REMOTE_ADDR'])?$_SERVER['REMOTE_ADDR']:'127.0.0.1';
+		return isset($_SERVER['HTTP_X_FORWARDED_FOR'])?$_SERVER['HTTP_X_FORWARDED_FOR']:(isset($_SERVER['REMOTE_ADDR'])?$_SERVER['REMOTE_ADDR']:'127.0.0.1');
 	}
 
 	/**


### PR DESCRIPTION
Updated CHttpRequest::getUserHostAddress() to first look for forwarded
IP (HTTP_X_FORWARDED_FOR). If there is none, then use REMOTE_ADDR. This
is useful for web apps running behind load balancers as this previously
may return the load balancer's IP instead of the client.
