### PR TITLE
Create temporary files in a non-shared temp dir

### DIFF
--- a/tests/TestApplication.php
+++ b/tests/TestApplication.php
@@ -7,7 +7,7 @@ class TestApplication extends CWebApplication
 	{
 		Yii::setApplication(null);
 		clearstatcache();
-		$this->tmpDir = $tmpDir ?: __DIR__;
+		$this->tmpDir = $tmpDir ? $tmpDir : __DIR__;
 		parent::__construct($config);
 	}
 

--- a/tests/TestApplication.php
+++ b/tests/TestApplication.php
@@ -2,10 +2,12 @@
 
 class TestApplication extends CWebApplication
 {
-	public function __construct($config=null)
+	private $tmpDir;
+	public function __construct($config=null, $tmpDir=null)
 	{
 		Yii::setApplication(null);
 		clearstatcache();
+		$this->tmpDir = $tmpDir ?: __DIR__;
 		parent::__construct($config);
 	}
 
@@ -34,17 +36,17 @@ class TestApplication extends CWebApplication
 
 	public function getAssetPath()
 	{
-		return dirname(__FILE__).DIRECTORY_SEPARATOR.'assets';
+		return $this->tmpDir.DIRECTORY_SEPARATOR.'assets';
 	}
 
 	public function getRuntimePath()
 	{
-		return dirname(__FILE__).DIRECTORY_SEPARATOR.'runtime';
+		return $this->tmpDir.DIRECTORY_SEPARATOR.'runtime';
 	}
 
 	public function getBasePath()
 	{
-		return dirname(__FILE__);
+		return $this->tmpDir;
 	}
 
 	public function setBasePath($value)

--- a/tests/framework/caching/CFileCacheDependencyTest.php
+++ b/tests/framework/caching/CFileCacheDependencyTest.php
@@ -18,7 +18,7 @@ class CFileCacheDependencyTest extends CTestCase
 
 	public function testHasChanged()
 	{
-		$tempFile=Yii::app()->getRuntimePath().'/CFileCacheDependencyTest_foo.txt';
+		$tempFile=tempnam(sys_get_temp_dir(), 'testHasChanged');
 		@unlink($tempFile);
 		$fw=fopen($tempFile,"w");
 		fwrite($fw,"test");

--- a/tests/framework/caching/CFileCacheTest.php
+++ b/tests/framework/caching/CFileCacheTest.php
@@ -14,7 +14,10 @@ class CFileCacheTest extends CTestCase
 
 	public function setUp()
 	{
-		$this->cachePath=Yii::getPathOfAlias('application.runtime.CFileCacheTest');
+		$this->cachePath=tempnam(sys_get_temp_dir(), 'CFileCacheTest');
+		unlink($this->cachePath);
+		@mkdir($this->cachePath);
+		$this->cachePath .= DIRECTORY_SEPARATOR . 'runtime';
 		if(!is_dir($this->cachePath) && !(@mkdir($this->cachePath)))
 			$this->markTestIncomplete('Unit tests runtime directory should have writable permissions!');
 
@@ -32,7 +35,7 @@ class CFileCacheTest extends CTestCase
 				'components'=>array(
 					'cache'=>array('class'=>'CFileCache','cachePath'=>$this->cachePath,'cachePathMode'=>$testMode),
 				),
-			));
+			), $this->cachePath.DIRECTORY_SEPARATOR.'..');
 			/** @var CFileCache $cache */
 			$cache=$app->cache;
 
@@ -51,7 +54,7 @@ class CFileCacheTest extends CTestCase
 				'components'=>array(
 					'cache'=>array('class'=>'CFileCache','cachePath'=>$this->cachePath,'cacheFileMode'=>$testMode),
 				),
-			));
+			), $this->cachePath.DIRECTORY_SEPARATOR.'..');
 			/** @var CFileCache $cache */
 			$cache=$app->cache;
 
@@ -74,7 +77,7 @@ class CFileCacheTest extends CTestCase
 			'components'=>array(
 				'cache'=>array('class'=>'CFileCache','cachePath'=>$this->cachePath),
 			),
-		));
+		), $this->cachePath.DIRECTORY_SEPARATOR.'..');
 		$app->reset();
 		$cache=$app->cache;
 
@@ -96,7 +99,7 @@ class CFileCacheTest extends CTestCase
 			'components'=>array(
 				'cache'=>array('class'=>'CFileCache','cachePath'=>$this->cachePath,'embedExpiry'=>true),
 			),
-		));
+		), $this->cachePath.DIRECTORY_SEPARATOR.'..');
 		$app->reset();
 		$cache=$app->cache;
 


### PR DESCRIPTION
When running unit tests in parallel, sharing a temporary directory is bad.
