### PR TITLE
New CDecimalValidator for SQL Decimal Data Types

### DIFF
--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -776,6 +776,7 @@ class YiiBase
 		'CFilterValidator' => '/validators/CFilterValidator.php',
 		'CInlineValidator' => '/validators/CInlineValidator.php',
 		'CNumberValidator' => '/validators/CNumberValidator.php',
+		'CDecimalValidator' => '/validators/CDecimalValidator.php',
 		'CRangeValidator' => '/validators/CRangeValidator.php',
 		'CRegularExpressionValidator' => '/validators/CRegularExpressionValidator.php',
 		'CRequiredValidator' => '/validators/CRequiredValidator.php',

--- a/framework/gii/generators/model/ModelCode.php
+++ b/framework/gii/generators/model/ModelCode.php
@@ -26,7 +26,7 @@ class ModelCode extends CCodeModel
 			array('connectionId', 'validateConnectionId', 'skipOnError'=>true),
 			array('tableName', 'validateTableName', 'skipOnError'=>true),
 			array('tablePrefix, modelClass', 'match', 'pattern'=>'/^[a-zA-Z_]\w*$/', 'message'=>'{attribute} should only contain word characters.'),
-				array('baseClass', 'match', 'pattern'=>'/^[a-zA-Z_][\w\\\\]*$/', 'message'=>'{attribute} should only contain word characters and backslashes.'),
+      array('baseClass', 'match', 'pattern'=>'/^[a-zA-Z_][\w\\\\]*$/', 'message'=>'{attribute} should only contain word characters and backslashes.'),
 			array('modelPath', 'validateModelPath', 'skipOnError'=>true),
 			array('baseClass, modelClass', 'validateReservedWord', 'skipOnError'=>true),
 			array('baseClass', 'validateBaseClass', 'skipOnError'=>true),
@@ -350,7 +350,7 @@ class ModelCode extends CCodeModel
 				{
 					// Put table and key name in variables for easier reading
 					$refTable=$fkEntry[0]; // Table name that current fk references to
-					$refKey=$fkEntry[1];	 // Key in that table being referenced
+					$refKey=$fkEntry[1];   // Key in that table being referenced
 					$refClassName=$this->generateClassName($refTable);
 
 					// Add relation for this table
@@ -392,7 +392,7 @@ class ModelCode extends CCodeModel
 			return $this->modelClass;
 
 		$tableName=$this->removePrefix($tableName,false);
-		if(($pos=strpos($tableName,'.'))!==false) // remove schema part (e.g. remove 'public2.' from 'public2.post')
+		if(($pos=strpos($tableName,'.'))!==false)  // remove schema part (e.g. remove 'public2.' from 'public2.post')
 			$tableName=substr($tableName,$pos+1);
 		$className='';
 		foreach(explode('_',$tableName) as $name)
@@ -422,7 +422,7 @@ class ModelCode extends CCodeModel
 			$relationName=$this->pluralize($relationName);
 
 		$names=preg_split('/_+/',$relationName,-1,PREG_SPLIT_NO_EMPTY);
-		if(empty($names)) return $relationName;	// unlikely
+		if(empty($names)) return $relationName;  // unlikely
 		for($name=$names[0], $i=1;$i<count($names);++$i)
 			$name.=ucfirst($names[$i]);
 

--- a/framework/gii/generators/model/ModelCode.php
+++ b/framework/gii/generators/model/ModelCode.php
@@ -392,7 +392,7 @@ class ModelCode extends CCodeModel
 			return $this->modelClass;
 
 		$tableName=$this->removePrefix($tableName,false);
-		if(($pos=strpos($tableName,'.'))!==false)  // remove schema part (e.g. remove 'public2.' from 'public2.post')
+		if(($pos=strpos($tableName,'.'))!==false) // remove schema part (e.g. remove 'public2.' from 'public2.post')
 			$tableName=substr($tableName,$pos+1);
 		$className='';
 		foreach(explode('_',$tableName) as $name)

--- a/framework/gii/generators/model/ModelCode.php
+++ b/framework/gii/generators/model/ModelCode.php
@@ -26,7 +26,7 @@ class ModelCode extends CCodeModel
 			array('connectionId', 'validateConnectionId', 'skipOnError'=>true),
 			array('tableName', 'validateTableName', 'skipOnError'=>true),
 			array('tablePrefix, modelClass', 'match', 'pattern'=>'/^[a-zA-Z_]\w*$/', 'message'=>'{attribute} should only contain word characters.'),
-      array('baseClass', 'match', 'pattern'=>'/^[a-zA-Z_][\w\\\\]*$/', 'message'=>'{attribute} should only contain word characters and backslashes.'),
+			array('baseClass', 'match', 'pattern'=>'/^[a-zA-Z_][\w\\\\]*$/', 'message'=>'{attribute} should only contain word characters and backslashes.'),
 			array('modelPath', 'validateModelPath', 'skipOnError'=>true),
 			array('baseClass, modelClass', 'validateReservedWord', 'skipOnError'=>true),
 			array('baseClass', 'validateBaseClass', 'skipOnError'=>true),
@@ -350,7 +350,7 @@ class ModelCode extends CCodeModel
 				{
 					// Put table and key name in variables for easier reading
 					$refTable=$fkEntry[0]; // Table name that current fk references to
-					$refKey=$fkEntry[1];   // Key in that table being referenced
+					$refKey=$fkEntry[1];	 // Key in that table being referenced
 					$refClassName=$this->generateClassName($refTable);
 
 					// Add relation for this table
@@ -422,7 +422,7 @@ class ModelCode extends CCodeModel
 			$relationName=$this->pluralize($relationName);
 
 		$names=preg_split('/_+/',$relationName,-1,PREG_SPLIT_NO_EMPTY);
-		if(empty($names)) return $relationName;  // unlikely
+		if(empty($names)) return $relationName;	// unlikely
 		for($name=$names[0], $i=1;$i<count($names);++$i)
 			$name.=ucfirst($names[$i]);
 

--- a/framework/gii/generators/model/ModelCode.php
+++ b/framework/gii/generators/model/ModelCode.php
@@ -350,7 +350,7 @@ class ModelCode extends CCodeModel
 				{
 					// Put table and key name in variables for easier reading
 					$refTable=$fkEntry[0]; // Table name that current fk references to
-					$refKey=$fkEntry[1];	 // Key in that table being referenced
+					$refKey=$fkEntry[1];   // Key in that table being referenced
 					$refClassName=$this->generateClassName($refTable);
 
 					// Add relation for this table
@@ -422,7 +422,7 @@ class ModelCode extends CCodeModel
 			$relationName=$this->pluralize($relationName);
 
 		$names=preg_split('/_+/',$relationName,-1,PREG_SPLIT_NO_EMPTY);
-		if(empty($names)) return $relationName;	// unlikely
+		if(empty($names)) return $relationName;  // unlikely
 		for($name=$names[0], $i=1;$i<count($names);++$i)
 			$name.=ucfirst($names[$i]);
 

--- a/framework/validators/CDecimalValidator.php
+++ b/framework/validators/CDecimalValidator.php
@@ -157,9 +157,11 @@ class CDecimalValidator extends CValidator
 		$c = localeconv();
 		$thousands = $c['thousands_sep'] ?: ',';
 		$decimal = $c['decimal_point'] ?: '.';
+    $thousandsMatch = ($thousands == '.') ? "\\." : $thousands;
+    $decimalMatch = ($thousands == '.') ? "\\." : $decimal;
 		$pattern=$this->numberPattern;
-		$pattern = str_replace("\\.","\\".$decimal,$pattern);
-		$pattern = str_replace(',',$thousands,$pattern);
+		$pattern = str_replace("\\.",$decimalMatch,$pattern);
+		$pattern = str_replace(',',$thousandsMatch,$pattern);
 		
 		$js="
 if(typeof(value)!='undefined' && value!==null && jQuery.trim(value)!='') {
@@ -174,7 +176,7 @@ if(typeof(value)!='undefined' && value!==null && jQuery.trim(value)!='') {
 		if($this->maxIntDigits!==null || $this->maxFloatDigits!==null)
 		{
 			$js.="
-		var parts = value.replace(/$thousands/g,\"\").split(\"$decimal\");
+		var parts = value.replace(/$thousandsMatch/g,\"\").split(\"$decimal\");
 ";
 		}
 		if($this->maxIntDigits!==null)

--- a/framework/validators/CDecimalValidator.php
+++ b/framework/validators/CDecimalValidator.php
@@ -84,7 +84,7 @@ class CDecimalValidator extends CValidator
 		if(is_string($value))
 			$value=trim(str_replace($thousands,'',$value));
 		
-		if(!is_numeric($value) || !empty(trim($value,'+-.,0123456789')))
+		if(!is_numeric($value) || trim($value,'+-.,0123456789'))
 		{
 			$this->addError($object, $attribute, Yii::t('yii',$this->message));
 			return;

--- a/framework/validators/CDecimalValidator.php
+++ b/framework/validators/CDecimalValidator.php
@@ -1,0 +1,209 @@
+﻿<?php
+/**
+ * CDecimalValidator class file.
+ *
+ * @author Evan King <evan.king@bluespurs.com>
+ * @link http://www.yiiframework.com/
+ * @copyright 2008-2013 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+/**
+ * CDecimalValidator validates that the attribute value is an SQL decimal value.
+ *
+ * In addition to the {@link message} property for setting a custom error message,
+ * CDecimalValidator has a couple custom error messages you can set that correspond
+ * to different validation scenarios. To specify a custom message when the numeric
+ * value has too many digits before the decimal, you may use the {@link tooManyIntDigits}
+ * property. Similarly with {@link tooManyFloatDigits} for too many digits after the
+ * decimal.
+ * The messages may contain additional placeholders that will be replaced with the
+ * actual content. In addition to the "{attribute}" placeholder, recognized by all
+ * validators (see {@link CValidator}), CDecimalValidator allows for the following
+ * placeholders to be specified:
+ * <ul>
+ * <li>{max}: the maximum number of digits on the side of the decimal being validated {@link max}.</li>
+ * </ul>
+ *
+ * @author Evan King <evan.king@bluespurs.com>
+ * @package system.validators
+ * @since never
+ */
+class CDecimalValidator extends CValidator
+{
+	/**
+	 * @var boolean whether the attribute value can be null or empty. Defaults to true,
+	 * meaning that if the attribute is empty, it is considered valid.
+	 */
+	public $allowEmpty=true;
+	/**
+	 * @var integer|float upper limit of the number. Defaults to null, meaning no upper limit.
+	 */
+	public $maxIntDigits;
+	/**
+	 * @var integer|float lower limit of the number. Defaults to null, meaning no lower limit.
+	 */
+	public $maxFloatDigits;
+	/**
+	 * @var string user-defined error message used when the input is not a number.
+	 */
+	public $message = '{attribute} must be a decimal number.';
+	/**
+	 * @var string user-defined error message used when there are too many digits before the decimal.
+	 */
+	public $tooManyIntDigits = '{attribute} has too many digits before the decimal (maximum is {max}).';
+	/**
+	 * @var string user-defined error message used when there are too many digits after the decimal.
+	 */
+	public $tooManyFloatDigits = '{attribute} has too many digits after the decimal (maximum is {max}).';
+	/**
+	 * @var string the regular expression for matching numbers.
+	 * @since 1.1.7
+	 */
+	public $numberPattern='/^\s*[-+]?[0-9]*(,[0-9]{3})*\.?[0-9]*\s*$/';
+
+
+	/**
+	 * Validates the attribute of the object.
+	 * If there is any error, the error message is added to the object.
+	 * @param CModel $object the object being validated
+	 * @param string $attribute the attribute being validated
+	 */
+	protected function validateAttribute($object,$attribute)
+	{
+		$value=$object->$attribute;
+		if($this->allowEmpty && $this->isEmpty($value))
+			return;
+    
+    // Note: localeconv fails to return +- signs even when locale has been set,
+    //  and SQL does not accept negative numbers in parenthesized format anyway
+    $c = localeconv();
+    $thousands = $c['thousands_sep'] ?: ',';
+    $decimal = $c['decimal_point'] ?: '.';
+    
+    if(is_string($value))
+      $value=trim(str_replace($thousands,'',$value));
+    
+		if(!is_numeric($value) || !empty(trim($value,'+-.,0123456789')))
+		{
+			$this->addError($object, $attribute, Yii::t('yii',$this->message));
+			return;
+		}
+    
+    $value=rtrim(ltrim($value,'0+-'),'0');
+    
+    $parts = explode($decimal,$value);
+    if(count($parts)>2)
+    {
+			$this->addError($object, $attribute, Yii::t('yii',$this->message));
+    }
+    
+    @list($intstr, $floatstr) = $parts;
+    if((int)$intstr!=$intstr || (int)$floatstr!=$floatstr)
+    {
+			$this->addError($object,$attribute,Yii::t('yii',$this->message));
+    }
+    
+    if($this->maxIntDigits!==null && strlen($intstr)>$this->maxIntDigits)
+    {
+			$this->addError(
+        $object,
+        $attribute,
+        Yii::t('yii',$this->tooManyIntDigits),
+        array('{max}'=>$this->maxIntDigits)
+      );
+    }
+    
+    if($this->maxFloatDigits!==null && strlen($floatstr)>$this->maxFloatDigits)
+    {
+			$this->addError(
+        $object,
+        $attribute,
+        Yii::t('yii',$this->tooManyFloatDigits),
+        array('{max}'=>$this->maxFloatDigits)
+      );
+    }
+	}
+
+	/**
+	 * Returns the JavaScript needed for performing client-side validation.
+	 * @param CModel $object the data object being validated
+	 * @param string $attribute the name of the attribute to be validated.
+	 * @return string the client-side validation script.
+	 * @see CActiveForm::enableClientValidation
+	 * @since 1.1.7
+	 */
+	public function clientValidateAttribute($object,$attribute)
+	{
+    if(!$this->enableClientValidation)
+      return '';
+    
+		$label=$object->getAttributeLabel($attribute);
+    
+		$message=strtr($this->message,array(
+      '{attribute}'=>$label,
+    ));
+    
+		$tooManyIntDigits=strtr($this->tooManyIntDigits,array(
+      '{attribute}'=>$label,
+			'{max}'=>$this->maxIntDigits,
+    ));
+    
+		$tooManyFloatDigits=strtr($this->tooManyFloatDigits,array(
+      '{attribute}'=>$label,
+			'{max}'=>$this->maxFloatDigits,
+    ));
+    
+    $c = localeconv();
+    $thousands = $c['thousands_sep'] ?: ',';
+    $decimal = $c['decimal_point'] ?: '.';
+		$pattern=$this->numberPattern;
+    $pattern = str_replace("\\.","\\".$decimal,$pattern);
+    $pattern = str_replace(',',$thousands,$pattern);
+    
+    $js="
+if(typeof(value)!='undefined' && value!==null && jQuery.trim(value)!='') {
+  value = String(value).replace(/^[+-]?0*/, '').replace(/0+$/, '');
+";
+
+		$js.="
+  if(!value.match($pattern)) {
+    messages.push(".CJSON::encode($message).");
+  } else {
+";
+		if($this->maxIntDigits!==null || $this->maxFloatDigits!==null)
+		{
+			$js.="
+    var parts = value.replace(/$thousands/g,\"\").split(\"$decimal\");
+";
+		}
+		if($this->maxIntDigits!==null)
+		{
+			$js.="
+    if(parts[0] && parts[0].length>{$this->maxIntDigits}) {
+      messages.push(".CJSON::encode($tooManyIntDigits).");
+    }
+";
+		}
+		if($this->maxFloatDigits!==null)
+		{
+			$js.="
+    if(parts[1] && parts[1].length>{$this->maxFloatDigits}) {
+      messages.push(".CJSON::encode($tooManyFloatDigits).");
+    }
+";
+		}
+    $js .= "
+  }
+}";
+
+		if(!$this->allowEmpty)
+		{
+			$js.=" else {
+  messages.push(".CJSON::encode($message).");
+}";
+		}
+
+		return $js;
+	}
+}

--- a/framework/validators/CDecimalValidator.php
+++ b/framework/validators/CDecimalValidator.php
@@ -158,7 +158,7 @@ class CDecimalValidator extends CValidator
 		$thousands = $c['thousands_sep'] ?: ',';
 		$decimal = $c['decimal_point'] ?: '.';
     $thousandsMatch = ($thousands == '.') ? "\\." : $thousands;
-    $decimalMatch = ($thousands == '.') ? "\\." : $decimal;
+    $decimalMatch = ($decimal == '.') ? "\\." : $decimal;
 		$pattern=$this->numberPattern;
 		$pattern = str_replace("\\.",$decimalMatch,$pattern);
 		$pattern = str_replace(',',$thousandsMatch,$pattern);

--- a/framework/validators/CDecimalValidator.php
+++ b/framework/validators/CDecimalValidator.php
@@ -31,179 +31,179 @@
  */
 class CDecimalValidator extends CValidator
 {
-	/**
-	 * @var boolean whether the attribute value can be null or empty. Defaults to true,
-	 * meaning that if the attribute is empty, it is considered valid.
-	 */
-	public $allowEmpty=true;
-	/**
-	 * @var integer|float upper limit of the number. Defaults to null, meaning no upper limit.
-	 */
-	public $maxIntDigits;
-	/**
-	 * @var integer|float lower limit of the number. Defaults to null, meaning no lower limit.
-	 */
-	public $maxFloatDigits;
-	/**
-	 * @var string user-defined error message used when the input is not a number.
-	 */
-	public $message = '{attribute} must be a decimal number.';
-	/**
-	 * @var string user-defined error message used when there are too many digits before the decimal.
-	 */
-	public $tooManyIntDigits = '{attribute} has too many digits before the decimal (maximum is {max}).';
-	/**
-	 * @var string user-defined error message used when there are too many digits after the decimal.
-	 */
-	public $tooManyFloatDigits = '{attribute} has too many digits after the decimal (maximum is {max}).';
-	/**
-	 * @var string the regular expression for matching numbers.
-	 * @since 1.1.7
-	 */
-	public $numberPattern='/^\s*[-+]?[0-9]*(,[0-9]{3})*\.?[0-9]*\s*$/';
+    /**
+     * @var boolean whether the attribute value can be null or empty. Defaults to true,
+     * meaning that if the attribute is empty, it is considered valid.
+     */
+    public $allowEmpty=true;
+    /**
+     * @var integer|float upper limit of the number. Defaults to null, meaning no upper limit.
+     */
+    public $maxIntDigits;
+    /**
+     * @var integer|float lower limit of the number. Defaults to null, meaning no lower limit.
+     */
+    public $maxFloatDigits;
+    /**
+     * @var string user-defined error message used when the input is not a number.
+     */
+    public $message = '{attribute} must be a decimal number.';
+    /**
+     * @var string user-defined error message used when there are too many digits before the decimal.
+     */
+    public $tooManyIntDigits = '{attribute} has too many digits before the decimal (maximum is {max}).';
+    /**
+     * @var string user-defined error message used when there are too many digits after the decimal.
+     */
+    public $tooManyFloatDigits = '{attribute} has too many digits after the decimal (maximum is {max}).';
+    /**
+     * @var string the regular expression for matching numbers.
+     * @since 1.1.7
+     */
+    public $numberPattern='/^\s*[-+]?[0-9]*(,[0-9]{3})*\.?[0-9]*\s*$/';
 
 
-	/**
-	 * Validates the attribute of the object.
-	 * If there is any error, the error message is added to the object.
-	 * @param CModel $object the object being validated
-	 * @param string $attribute the attribute being validated
-	 */
-	protected function validateAttribute($object,$attribute)
-	{
-		$value=$object->$attribute;
-		if($this->allowEmpty && $this->isEmpty($value))
-			return;
-    
-    // Note: localeconv fails to return +- signs even when locale has been set,
-    //  and SQL does not accept negative numbers in parenthesized format anyway
-    $c = localeconv();
-    $thousands = $c['thousands_sep'] ?: ',';
-    $decimal = $c['decimal_point'] ?: '.';
-    
-    if(is_string($value))
-      $value=trim(str_replace($thousands,'',$value));
-    
-		if(!is_numeric($value) || !empty(trim($value,'+-.,0123456789')))
-		{
-			$this->addError($object, $attribute, Yii::t('yii',$this->message));
-			return;
-		}
-    
-    $value=rtrim(ltrim($value,'0+-'),'0');
-    
-    $parts = explode($decimal,$value);
-    if(count($parts)>2)
+    /**
+     * Validates the attribute of the object.
+     * If there is any error, the error message is added to the object.
+     * @param CModel $object the object being validated
+     * @param string $attribute the attribute being validated
+     */
+    protected function validateAttribute($object,$attribute)
     {
-			$this->addError($object, $attribute, Yii::t('yii',$this->message));
+        $value=$object->$attribute;
+        if($this->allowEmpty && $this->isEmpty($value))
+            return;
+        
+        // Note: localeconv fails to return +- signs even when locale has been set,
+        //    and SQL does not accept negative numbers in parenthesized format anyway
+        $c = localeconv();
+        $thousands = $c['thousands_sep'] ?: ',';
+        $decimal = $c['decimal_point'] ?: '.';
+        
+        if(is_string($value))
+            $value=trim(str_replace($thousands,'',$value));
+        
+        if(!is_numeric($value) || !empty(trim($value,'+-.,0123456789')))
+        {
+            $this->addError($object, $attribute, Yii::t('yii',$this->message));
+            return;
+        }
+        
+        $value=rtrim(ltrim($value,'0+-'),'0');
+        
+        $parts = explode($decimal,$value);
+        if(count($parts)>2)
+        {
+            $this->addError($object, $attribute, Yii::t('yii',$this->message));
+        }
+        
+        @list($intstr, $floatstr) = $parts;
+        if((int)$intstr!=$intstr || (int)$floatstr!=$floatstr)
+        {
+            $this->addError($object,$attribute,Yii::t('yii',$this->message));
+        }
+        
+        if($this->maxIntDigits!==null && strlen($intstr)>$this->maxIntDigits)
+        {
+            $this->addError(
+                $object,
+                $attribute,
+                Yii::t('yii',$this->tooManyIntDigits),
+                array('{max}'=>$this->maxIntDigits)
+            );
+        }
+        
+        if($this->maxFloatDigits!==null && strlen($floatstr)>$this->maxFloatDigits)
+        {
+            $this->addError(
+                $object,
+                $attribute,
+                Yii::t('yii',$this->tooManyFloatDigits),
+                array('{max}'=>$this->maxFloatDigits)
+            );
+        }
     }
-    
-    @list($intstr, $floatstr) = $parts;
-    if((int)$intstr!=$intstr || (int)$floatstr!=$floatstr)
-    {
-			$this->addError($object,$attribute,Yii::t('yii',$this->message));
-    }
-    
-    if($this->maxIntDigits!==null && strlen($intstr)>$this->maxIntDigits)
-    {
-			$this->addError(
-        $object,
-        $attribute,
-        Yii::t('yii',$this->tooManyIntDigits),
-        array('{max}'=>$this->maxIntDigits)
-      );
-    }
-    
-    if($this->maxFloatDigits!==null && strlen($floatstr)>$this->maxFloatDigits)
-    {
-			$this->addError(
-        $object,
-        $attribute,
-        Yii::t('yii',$this->tooManyFloatDigits),
-        array('{max}'=>$this->maxFloatDigits)
-      );
-    }
-	}
 
-	/**
-	 * Returns the JavaScript needed for performing client-side validation.
-	 * @param CModel $object the data object being validated
-	 * @param string $attribute the name of the attribute to be validated.
-	 * @return string the client-side validation script.
-	 * @see CActiveForm::enableClientValidation
-	 * @since 1.1.7
-	 */
-	public function clientValidateAttribute($object,$attribute)
-	{
-    if(!$this->enableClientValidation)
-      return '';
-    
-		$label=$object->getAttributeLabel($attribute);
-    
-		$message=strtr($this->message,array(
-      '{attribute}'=>$label,
-    ));
-    
-		$tooManyIntDigits=strtr($this->tooManyIntDigits,array(
-      '{attribute}'=>$label,
-			'{max}'=>$this->maxIntDigits,
-    ));
-    
-		$tooManyFloatDigits=strtr($this->tooManyFloatDigits,array(
-      '{attribute}'=>$label,
-			'{max}'=>$this->maxFloatDigits,
-    ));
-    
-    $c = localeconv();
-    $thousands = $c['thousands_sep'] ?: ',';
-    $decimal = $c['decimal_point'] ?: '.';
-		$pattern=$this->numberPattern;
-    $pattern = str_replace("\\.","\\".$decimal,$pattern);
-    $pattern = str_replace(',',$thousands,$pattern);
-    
-    $js="
+    /**
+     * Returns the JavaScript needed for performing client-side validation.
+     * @param CModel $object the data object being validated
+     * @param string $attribute the name of the attribute to be validated.
+     * @return string the client-side validation script.
+     * @see CActiveForm::enableClientValidation
+     * @since 1.1.7
+     */
+    public function clientValidateAttribute($object,$attribute)
+    {
+        if(!$this->enableClientValidation)
+            return '';
+        
+        $label=$object->getAttributeLabel($attribute);
+        
+        $message=strtr($this->message,array(
+            '{attribute}'=>$label,
+        ));
+        
+        $tooManyIntDigits=strtr($this->tooManyIntDigits,array(
+            '{attribute}'=>$label,
+            '{max}'=>$this->maxIntDigits,
+        ));
+        
+        $tooManyFloatDigits=strtr($this->tooManyFloatDigits,array(
+            '{attribute}'=>$label,
+            '{max}'=>$this->maxFloatDigits,
+        ));
+        
+        $c = localeconv();
+        $thousands = $c['thousands_sep'] ?: ',';
+        $decimal = $c['decimal_point'] ?: '.';
+        $pattern=$this->numberPattern;
+        $pattern = str_replace("\\.","\\".$decimal,$pattern);
+        $pattern = str_replace(',',$thousands,$pattern);
+        
+        $js="
 if(typeof(value)!='undefined' && value!==null && jQuery.trim(value)!='') {
-  value = String(value).replace(/^[+-]?0*/, '').replace(/0+$/, '');
+    value = String(value).replace(/^[+-]?0*/, '').replace(/0+$/, '');
 ";
 
-		$js.="
-  if(!value.match($pattern)) {
+        $js.="
+    if(!value.match($pattern)) {
+        messages.push(".CJSON::encode($message).");
+    } else {
+";
+        if($this->maxIntDigits!==null || $this->maxFloatDigits!==null)
+        {
+            $js.="
+        var parts = value.replace(/$thousands/g,\"\").split(\"$decimal\");
+";
+        }
+        if($this->maxIntDigits!==null)
+        {
+            $js.="
+        if(parts[0] && parts[0].length>{$this->maxIntDigits}) {
+            messages.push(".CJSON::encode($tooManyIntDigits).");
+        }
+";
+        }
+        if($this->maxFloatDigits!==null)
+        {
+            $js.="
+        if(parts[1] && parts[1].length>{$this->maxFloatDigits}) {
+            messages.push(".CJSON::encode($tooManyFloatDigits).");
+        }
+";
+        }
+        $js .= "
+    }
+}";
+
+        if(!$this->allowEmpty)
+        {
+            $js.=" else {
     messages.push(".CJSON::encode($message).");
-  } else {
-";
-		if($this->maxIntDigits!==null || $this->maxFloatDigits!==null)
-		{
-			$js.="
-    var parts = value.replace(/$thousands/g,\"\").split(\"$decimal\");
-";
-		}
-		if($this->maxIntDigits!==null)
-		{
-			$js.="
-    if(parts[0] && parts[0].length>{$this->maxIntDigits}) {
-      messages.push(".CJSON::encode($tooManyIntDigits).");
-    }
-";
-		}
-		if($this->maxFloatDigits!==null)
-		{
-			$js.="
-    if(parts[1] && parts[1].length>{$this->maxFloatDigits}) {
-      messages.push(".CJSON::encode($tooManyFloatDigits).");
-    }
-";
-		}
-    $js .= "
-  }
 }";
+        }
 
-		if(!$this->allowEmpty)
-		{
-			$js.=" else {
-  messages.push(".CJSON::encode($message).");
-}";
-		}
-
-		return $js;
-	}
+        return $js;
+    }
 }

--- a/framework/validators/CDecimalValidator.php
+++ b/framework/validators/CDecimalValidator.php
@@ -157,8 +157,8 @@ class CDecimalValidator extends CValidator
 		$c = localeconv();
 		$thousands = $c['thousands_sep'] ?: ',';
 		$decimal = $c['decimal_point'] ?: '.';
-    $thousandsMatch = ($thousands == '.') ? "\\." : $thousands;
-    $decimalMatch = ($decimal == '.') ? "\\." : $decimal;
+		$thousandsMatch = ($thousands == '.') ? "\\." : $thousands;
+		$decimalMatch = ($decimal == '.') ? "\\." : $decimal;
 		$pattern=$this->numberPattern;
 		$pattern = str_replace("\\.",$decimalMatch,$pattern);
 		$pattern = str_replace(',',$thousandsMatch,$pattern);

--- a/framework/validators/CDecimalValidator.php
+++ b/framework/validators/CDecimalValidator.php
@@ -31,179 +31,179 @@
  */
 class CDecimalValidator extends CValidator
 {
-    /**
-     * @var boolean whether the attribute value can be null or empty. Defaults to true,
-     * meaning that if the attribute is empty, it is considered valid.
-     */
-    public $allowEmpty=true;
-    /**
-     * @var integer|float upper limit of the number. Defaults to null, meaning no upper limit.
-     */
-    public $maxIntDigits;
-    /**
-     * @var integer|float lower limit of the number. Defaults to null, meaning no lower limit.
-     */
-    public $maxFloatDigits;
-    /**
-     * @var string user-defined error message used when the input is not a number.
-     */
-    public $message = '{attribute} must be a decimal number.';
-    /**
-     * @var string user-defined error message used when there are too many digits before the decimal.
-     */
-    public $tooManyIntDigits = '{attribute} has too many digits before the decimal (maximum is {max}).';
-    /**
-     * @var string user-defined error message used when there are too many digits after the decimal.
-     */
-    public $tooManyFloatDigits = '{attribute} has too many digits after the decimal (maximum is {max}).';
-    /**
-     * @var string the regular expression for matching numbers.
-     * @since 1.1.7
-     */
-    public $numberPattern='/^\s*[-+]?[0-9]*(,[0-9]{3})*\.?[0-9]*\s*$/';
+	/**
+	 * @var boolean whether the attribute value can be null or empty. Defaults to true,
+	 * meaning that if the attribute is empty, it is considered valid.
+	 */
+	public $allowEmpty=true;
+	/**
+	 * @var integer|float upper limit of the number. Defaults to null, meaning no upper limit.
+	 */
+	public $maxIntDigits;
+	/**
+	 * @var integer|float lower limit of the number. Defaults to null, meaning no lower limit.
+	 */
+	public $maxFloatDigits;
+	/**
+	 * @var string user-defined error message used when the input is not a number.
+	 */
+	public $message = '{attribute} must be a decimal number.';
+	/**
+	 * @var string user-defined error message used when there are too many digits before the decimal.
+	 */
+	public $tooManyIntDigits = '{attribute} has too many digits before the decimal (maximum is {max}).';
+	/**
+	 * @var string user-defined error message used when there are too many digits after the decimal.
+	 */
+	public $tooManyFloatDigits = '{attribute} has too many digits after the decimal (maximum is {max}).';
+	/**
+	 * @var string the regular expression for matching numbers.
+	 * @since 1.1.7
+	 */
+	public $numberPattern='/^\s*[-+]?[0-9]*(,[0-9]{3})*\.?[0-9]*\s*$/';
 
 
-    /**
-     * Validates the attribute of the object.
-     * If there is any error, the error message is added to the object.
-     * @param CModel $object the object being validated
-     * @param string $attribute the attribute being validated
-     */
-    protected function validateAttribute($object,$attribute)
-    {
-        $value=$object->$attribute;
-        if($this->allowEmpty && $this->isEmpty($value))
-            return;
-        
-        // Note: localeconv fails to return +- signs even when locale has been set,
-        //    and SQL does not accept negative numbers in parenthesized format anyway
-        $c = localeconv();
-        $thousands = $c['thousands_sep'] ?: ',';
-        $decimal = $c['decimal_point'] ?: '.';
-        
-        if(is_string($value))
-            $value=trim(str_replace($thousands,'',$value));
-        
-        if(!is_numeric($value) || !empty(trim($value,'+-.,0123456789')))
-        {
-            $this->addError($object, $attribute, Yii::t('yii',$this->message));
-            return;
-        }
-        
-        $value=rtrim(ltrim($value,'0+-'),'0');
-        
-        $parts = explode($decimal,$value);
-        if(count($parts)>2)
-        {
-            $this->addError($object, $attribute, Yii::t('yii',$this->message));
-        }
-        
-        @list($intstr, $floatstr) = $parts;
-        if((int)$intstr!=$intstr || (int)$floatstr!=$floatstr)
-        {
-            $this->addError($object,$attribute,Yii::t('yii',$this->message));
-        }
-        
-        if($this->maxIntDigits!==null && strlen($intstr)>$this->maxIntDigits)
-        {
-            $this->addError(
-                $object,
-                $attribute,
-                Yii::t('yii',$this->tooManyIntDigits),
-                array('{max}'=>$this->maxIntDigits)
-            );
-        }
-        
-        if($this->maxFloatDigits!==null && strlen($floatstr)>$this->maxFloatDigits)
-        {
-            $this->addError(
-                $object,
-                $attribute,
-                Yii::t('yii',$this->tooManyFloatDigits),
-                array('{max}'=>$this->maxFloatDigits)
-            );
-        }
-    }
+	/**
+	 * Validates the attribute of the object.
+	 * If there is any error, the error message is added to the object.
+	 * @param CModel $object the object being validated
+	 * @param string $attribute the attribute being validated
+	 */
+	protected function validateAttribute($object,$attribute)
+	{
+		$value=$object->$attribute;
+		if($this->allowEmpty && $this->isEmpty($value))
+			return;
+		
+		// Note: localeconv fails to return +- signs even when locale has been set,
+		//	and SQL does not accept negative numbers in parenthesized format anyway
+		$c = localeconv();
+		$thousands = $c['thousands_sep'] ?: ',';
+		$decimal = $c['decimal_point'] ?: '.';
+		
+		if(is_string($value))
+			$value=trim(str_replace($thousands,'',$value));
+		
+		if(!is_numeric($value) || !empty(trim($value,'+-.,0123456789')))
+		{
+			$this->addError($object, $attribute, Yii::t('yii',$this->message));
+			return;
+		}
+		
+		$value=rtrim(ltrim($value,'0+-'),'0');
+		
+		$parts = explode($decimal,$value);
+		if(count($parts)>2)
+		{
+			$this->addError($object, $attribute, Yii::t('yii',$this->message));
+		}
+		
+		@list($intstr, $floatstr) = $parts;
+		if((int)$intstr!=$intstr || (int)$floatstr!=$floatstr)
+		{
+			$this->addError($object,$attribute,Yii::t('yii',$this->message));
+		}
+		
+		if($this->maxIntDigits!==null && strlen($intstr)>$this->maxIntDigits)
+		{
+			$this->addError(
+				$object,
+				$attribute,
+				Yii::t('yii',$this->tooManyIntDigits),
+				array('{max}'=>$this->maxIntDigits)
+			);
+		}
+		
+		if($this->maxFloatDigits!==null && strlen($floatstr)>$this->maxFloatDigits)
+		{
+			$this->addError(
+				$object,
+				$attribute,
+				Yii::t('yii',$this->tooManyFloatDigits),
+				array('{max}'=>$this->maxFloatDigits)
+			);
+		}
+	}
 
-    /**
-     * Returns the JavaScript needed for performing client-side validation.
-     * @param CModel $object the data object being validated
-     * @param string $attribute the name of the attribute to be validated.
-     * @return string the client-side validation script.
-     * @see CActiveForm::enableClientValidation
-     * @since 1.1.7
-     */
-    public function clientValidateAttribute($object,$attribute)
-    {
-        if(!$this->enableClientValidation)
-            return '';
-        
-        $label=$object->getAttributeLabel($attribute);
-        
-        $message=strtr($this->message,array(
-            '{attribute}'=>$label,
-        ));
-        
-        $tooManyIntDigits=strtr($this->tooManyIntDigits,array(
-            '{attribute}'=>$label,
-            '{max}'=>$this->maxIntDigits,
-        ));
-        
-        $tooManyFloatDigits=strtr($this->tooManyFloatDigits,array(
-            '{attribute}'=>$label,
-            '{max}'=>$this->maxFloatDigits,
-        ));
-        
-        $c = localeconv();
-        $thousands = $c['thousands_sep'] ?: ',';
-        $decimal = $c['decimal_point'] ?: '.';
-        $pattern=$this->numberPattern;
-        $pattern = str_replace("\\.","\\".$decimal,$pattern);
-        $pattern = str_replace(',',$thousands,$pattern);
-        
-        $js="
+	/**
+	 * Returns the JavaScript needed for performing client-side validation.
+	 * @param CModel $object the data object being validated
+	 * @param string $attribute the name of the attribute to be validated.
+	 * @return string the client-side validation script.
+	 * @see CActiveForm::enableClientValidation
+	 * @since 1.1.7
+	 */
+	public function clientValidateAttribute($object,$attribute)
+	{
+		if(!$this->enableClientValidation)
+			return '';
+		
+		$label=$object->getAttributeLabel($attribute);
+		
+		$message=strtr($this->message,array(
+			'{attribute}'=>$label,
+		));
+		
+		$tooManyIntDigits=strtr($this->tooManyIntDigits,array(
+			'{attribute}'=>$label,
+			'{max}'=>$this->maxIntDigits,
+		));
+		
+		$tooManyFloatDigits=strtr($this->tooManyFloatDigits,array(
+			'{attribute}'=>$label,
+			'{max}'=>$this->maxFloatDigits,
+		));
+		
+		$c = localeconv();
+		$thousands = $c['thousands_sep'] ?: ',';
+		$decimal = $c['decimal_point'] ?: '.';
+		$pattern=$this->numberPattern;
+		$pattern = str_replace("\\.","\\".$decimal,$pattern);
+		$pattern = str_replace(',',$thousands,$pattern);
+		
+		$js="
 if(typeof(value)!='undefined' && value!==null && jQuery.trim(value)!='') {
-    value = String(value).replace(/^[+-]?0*/, '').replace(/0+$/, '');
+	value = String(value).replace(/^[+-]?0*/, '').replace(/0+$/, '');
 ";
 
-        $js.="
-    if(!value.match($pattern)) {
-        messages.push(".CJSON::encode($message).");
-    } else {
+		$js.="
+	if(!value.match($pattern)) {
+		messages.push(".CJSON::encode($message).");
+	} else {
 ";
-        if($this->maxIntDigits!==null || $this->maxFloatDigits!==null)
-        {
-            $js.="
-        var parts = value.replace(/$thousands/g,\"\").split(\"$decimal\");
+		if($this->maxIntDigits!==null || $this->maxFloatDigits!==null)
+		{
+			$js.="
+		var parts = value.replace(/$thousands/g,\"\").split(\"$decimal\");
 ";
-        }
-        if($this->maxIntDigits!==null)
-        {
-            $js.="
-        if(parts[0] && parts[0].length>{$this->maxIntDigits}) {
-            messages.push(".CJSON::encode($tooManyIntDigits).");
-        }
+		}
+		if($this->maxIntDigits!==null)
+		{
+			$js.="
+		if(parts[0] && parts[0].length>{$this->maxIntDigits}) {
+			messages.push(".CJSON::encode($tooManyIntDigits).");
+		}
 ";
-        }
-        if($this->maxFloatDigits!==null)
-        {
-            $js.="
-        if(parts[1] && parts[1].length>{$this->maxFloatDigits}) {
-            messages.push(".CJSON::encode($tooManyFloatDigits).");
-        }
+		}
+		if($this->maxFloatDigits!==null)
+		{
+			$js.="
+		if(parts[1] && parts[1].length>{$this->maxFloatDigits}) {
+			messages.push(".CJSON::encode($tooManyFloatDigits).");
+		}
 ";
-        }
-        $js .= "
-    }
+		}
+		$js .= "
+	}
 }";
 
-        if(!$this->allowEmpty)
-        {
-            $js.=" else {
-    messages.push(".CJSON::encode($message).");
+		if(!$this->allowEmpty)
+		{
+			$js.=" else {
+	messages.push(".CJSON::encode($message).");
 }";
-        }
+		}
 
-        return $js;
-    }
+		return $js;
+	}
 }

--- a/framework/validators/CValidator.php
+++ b/framework/validators/CValidator.php
@@ -69,6 +69,7 @@ abstract class CValidator extends CComponent
 		'length'=>'CStringValidator',
 		'in'=>'CRangeValidator',
 		'numerical'=>'CNumberValidator',
+		'decimal'=>'CDecimalValidator',
 		'captcha'=>'CCaptchaValidator',
 		'type'=>'CTypeValidator',
 		'file'=>'CFileValidator',

--- a/tests/framework/validators/CDecimalValidatorTest.php
+++ b/tests/framework/validators/CDecimalValidatorTest.php
@@ -2,116 +2,116 @@
 
 class CDecimalValidatorTest extends CTestCase {
 
-    private static $jsTest = '';
+	private static $jsTest = '';
 
-    public function testValidation() {
-        $m = new CDecimalValidator();
-        $basicError = strtr($m->message, array('{attribute}' => 'Decimal'));
-        $intError = strtr($m->tooManyIntDigits, array('{attribute}' => 'Decimal', '{max}' => '{iMax}'));
-        $floatError = strtr($m->tooManyFloatDigits, array('{attribute}' => 'Decimal', '{max}' => '{fMax}'));
-        
-        $cases = array(
-            // empty inputs
-            array(true, 1, 1, null),
-            array(false, 1, 1, null, $basicError),
-            array(true, 1, 1, ''),
-            array(false, 1, 1, '', $basicError),
-            array(false, 1, 1, '0'),
-            array(false, 1, 1, '0.0'),
-            
-            // non-numeric inputs
-            array(false, 1, 1, array(), $basicError),
-            array(false, 1, 1, new stdClass(), $basicError),
-            array(false, 1, 1, 'abcde', $basicError),
-            
-            // numeric input in invalid formats
-            array(false, 1, 1, '0e4', $basicError),
-            array(false, 1, 1, '0x4', $basicError),
-            
-            // valid formats invalidated by extra garbage
-            array(true, 1, 1, '0.0e4', $basicError),
-            
-            // valid formats with leading/trailing zeroes and punctuation
-            array(false, 1, 1, '-00.00'),
-            array(false, 1, 1, '+01.10'),
-            array(false, 1, 1, '-00.00'),
-            
-            // valid inputs outside range limits
-            array(true, 1, 1, '11.1', $intError),
-            array(true, 1, 1, '1.11', $floatError),
-            array(true, 1, 1, '11.11', array($intError, $floatError)),
-            
-            // valid inputs
-            array(false, 1, 1, 0),
-            array(false, 1, 1, 0.0),
-            array(false, 1, 1, 9),
-            array(false, 1, 1, 9.9),
-            array(false, 1, 1, '9'),
-            array(false, 1, 1, '9.9'),
-            array(false, 1, 0, 1.0),
-            array(false, 0, 1, 0.1),
-            array(false, 0, 1, '0.1'),
-            array(false, 0, 1, '.1'),
-            array(false, 7, 5, '1,111,111.11111'),
-            array(false, 7, 5, '-1,111,111.11111'),
-            array(false, 7, 5, '+1,111,111.11111'),
-            array(false, 7, 5, '+01,111,111.11111'),
-        );
-        
-        $i = 1;
-        foreach($cases as $case) {
-            $this->inputTest($i++, $case[0], $case[1], $case[2], $case[3], @$case[4]);
-        }
-    }
-    
-    private function inputTest($testNum, $allowEmpty, $iCount, $fCount, $input, $errors = null) {
-        
-        $model = new CDecimalValidatorTestModel();
-        $model->decimal = $input;
-        
-        $validator = new CDecimalValidator();
-        $validator->maxIntDigits = $iCount;
-        $validator->maxFloatDigits = $fCount;
-        $validator->attributes = array('decimal');
-        $validator->allowEmpty = $allowEmpty;
-        $validator->validate($model);
-        
-        if(empty($errors)) {
-            $errors = array();
-        } else {
-            if(!is_array($errors)) {
-                $errors = array($errors);
-            }
-            foreach($errors as $key => $value) {
-                $errors[$key] = strtr($value, array('{iMax}' => $iCount, '{fMax}' => $fCount));
-            }
-        }
-        $dErrors = empty($errors) ? array() : array('decimal' => $errors);
-        $this->assertEquals($dErrors, $model->getErrors(), "case $testNum:");
-        
-        // TODO: run generated js per test for each one assert messages == (array)$errors['decimal]
-        $input = json_encode($input);
-        self::$jsTest .= "\nconsole.log('case '+$testNum);\nmessages = [];\nvalue = $input;\n";
-        self::$jsTest .= $validator->clientValidateAttribute($model, 'decimal');
-        self::$jsTest .= "\nconsole.log(".CJSON::encode($errors).");\nconsole.log(messages);\n";
-    }
-    
-    public static function tearDownAfterClass() {
-        file_put_contents('./jsTest.js', self::$jsTest);
-    }
+	public function testValidation() {
+		$m = new CDecimalValidator();
+		$basicError = strtr($m->message, array('{attribute}' => 'Decimal'));
+		$intError = strtr($m->tooManyIntDigits, array('{attribute}' => 'Decimal', '{max}' => '{iMax}'));
+		$floatError = strtr($m->tooManyFloatDigits, array('{attribute}' => 'Decimal', '{max}' => '{fMax}'));
+		
+		$cases = array(
+			// empty inputs
+			array(true, 1, 1, null),
+			array(false, 1, 1, null, $basicError),
+			array(true, 1, 1, ''),
+			array(false, 1, 1, '', $basicError),
+			array(false, 1, 1, '0'),
+			array(false, 1, 1, '0.0'),
+			
+			// non-numeric inputs
+			array(false, 1, 1, array(), $basicError),
+			array(false, 1, 1, new stdClass(), $basicError),
+			array(false, 1, 1, 'abcde', $basicError),
+			
+			// numeric input in invalid formats
+			array(false, 1, 1, '0e4', $basicError),
+			array(false, 1, 1, '0x4', $basicError),
+			
+			// valid formats invalidated by extra garbage
+			array(true, 1, 1, '0.0e4', $basicError),
+			
+			// valid formats with leading/trailing zeroes and punctuation
+			array(false, 1, 1, '-00.00'),
+			array(false, 1, 1, '+01.10'),
+			array(false, 1, 1, '-00.00'),
+			
+			// valid inputs outside range limits
+			array(true, 1, 1, '11.1', $intError),
+			array(true, 1, 1, '1.11', $floatError),
+			array(true, 1, 1, '11.11', array($intError, $floatError)),
+			
+			// valid inputs
+			array(false, 1, 1, 0),
+			array(false, 1, 1, 0.0),
+			array(false, 1, 1, 9),
+			array(false, 1, 1, 9.9),
+			array(false, 1, 1, '9'),
+			array(false, 1, 1, '9.9'),
+			array(false, 1, 0, 1.0),
+			array(false, 0, 1, 0.1),
+			array(false, 0, 1, '0.1'),
+			array(false, 0, 1, '.1'),
+			array(false, 7, 5, '1,111,111.11111'),
+			array(false, 7, 5, '-1,111,111.11111'),
+			array(false, 7, 5, '+1,111,111.11111'),
+			array(false, 7, 5, '+01,111,111.11111'),
+		);
+		
+		$i = 1;
+		foreach($cases as $case) {
+			$this->inputTest($i++, $case[0], $case[1], $case[2], $case[3], @$case[4]);
+		}
+	}
+	
+	private function inputTest($testNum, $allowEmpty, $iCount, $fCount, $input, $errors = null) {
+		
+		$model = new CDecimalValidatorTestModel();
+		$model->decimal = $input;
+		
+		$validator = new CDecimalValidator();
+		$validator->maxIntDigits = $iCount;
+		$validator->maxFloatDigits = $fCount;
+		$validator->attributes = array('decimal');
+		$validator->allowEmpty = $allowEmpty;
+		$validator->validate($model);
+		
+		if(empty($errors)) {
+			$errors = array();
+		} else {
+			if(!is_array($errors)) {
+				$errors = array($errors);
+			}
+			foreach($errors as $key => $value) {
+				$errors[$key] = strtr($value, array('{iMax}' => $iCount, '{fMax}' => $fCount));
+			}
+		}
+		$dErrors = empty($errors) ? array() : array('decimal' => $errors);
+		$this->assertEquals($dErrors, $model->getErrors(), "case $testNum:");
+		
+		// TODO: run generated js per test for each one assert messages == (array)$errors['decimal]
+		$input = json_encode($input);
+		self::$jsTest .= "\nconsole.log('case '+$testNum);\nmessages = [];\nvalue = $input;\n";
+		self::$jsTest .= $validator->clientValidateAttribute($model, 'decimal');
+		self::$jsTest .= "\nconsole.log(".CJSON::encode($errors).");\nconsole.log(messages);\n";
+	}
+	
+	public static function tearDownAfterClass() {
+		file_put_contents('./jsTest.js', self::$jsTest);
+	}
 
 }
 
 class CDecimalValidatorTestModel extends CFormModel {
 
-    public $decimal;
-    private $fieldLabels = array('decimal' => 'Decimal');
+	public $decimal;
+	private $fieldLabels = array('decimal' => 'Decimal');
 
-    public function attributeNames() {
-        return array_keys($this->fieldLabels);
-    }
-    
-    public function attributeLabels() {
-        return $this->fieldLabels;
-    } 
+	public function attributeNames() {
+		return array_keys($this->fieldLabels);
+	}
+	
+	public function attributeLabels() {
+		return $this->fieldLabels;
+	} 
 }

--- a/tests/framework/validators/CDecimalValidatorTest.php
+++ b/tests/framework/validators/CDecimalValidatorTest.php
@@ -2,8 +2,6 @@
 
 class CDecimalValidatorTest extends CTestCase {
 
-	private static $jsTest = '';
-
 	public function testValidation() {
 		$m = new CDecimalValidator();
 		$basicError = strtr($m->message, array('{attribute}' => 'Decimal'));
@@ -89,15 +87,11 @@ class CDecimalValidatorTest extends CTestCase {
 		$dErrors = empty($errors) ? array() : array('decimal' => $errors);
 		$this->assertEquals($dErrors, $model->getErrors(), "case $testNum:");
 		
-		// TODO: run generated js per test for each one assert messages == (array)$errors['decimal]
-		$input = json_encode($input);
-		self::$jsTest .= "\nconsole.log('case '+$testNum);\nmessages = [];\nvalue = $input;\n";
-		self::$jsTest .= $validator->clientValidateAttribute($model, 'decimal');
-		self::$jsTest .= "\nconsole.log(".CJSON::encode($errors).");\nconsole.log(messages);\n";
-	}
-	
-	public static function tearDownAfterClass() {
-		file_put_contents('./jsTest.js', self::$jsTest);
+		// TODO: run generated js per test and for each one assert messages == (array)$errors['decimal]
+		//$input = json_encode($input);
+		//$jsTest .= "\nconsole.log('case '+$testNum);\nmessages = [];\nvalue = $input;\n";
+		//$jsTest .= $validator->clientValidateAttribute($model, 'decimal');
+		//$jsTest .= "\nconsole.log(".CJSON::encode($errors).");\nconsole.log(messages);\n";
 	}
 
 }

--- a/tests/framework/validators/CDecimalValidatorTest.php
+++ b/tests/framework/validators/CDecimalValidatorTest.php
@@ -1,0 +1,117 @@
+<?php
+
+class CDecimalValidatorTest extends CTestCase {
+
+  private static $jsTest = '';
+
+  public function testValidation() {
+    $m = new CDecimalValidator();
+    $basicError = strtr($m->message, array('{attribute}' => 'Decimal'));
+    $intError = strtr($m->tooManyIntDigits, array('{attribute}' => 'Decimal', '{max}' => '{iMax}'));
+    $floatError = strtr($m->tooManyFloatDigits, array('{attribute}' => 'Decimal', '{max}' => '{fMax}'));
+    
+    $cases = array(
+      // empty inputs
+      array(true, 1, 1, null),
+      array(false, 1, 1, null, $basicError),
+      array(true, 1, 1, ''),
+      array(false, 1, 1, '', $basicError),
+      array(false, 1, 1, '0'),
+      array(false, 1, 1, '0.0'),
+      
+      // non-numeric inputs
+      array(false, 1, 1, array(), $basicError),
+      array(false, 1, 1, new stdClass(), $basicError),
+      array(false, 1, 1, 'abcde', $basicError),
+      
+      // numeric input in invalid formats
+      array(false, 1, 1, '0e4', $basicError),
+      array(false, 1, 1, '0x4', $basicError),
+      
+      // valid formats invalidated by extra garbage
+      array(true, 1, 1, '0.0e4', $basicError),
+      
+      // valid formats with leading/trailing zeroes and punctuation
+      array(false, 1, 1, '-00.00'),
+      array(false, 1, 1, '+01.10'),
+      array(false, 1, 1, '-00.00'),
+      
+      // valid inputs outside range limits
+      array(true, 1, 1, '11.1', $intError),
+      array(true, 1, 1, '1.11', $floatError),
+      array(true, 1, 1, '11.11', array($intError, $floatError)),
+      
+      // valid inputs
+      array(false, 1, 1, 0),
+      array(false, 1, 1, 0.0),
+      array(false, 1, 1, 9),
+      array(false, 1, 1, 9.9),
+      array(false, 1, 1, '9'),
+      array(false, 1, 1, '9.9'),
+      array(false, 1, 0, 1.0),
+      array(false, 0, 1, 0.1),
+      array(false, 0, 1, '0.1'),
+      array(false, 0, 1, '.1'),
+      array(false, 7, 5, '1,111,111.11111'),
+      array(false, 7, 5, '-1,111,111.11111'),
+      array(false, 7, 5, '+1,111,111.11111'),
+      array(false, 7, 5, '+01,111,111.11111'),
+    );
+    
+    $i = 1;
+    foreach($cases as $case) {
+      $this->inputTest($i++, $case[0], $case[1], $case[2], $case[3], @$case[4]);
+    }
+  }
+  
+  private function inputTest($testNum, $allowEmpty, $iCount, $fCount, $input, $errors = null) {
+    
+    $model = new CDecimalValidatorTestModel();
+    $model->decimal = $input;
+    
+    $validator = new CDecimalValidator();
+    $validator->maxIntDigits = $iCount;
+    $validator->maxFloatDigits = $fCount;
+    $validator->attributes = array('decimal');
+    $validator->allowEmpty = $allowEmpty;
+    $validator->validate($model);
+    
+    if(empty($errors)) {
+      $errors = array();
+    } else {
+      if(!is_array($errors)) {
+        $errors = array($errors);
+      }
+      foreach($errors as $key => $value) {
+        $errors[$key] = strtr($value, array('{iMax}' => $iCount, '{fMax}' => $fCount));
+      }
+    }
+    $dErrors = empty($errors) ? array() : array('decimal' => $errors);
+    $this->assertEquals($dErrors, $model->getErrors(), "case $testNum:");
+    
+    // TODO: run generated js per test for each one assert messages == (array)$errors['decimal]
+    $input = json_encode($input);
+    self::$jsTest .= "\nconsole.log('case '+$testNum);\nmessages = [];\nvalue = $input;\n";
+    self::$jsTest .= $validator->clientValidateAttribute($model, 'decimal');
+    self::$jsTest .= "\nconsole.log(".CJSON::encode($errors).");\nconsole.log(messages);\n";
+  }
+  
+  public static function tearDownAfterClass() {
+    file_put_contents('./jsTest.js', self::$jsTest);
+  }
+
+}
+
+class CDecimalValidatorTestModel extends CFormModel {
+
+  public $decimal;
+  private $fieldLabels = array('decimal' => 'Decimal');
+
+  public function attributeNames() {
+    return array_keys($this->fieldLabels);
+  }
+  
+  public function attributeLabels() {
+    return $this->fieldLabels;
+  } 
+}

--- a/tests/framework/validators/CDecimalValidatorTest.php
+++ b/tests/framework/validators/CDecimalValidatorTest.php
@@ -2,116 +2,116 @@
 
 class CDecimalValidatorTest extends CTestCase {
 
-  private static $jsTest = '';
+    private static $jsTest = '';
 
-  public function testValidation() {
-    $m = new CDecimalValidator();
-    $basicError = strtr($m->message, array('{attribute}' => 'Decimal'));
-    $intError = strtr($m->tooManyIntDigits, array('{attribute}' => 'Decimal', '{max}' => '{iMax}'));
-    $floatError = strtr($m->tooManyFloatDigits, array('{attribute}' => 'Decimal', '{max}' => '{fMax}'));
-    
-    $cases = array(
-      // empty inputs
-      array(true, 1, 1, null),
-      array(false, 1, 1, null, $basicError),
-      array(true, 1, 1, ''),
-      array(false, 1, 1, '', $basicError),
-      array(false, 1, 1, '0'),
-      array(false, 1, 1, '0.0'),
-      
-      // non-numeric inputs
-      array(false, 1, 1, array(), $basicError),
-      array(false, 1, 1, new stdClass(), $basicError),
-      array(false, 1, 1, 'abcde', $basicError),
-      
-      // numeric input in invalid formats
-      array(false, 1, 1, '0e4', $basicError),
-      array(false, 1, 1, '0x4', $basicError),
-      
-      // valid formats invalidated by extra garbage
-      array(true, 1, 1, '0.0e4', $basicError),
-      
-      // valid formats with leading/trailing zeroes and punctuation
-      array(false, 1, 1, '-00.00'),
-      array(false, 1, 1, '+01.10'),
-      array(false, 1, 1, '-00.00'),
-      
-      // valid inputs outside range limits
-      array(true, 1, 1, '11.1', $intError),
-      array(true, 1, 1, '1.11', $floatError),
-      array(true, 1, 1, '11.11', array($intError, $floatError)),
-      
-      // valid inputs
-      array(false, 1, 1, 0),
-      array(false, 1, 1, 0.0),
-      array(false, 1, 1, 9),
-      array(false, 1, 1, 9.9),
-      array(false, 1, 1, '9'),
-      array(false, 1, 1, '9.9'),
-      array(false, 1, 0, 1.0),
-      array(false, 0, 1, 0.1),
-      array(false, 0, 1, '0.1'),
-      array(false, 0, 1, '.1'),
-      array(false, 7, 5, '1,111,111.11111'),
-      array(false, 7, 5, '-1,111,111.11111'),
-      array(false, 7, 5, '+1,111,111.11111'),
-      array(false, 7, 5, '+01,111,111.11111'),
-    );
-    
-    $i = 1;
-    foreach($cases as $case) {
-      $this->inputTest($i++, $case[0], $case[1], $case[2], $case[3], @$case[4]);
+    public function testValidation() {
+        $m = new CDecimalValidator();
+        $basicError = strtr($m->message, array('{attribute}' => 'Decimal'));
+        $intError = strtr($m->tooManyIntDigits, array('{attribute}' => 'Decimal', '{max}' => '{iMax}'));
+        $floatError = strtr($m->tooManyFloatDigits, array('{attribute}' => 'Decimal', '{max}' => '{fMax}'));
+        
+        $cases = array(
+            // empty inputs
+            array(true, 1, 1, null),
+            array(false, 1, 1, null, $basicError),
+            array(true, 1, 1, ''),
+            array(false, 1, 1, '', $basicError),
+            array(false, 1, 1, '0'),
+            array(false, 1, 1, '0.0'),
+            
+            // non-numeric inputs
+            array(false, 1, 1, array(), $basicError),
+            array(false, 1, 1, new stdClass(), $basicError),
+            array(false, 1, 1, 'abcde', $basicError),
+            
+            // numeric input in invalid formats
+            array(false, 1, 1, '0e4', $basicError),
+            array(false, 1, 1, '0x4', $basicError),
+            
+            // valid formats invalidated by extra garbage
+            array(true, 1, 1, '0.0e4', $basicError),
+            
+            // valid formats with leading/trailing zeroes and punctuation
+            array(false, 1, 1, '-00.00'),
+            array(false, 1, 1, '+01.10'),
+            array(false, 1, 1, '-00.00'),
+            
+            // valid inputs outside range limits
+            array(true, 1, 1, '11.1', $intError),
+            array(true, 1, 1, '1.11', $floatError),
+            array(true, 1, 1, '11.11', array($intError, $floatError)),
+            
+            // valid inputs
+            array(false, 1, 1, 0),
+            array(false, 1, 1, 0.0),
+            array(false, 1, 1, 9),
+            array(false, 1, 1, 9.9),
+            array(false, 1, 1, '9'),
+            array(false, 1, 1, '9.9'),
+            array(false, 1, 0, 1.0),
+            array(false, 0, 1, 0.1),
+            array(false, 0, 1, '0.1'),
+            array(false, 0, 1, '.1'),
+            array(false, 7, 5, '1,111,111.11111'),
+            array(false, 7, 5, '-1,111,111.11111'),
+            array(false, 7, 5, '+1,111,111.11111'),
+            array(false, 7, 5, '+01,111,111.11111'),
+        );
+        
+        $i = 1;
+        foreach($cases as $case) {
+            $this->inputTest($i++, $case[0], $case[1], $case[2], $case[3], @$case[4]);
+        }
     }
-  }
-  
-  private function inputTest($testNum, $allowEmpty, $iCount, $fCount, $input, $errors = null) {
     
-    $model = new CDecimalValidatorTestModel();
-    $model->decimal = $input;
-    
-    $validator = new CDecimalValidator();
-    $validator->maxIntDigits = $iCount;
-    $validator->maxFloatDigits = $fCount;
-    $validator->attributes = array('decimal');
-    $validator->allowEmpty = $allowEmpty;
-    $validator->validate($model);
-    
-    if(empty($errors)) {
-      $errors = array();
-    } else {
-      if(!is_array($errors)) {
-        $errors = array($errors);
-      }
-      foreach($errors as $key => $value) {
-        $errors[$key] = strtr($value, array('{iMax}' => $iCount, '{fMax}' => $fCount));
-      }
+    private function inputTest($testNum, $allowEmpty, $iCount, $fCount, $input, $errors = null) {
+        
+        $model = new CDecimalValidatorTestModel();
+        $model->decimal = $input;
+        
+        $validator = new CDecimalValidator();
+        $validator->maxIntDigits = $iCount;
+        $validator->maxFloatDigits = $fCount;
+        $validator->attributes = array('decimal');
+        $validator->allowEmpty = $allowEmpty;
+        $validator->validate($model);
+        
+        if(empty($errors)) {
+            $errors = array();
+        } else {
+            if(!is_array($errors)) {
+                $errors = array($errors);
+            }
+            foreach($errors as $key => $value) {
+                $errors[$key] = strtr($value, array('{iMax}' => $iCount, '{fMax}' => $fCount));
+            }
+        }
+        $dErrors = empty($errors) ? array() : array('decimal' => $errors);
+        $this->assertEquals($dErrors, $model->getErrors(), "case $testNum:");
+        
+        // TODO: run generated js per test for each one assert messages == (array)$errors['decimal]
+        $input = json_encode($input);
+        self::$jsTest .= "\nconsole.log('case '+$testNum);\nmessages = [];\nvalue = $input;\n";
+        self::$jsTest .= $validator->clientValidateAttribute($model, 'decimal');
+        self::$jsTest .= "\nconsole.log(".CJSON::encode($errors).");\nconsole.log(messages);\n";
     }
-    $dErrors = empty($errors) ? array() : array('decimal' => $errors);
-    $this->assertEquals($dErrors, $model->getErrors(), "case $testNum:");
     
-    // TODO: run generated js per test for each one assert messages == (array)$errors['decimal]
-    $input = json_encode($input);
-    self::$jsTest .= "\nconsole.log('case '+$testNum);\nmessages = [];\nvalue = $input;\n";
-    self::$jsTest .= $validator->clientValidateAttribute($model, 'decimal');
-    self::$jsTest .= "\nconsole.log(".CJSON::encode($errors).");\nconsole.log(messages);\n";
-  }
-  
-  public static function tearDownAfterClass() {
-    file_put_contents('./jsTest.js', self::$jsTest);
-  }
+    public static function tearDownAfterClass() {
+        file_put_contents('./jsTest.js', self::$jsTest);
+    }
 
 }
 
 class CDecimalValidatorTestModel extends CFormModel {
 
-  public $decimal;
-  private $fieldLabels = array('decimal' => 'Decimal');
+    public $decimal;
+    private $fieldLabels = array('decimal' => 'Decimal');
 
-  public function attributeNames() {
-    return array_keys($this->fieldLabels);
-  }
-  
-  public function attributeLabels() {
-    return $this->fieldLabels;
-  } 
+    public function attributeNames() {
+        return array_keys($this->fieldLabels);
+    }
+    
+    public function attributeLabels() {
+        return $this->fieldLabels;
+    } 
 }


### PR DESCRIPTION
Addresses https://github.com/yiisoft/yii/issues/1323
 - [x] Add and thoroughly test CDecimalValidator.
 - [x] Adjust unit test code to plumb into any js-unit testing expected (or at least remove the js output saved for manual testing).
 - [x] Alter Gii to use CDecimalValidator on inputs matching "decimal(m, n)" descriptors.
 - [x] Register decimal as a built-in validator.

First piece is the main unit of new functionality, so I'd like some feedback on that.  I could also use pointers on unit testing the javascript generated by the validator (it wasn't readily apparent in the other validator tests how the javascript is covered).