### PR TITLE
[travis ci] Enabled memcached in the service section again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
 
 services:
   - redis-server
+  - memcached
 
 before_script:
   - ./tests/travis/mysql-setup.sh


### PR DESCRIPTION
An [environmental change](http://about.travis-ci.org//blog/2013-11-18-upcoming-build-environment-updates) in Travis CI a few days ago seems to cause memcached not to be available at startup of the VM.

With this PR, builds in Travis should be passing again.
