### PR TITLE
ActiveFinder::populateRecord fixed.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Work in progress
 
 Version 1.1.15 under development
 --------------------------------
+- Enh: CActiveFinder::populateRecord fixed. $this->_pkAlias May be NULL, but it wasn't validated. (jonasasx)
 - Bug #268: Fixed Active Record count error when some field name starting from 'count' (nineinchnick)
 - Bug #2378: CActiveRecord::tableName() in namespaced model returned fully qualified class name (velosipedist, cebe)
 - Bug #2654: Allow CDbCommand to compose queries without 'from' clause (klimov-paul)

--- a/framework/db/ar/CActiveFinder.php
+++ b/framework/db/ar/CActiveFinder.php
@@ -822,7 +822,7 @@ class CJoinElement
 			else	// no matching related objects
 				return null;
 		}
-		else // is_array, composite key
+		elseif(is_array($this->_pkAlias)) // is_array, composite key
 		{
 			$pk=array();
 			foreach($this->_pkAlias as $name=>$alias)
@@ -833,6 +833,8 @@ class CJoinElement
 					return null;
 			}
 			$pk=serialize($pk);
+		} else {
+		    $pk = null;
 		}
 
 		// retrieve or populate the record according to the primary key value


### PR DESCRIPTION
$this->_pkAlias May be NULL, but it wasn't validated.
