### PR TITLE
It's better to prevent password field viewstate

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2422,7 +2422,7 @@ EOD;
 
 		if($type==='file')
 			unset($htmlOptions['value']);
-		elseif(!isset($htmlOptions['value']))
+		elseif(!isset($htmlOptions['value']) && $type!=='password')
 			$htmlOptions['value']=self::resolveValue($model,$attribute);
 		if($model->hasErrors($attribute))
 			self::addErrorCss($htmlOptions);


### PR DESCRIPTION
The password field is filled out in the postback validation process and the developer can't reset the password manually (if a validation rule such as not unique email usage was there).

Mostly password fields don't have viewstate in ASP.Net or other web frameworks. Because either in HTTP or HTTPS postback communications the posted password will be visible in the source code(and the cache hisotry) of the page has been responded back to the client.

This commit affects in the CActiveForm and the ::activePasswordField.
