### PR TITLE
CJuiDatepicker fix a bug when defaultOptions are set but 'language' param is not set (Chinese instead of English)

### DIFF
--- a/framework/zii/widgets/jui/CJuiDatePicker.php
+++ b/framework/zii/widgets/jui/CJuiDatePicker.php
@@ -110,7 +110,7 @@ class CJuiDatePicker extends CJuiInputWidget
 		$options=CJavaScript::encode($this->options);
 		$js = "jQuery('#{$id}').datepicker($options);";
 
-		if($this->language!='' && $this->language!='en')
+		if(!$this->_isLangDefault())
 		{
 			$this->registerScriptFile($this->i18nScriptFile);
 			$js = "jQuery('#{$id}').datepicker(jQuery.extend({showMonthAfterYear:false},jQuery.datepicker.regional['{$this->language}'],{$options}));";
@@ -120,9 +120,18 @@ class CJuiDatePicker extends CJuiInputWidget
 
 		if(isset($this->defaultOptions))
 		{
-			$this->registerScriptFile($this->i18nScriptFile);
+			if(!$this->_isLangDefault())
+			{
+				$this->registerScriptFile($this->i18nScriptFile);
+			}
+
 			$cs->registerScript(__CLASS__,$this->defaultOptions!==null?'jQuery.datepicker.setDefaults('.CJavaScript::encode($this->defaultOptions).');':'');
 		}
 		$cs->registerScript(__CLASS__.'#'.$id,$js);
+	}
+
+	private function _isLangDefault()
+	{
+		return $this->language=='' || $this->language=='en';
 	}
 }


### PR DESCRIPTION
When no 'language' is set for datepicker widget, but the 'defaultOptions' param is filled, the calendar is displayed in Chinese (or some other language, I'm not quite sure, using the  hieroglyphs) when it must be displayed in English. I encountered with this behaviour in a lot of questions on the internet (especially amoung yii beginners like me).
I'm attaching 2 screenshot with bug and after my fix.

Also here https://www.dropbox.com/s/fkvx4dj8kwnthsz/jui_bug_chinese.zip you can find a small yii view code which can be usefull to reproduce the bug.

![bug](https://f.cloud.github.com/assets/3856071/1320068/83a1c942-3334-11e3-982e-16c35d1fe006.jpg)
![fix](https://f.cloud.github.com/assets/3856071/1320067/8390c4f8-3334-11e3-9bf7-e181d7c693f5.jpg)
