### PR TITLE
Fix issue 2993 - Crash when inserting a record with a DATETIME with CURRENT_TIMESTAMP as default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
                    ========================
 Work in progress
 ----------------
+- Bug 2993: Crash when inserting a record with a DATETIME with CURRENT_TIMESTAMP as default
 
 Version 1.1.15 under development
 --------------------------------

--- a/framework/db/schema/mysql/CMysqlColumnSchema.php
+++ b/framework/db/schema/mysql/CMysqlColumnSchema.php
@@ -46,6 +46,8 @@ class CMysqlColumnSchema extends CDbColumnSchema
 			$this->defaultValue=bindec(trim($defaultValue,'b\''));
 		elseif($this->dbType==='timestamp' && $defaultValue==='CURRENT_TIMESTAMP')
 			$this->defaultValue=null;
+		elseif($this->dbType==='datetime' && $defaultValue==='CURRENT_TIMESTAMP')
+			$this->defaultValue=null;
 		else
 			parent::extractDefault($defaultValue);
 	}


### PR DESCRIPTION
Fix for issue 2993
