### PR TITLE
Fixes issues caused by bug #835 fix, no longer able to terminate silently

### DIFF
--- a/framework/base/CApplication.php
+++ b/framework/base/CApplication.php
@@ -176,7 +176,7 @@ abstract class CApplication extends CModule
 	{
 		if($this->hasEventHandler('onBeginRequest'))
 			$this->onBeginRequest(new CEvent($this));
-		register_shutdown_function(array($this,'shutdown'));
+		register_shutdown_function(array($this,'shutdown'),0,false);
 		$this->processRequest();
 		if($this->hasEventHandler('onEndRequest'))
 			$this->onEndRequest(new CEvent($this));
@@ -202,13 +202,16 @@ abstract class CApplication extends CModule
 	 * This method is triggered by PHP's register_shutdown_function()
 	 * Terminates the application silently by calling
 	 * {@link end} but discards output.
+	 * @param integer $status exit status (value 0 means normal exit while other values mean abnormal exit).
+	 * @param boolean $exit whether to exit the current request.
 	 */
-	public function shutdown()
+	public function shutdown($status=0,$exit=true)
 	{
 		ob_start();
 		$this->end(0,false);
 		ob_end_clean();
-		exit(0);
+		if($exit)
+			exit($status);
 	}
 
 	/**

--- a/framework/base/CApplication.php
+++ b/framework/base/CApplication.php
@@ -176,7 +176,7 @@ abstract class CApplication extends CModule
 	{
 		if($this->hasEventHandler('onBeginRequest'))
 			$this->onBeginRequest(new CEvent($this));
-		register_shutdown_function(array($this,'end'),0,false);
+		register_shutdown_function(array($this,'shutdown'));
 		$this->processRequest();
 		if($this->hasEventHandler('onEndRequest'))
 			$this->onEndRequest(new CEvent($this));
@@ -196,6 +196,19 @@ abstract class CApplication extends CModule
 			$this->onEndRequest(new CEvent($this));
 		if($exit)
 			exit($status);
+	}
+	
+	/**
+	 * This method is triggered by PHP's register_shutdown_function()
+	 * Terminates the application silently by calling
+	 * {@link end} but discards output.
+	 */
+	public function shutdown()
+	{
+		ob_start();
+		$this->end(0,false);
+		ob_end_clean();
+		exit(0);
 	}
 
 	/**

--- a/framework/web/CHttpRequest.php
+++ b/framework/web/CHttpRequest.php
@@ -1066,9 +1066,7 @@ class CHttpRequest extends CApplicationComponent
 		{
 			// clean up the application first because the file downloading could take long time
 			// which may cause timeout of some resources (such as DB connection)
-			ob_start();
-			Yii::app()->end(0,false);
-			ob_end_clean();
+			Yii::app()->shutdown(0,false);
 			echo $content;
 			exit(0);
 		}

--- a/framework/yiilite.php
+++ b/framework/yiilite.php
@@ -1187,7 +1187,7 @@ abstract class CApplication extends CModule
 	{
 		if($this->hasEventHandler('onBeginRequest'))
 			$this->onBeginRequest(new CEvent($this));
-		register_shutdown_function(array($this,'end'),0,false);
+		register_shutdown_function(array($this,'shutdown'),0,false);
 		$this->processRequest();
 		if($this->hasEventHandler('onEndRequest'))
 			$this->onEndRequest(new CEvent($this));
@@ -1196,6 +1196,14 @@ abstract class CApplication extends CModule
 	{
 		if($this->hasEventHandler('onEndRequest'))
 			$this->onEndRequest(new CEvent($this));
+		if($exit)
+			exit($status);
+	}
+	public function shutdown($status=0,$exit=true)
+	{
+		ob_start();
+		$this->end(0,false);
+		ob_end_clean();
 		if($exit)
 			exit($status);
 	}


### PR DESCRIPTION
Fixes issues caused by https://github.com/yiisoft/yii/issues/835 where it was no longer possible to terminate the application silently.  E.g. when sending non-HTML (JSON, files, images, etc) and debug info is on, many people use exit to avoid output.

See http://www.yiiframework.com/forum/index.php/topic/47227-issues-with-fixed-bug-835-onendrequest/