### PR TITLE
support for using pdo_odbc by overriding driverName property of CDbConnection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ Version 1.1.15 under development
 - Bug #2876: Fixed single quotes in comments column causes syntax error in model code generated  by Gii(klimov-paul)
 - Enh: Public method CFileHelper::createDirectory() has been added (klimov-paul)
 - Enh #106: Added getters to CGridColumn to allow getting cell contents for extended use cases of CGridView (cebe)
+- Enh #132: Support for using pdo_odbc by overriding driverName property of CDbConnection (nineinchnick)
 - Enh #182: CSort: allow arrays in asc/desc keys of virtual attributes (nineinchnick)
 - Enh #640: Introduce bigpk and bigint column types in each class extending CDbSchema (nineinchnick)
 - Enh #2737: CFileCache: added cachePathMode and cacheFileMode options to set modes used by chmod() for cache directory and files (ujovlado)

--- a/framework/db/CDbConnection.php
+++ b/framework/db/CDbConnection.php
@@ -250,6 +250,8 @@ class CDbConnection extends CApplicationComponent
 	 */
 	public $pdoClass = 'PDO';
 
+	protected $_driverName;
+
 	private $_attributes=array();
 	private $_active=false;
 	private $_pdo;
@@ -413,9 +415,8 @@ class CDbConnection extends CApplicationComponent
 	protected function createPdoInstance()
 	{
 		$pdoClass=$this->pdoClass;
-		if(($pos=strpos($this->connectionString,':'))!==false)
+		if(($driver=$this->getDriverName())!==null)
 		{
-			$driver=strtolower(substr($this->connectionString,0,$pos));
 			if($driver==='mssql' || $driver==='dblib')
 				$pdoClass='CMssqlPdoAdapter';
 			elseif($driver==='sqlsrv')
@@ -692,9 +693,20 @@ class CDbConnection extends CApplicationComponent
 	 */
 	public function getDriverName()
 	{
-		if(($pos=strpos($this->connectionString, ':'))!==false)
-			return strtolower(substr($this->connectionString, 0, $pos));
+		if($this->_driverName!==null)
+			return $this->_driverName;
+		elseif(($pos=strpos($this->connectionString, ':'))!==false)
+			return $this->_driverName=strtolower(substr($this->connectionString, 0, $pos));
 		// return $this->getAttribute(PDO::ATTR_DRIVER_NAME);
+	}
+
+	/**
+	 * Sets driverName, overriding value extracted from the {@link connectionString}.
+	 * @param string $value a key from the {@link driverMap} property
+	 */
+	public function setDriverName($value)
+	{
+		$this->_driverName = $value;
 	}
 
 	/**

--- a/tests/framework/db/CDbConnectionTest.php
+++ b/tests/framework/db/CDbConnectionTest.php
@@ -109,4 +109,22 @@ class CDbConnectionTest extends CTestCase
 		$this->_connection->nullConversion=PDO::NULL_EMPTY_STRING;
 		$this->assertEquals(PDO::NULL_EMPTY_STRING,$this->_connection->NullConversion);
 	}
+
+	public function testOdbc()
+	{
+		if(!extension_loaded('pdo_odbc'))
+			$this->markTestSkipped('pdo_odbc extension is required.');
+		$db=new CDbConnection;
+		$db->connectionString='odbc:Driver=SQLite3;Database=:memory:';
+		$db->driverName = 'sqlite';
+
+		$this->assertEquals('odbc', $db->getAttribute(PDO::ATTR_DRIVER_NAME));
+		$this->assertEquals('sqlite', $db->getDriverName());
+
+		$sql='SELECT * FROM posts';
+		$db->active=true;
+		$db->pdoInstance->exec(file_get_contents(dirname(__FILE__).'/data/sqlite.sql'));
+		$command=$db->createCommand($sql);
+		$this->assertTrue($command instanceof CDbCommand);
+	}
 }


### PR DESCRIPTION
Resolves #132. Forgot to add somewhere that the test along with pdo_odbc also requires a [driver for SQLite3](http://www.ch-werner.de/sqliteodbc/).
