### PR TITLE
avoid param name collisions in CDbCommandBuilder, fixes #583

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Work in progress
 Version 1.1.15 under development
 --------------------------------
 - Bug #268: Fixed Active Record count error when some field name starting from 'count' (nineinchnick)
+- Bug #583: Fixed param name collision in CDbCommandBuilder class when using createColumnCriteria() with createUpdateCommand() (nineinchnick)
 - Bug #2378: CActiveRecord::tableName() in namespaced model returned fully qualified class name (velosipedist, cebe)
 - Bug #2654: Allow CDbCommand to compose queries without 'from' clause (klimov-paul)
 - Bug #2753: Fixed CErrorHandler::errorAction ignored if error occurs while AJAX request (klimov-paul)

--- a/framework/db/schema/CDbCommandBuilder.php
+++ b/framework/db/schema/CDbCommandBuilder.php
@@ -21,6 +21,11 @@
 class CDbCommandBuilder extends CComponent
 {
 	const PARAM_PREFIX=':yp';
+	/**
+	 * @var integer the global counter for anonymous binding parameters.
+	 * This counter is used for generating the name for the anonymous parameters.
+	 */
+	public static $paramCount=0;
 
 	private $_schema;
 	private $_connection;
@@ -211,7 +216,6 @@ class CDbCommandBuilder extends CComponent
 		$fields=array();
 		$values=array();
 		$placeholders=array();
-		$i=0;
 		foreach($data as $name=>$value)
 		{
 			if(($column=$table->getColumn($name))!==null && ($value!==null || $column->allowNull))
@@ -225,9 +229,8 @@ class CDbCommandBuilder extends CComponent
 				}
 				else
 				{
-					$placeholders[]=self::PARAM_PREFIX.$i;
-					$values[self::PARAM_PREFIX.$i]=$column->typecast($value);
-					$i++;
+					$placeholders[]=self::PARAM_PREFIX.self::$paramCount;
+					$values[self::PARAM_PREFIX.self::$paramCount++]=$column->typecast($value);
 				}
 			}
 		}
@@ -364,7 +367,6 @@ class CDbCommandBuilder extends CComponent
 		$fields=array();
 		$values=array();
 		$bindByPosition=isset($criteria->params[0]);
-		$i=0;
 		foreach($data as $name=>$value)
 		{
 			if(($column=$table->getColumn($name))!==null)
@@ -382,9 +384,8 @@ class CDbCommandBuilder extends CComponent
 				}
 				else
 				{
-					$fields[]=$column->rawName.'='.self::PARAM_PREFIX.$i;
-					$values[self::PARAM_PREFIX.$i]=$column->typecast($value);
-					$i++;
+					$fields[]=$column->rawName.'='.self::PARAM_PREFIX.self::$paramCount;
+					$values[self::PARAM_PREFIX.self::$paramCount++]=$column->typecast($value);
 				}
 			}
 		}
@@ -664,7 +665,6 @@ class CDbCommandBuilder extends CComponent
 		$bindByPosition=isset($criteria->params[0]);
 		$conditions=array();
 		$values=array();
-		$i=0;
 		if($prefix===null)
 			$prefix=$table->rawName.'.';
 		foreach($columns as $name=>$value)
@@ -682,9 +682,8 @@ class CDbCommandBuilder extends CComponent
 					}
 					else
 					{
-						$conditions[]=$prefix.$column->rawName.'='.self::PARAM_PREFIX.$i;
-						$values[self::PARAM_PREFIX.$i]=$value;
-						$i++;
+						$conditions[]=$prefix.$column->rawName.'='.self::PARAM_PREFIX.self::$paramCount;
+						$values[self::PARAM_PREFIX.self::$paramCount++]=$value;
 					}
 				}
 				else

--- a/tests/framework/db/schema/CPostgresTest.php
+++ b/tests/framework/db/schema/CPostgresTest.php
@@ -131,6 +131,7 @@ class CPostgresTest extends CTestCase
 
 	public function testCommandBuilder()
 	{
+		CDbCommandBuilder::$paramCount=0;
 		$schema=$this->db->schema;
 		$builder=$schema->commandBuilder;
 		$this->assertTrue($builder instanceof CDbCommandBuilder);
@@ -230,7 +231,7 @@ class CPostgresTest extends CTestCase
 
 		// createColumnCriteria
 		$c=$builder->createColumnCriteria($table,array('id'=>1,'author_id'=>2),'title=\'\'');
-		$this->assertEquals('"test"."posts"."id"=:yp0 AND "test"."posts"."author_id"=:yp1 AND (title=\'\')',$c->condition);
+		$this->assertEquals('"test"."posts"."id"=:yp5 AND "test"."posts"."author_id"=:yp6 AND (title=\'\')',$c->condition);
 	}
 
 	public function testResetSequence()

--- a/tests/framework/db/schema/CSqliteTest.php
+++ b/tests/framework/db/schema/CSqliteTest.php
@@ -118,6 +118,7 @@ class CSqliteTest extends CTestCase
 
 	public function testCommandBuilder()
 	{
+		CDbCommandBuilder::$paramCount=0;
 		$schema=$this->db->schema;
 		$builder=$schema->commandBuilder;
 		$this->assertTrue($builder instanceof CDbCommandBuilder);
@@ -220,7 +221,7 @@ class CSqliteTest extends CTestCase
 
 		// createColumnCriteria
 		$c=$builder->createColumnCriteria($table,array('id'=>1,'author_id'=>2),'title=\'\'');
-		$this->assertEquals('\'posts\'."id"=:yp0 AND \'posts\'."author_id"=:yp1 AND (title=\'\')',$c->condition);
+		$this->assertEquals('\'posts\'."id"=:yp5 AND \'posts\'."author_id"=:yp6 AND (title=\'\')',$c->condition);
 
 		$c=$builder->createPkCriteria($table2,array());
 		$this->assertEquals('0=1',$c->condition);


### PR DESCRIPTION
use a static count of param placeholders in CDbCommandBuilder, same as in CDbCriteria, fixes #583