### PR TITLE
fix lastmodifiedexpression

### DIFF
--- a/framework/web/filters/CHttpCacheFilter.php
+++ b/framework/web/filters/CHttpCacheFilter.php
@@ -123,7 +123,9 @@ class CHttpCacheFilter extends CFilter
 		if($this->lastModifiedExpression)
 		{
 			$value=$this->evaluateExpression($this->lastModifiedExpression);
-			if(is_numeric($value)&&$value==(int)$value)
+			if($value===false)
+				return false;
+			elseif(is_numeric($value)&&$value==(int)$value)
 				return $value;
 			elseif(($lastModified=strtotime($value))===false)
 				throw new CException(Yii::t('yii','Invalid expression for CHttpCacheFilter.lastModifiedExpression: The evaluation result "{value}" could not be understood by strtotime()',


### PR DESCRIPTION
For example if table {{post}} empty :

```php
public function filters()
{
    return array(
        array(
            'CHttpCacheFilter + index',
            'lastModified'=>Yii::app()->db->createCommand("SELECT MAX(`update_time`) FROM {{post}}")->queryScalar(),
            'lastModifiedExpression'=>'Yii::app()->db->createCommand("SELECT MAX(`update_time`) FROM {{post}}")->queryScalar()',
        ),
    );
}
```

if i use only lastModified is ok.
If i use lastModifiedExpression i catch exception
