### PR TITLE
Support labels with attribute bracket notation like post[author][name]

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -590,7 +590,7 @@ abstract class CActiveRecord extends CModel
 	 * Returns the text label for the specified attribute.
 	 * This method overrides the parent implementation by supporting
 	 * returning the label defined in relational object.
-	 * In particular, if the attribute name is in the form of "post.author.name",
+	 * In particular, if the attribute name is in the form of "post.author.name" or "post[author][name]",
 	 * then this method will derive the label from the "author" relation's "name" attribute.
 	 * @param string $attribute the attribute name
 	 * @return string the attribute label
@@ -602,8 +602,10 @@ abstract class CActiveRecord extends CModel
 		$labels=$this->attributeLabels();
 		if(isset($labels[$attribute]))
 			return $labels[$attribute];
-		elseif(strpos($attribute,'.')!==false)
+		elseif(($dot=strpos($attribute,'.'))!==false || strpos($attribute,'[')!==false)
 		{
+			if ($dot===false) // convert bracket to dot notation
+				$attribute = strtr($attribute, array(']['=>'.','['=>'.',']'=>''));
 			$segs=explode('.',$attribute);
 			$name=array_pop($segs);
 			$model=$this;


### PR DESCRIPTION
It allows to write the following code in views:

``` php
echo $form->checkBox($model,'params[hasCar]');
echo $form->labelEx($model,'params[hasCar]'); // before, i had to write 'params.hasCar'
echo $form->error($model,'params[hasCar]');
```

It has the additional advantage of correctly generating the 'for' attribute, i.e. the label will be 

``` html
<label for="Offer_params_hasCar">Possède une voiture</label>
```

instead of 

``` html
<label for="Offer_params.hasCar">Possède une voiture</label>
```

which wasn't focusing on the associated input
