### PR TITLE
Added id parameter to CSort and CPagination

### DIFF
--- a/framework/web/CDataProvider.php
+++ b/framework/web/CDataProvider.php
@@ -72,7 +72,7 @@ abstract class CDataProvider extends CComponent implements IDataProvider
 		{
 			$this->_pagination=new $className;
 			if(($id=$this->getId())!='')
-				$this->_pagination->pageVar=$id.'_page';
+				$this->_pagination->setId($id);
 		}
 		return $this->_pagination;
 	}
@@ -120,7 +120,7 @@ abstract class CDataProvider extends CComponent implements IDataProvider
 		{
 			$this->_sort=new $className;
 			if(($id=$this->getId())!='')
-				$this->_sort->sortVar=$id.'_sort';
+				$this->_sort->setId($id);
 		}
 		return $this->_sort;
 	}

--- a/framework/web/CPagination.php
+++ b/framework/web/CPagination.php
@@ -50,6 +50,7 @@
  * )) ?>
  * </pre>
  *
+ * @property string $id The unique ID that uniquely identifies the underlying data.
  * @property integer $pageSize Number of items in each page. Defaults to 10.
  * @property integer $itemCount Total number of items. Defaults to 0.
  * @property integer $pageCount Number of pages.
@@ -99,6 +100,7 @@ class CPagination extends CComponent
 	private $_pageSize=self::DEFAULT_PAGE_SIZE;
 	private $_itemCount=0;
 	private $_currentPage;
+	private $_id;
 
 	/**
 	 * Constructor.
@@ -109,6 +111,28 @@ class CPagination extends CComponent
 		$this->setItemCount($itemCount);
 	}
 
+	/**
+	 * Returns the ID that uniquely identifies the underlying data.
+	 * @return string the unique ID that uniquely identifies the underlying data.
+	 */
+	public function getId()
+	{
+		return $this->_id;
+	}
+
+	/**
+	 * Sets the underlying data ID.
+	 * @param string $value the unique ID that uniquely identifies the underlying data.
+	 */
+	public function setId($value)
+	{
+		$this->_id=$value;
+		if($value!='')
+			$this->pageVar=$value.'_page';
+		else
+			$this->pageVar='page';
+	}
+	
 	/**
 	 * @return integer number of items in each page. Defaults to 10.
 	 */

--- a/framework/web/CSort.php
+++ b/framework/web/CSort.php
@@ -36,6 +36,7 @@
  * represent the attribute names, while the values represent the virtual attribute definitions.
  * For more details, please check the documentation about {@link attributes}.
  *
+ * @property string $id The unique ID that uniquely identifies the underlying data.
  * @property string $orderBy The order-by columns represented by this sort object.
  * This can be put in the ORDER BY clause of a SQL statement.
  * @property array $directions Sort directions indexed by attribute names.
@@ -194,6 +195,7 @@ class CSort extends CComponent
 	public $params;
 
 	private $_directions;
+	private $_id;
 
 	/**
 	 * Constructor.
@@ -203,6 +205,28 @@ class CSort extends CComponent
 	public function __construct($modelClass=null)
 	{
 		$this->modelClass=$modelClass;
+	}
+	
+	/**
+	 * Returns the ID that uniquely identifies the underlying data.
+	 * @return string the unique ID that uniquely identifies the underlying data.
+	 */
+	public function getId()
+	{
+		return $this->_id;
+	}
+
+	/**
+	 * Sets the sort ID.
+	 * @param string $value the unique ID that uniquely identifies the underlying data.
+	 */
+	public function setId($value)
+	{
+		$this->_id=$value;
+		if($value!='')
+			$this->sortVar=$value.'_sort';
+		else
+			$this->sortVar='sort';
 	}
 
 	/**


### PR DESCRIPTION
CDataProvider should not know about pagination->pageVar and
pagination->sortVar. Setting the 'id' param allowed me to use a subclass
of CPagination which also has a pageSizeVar to handle pageSize the same
way as pageVar
