### PR TITLE
Update CActiveRecordBehavior.php

### DIFF
--- a/framework/db/ar/CActiveRecordBehavior.php
+++ b/framework/db/ar/CActiveRecordBehavior.php
@@ -44,7 +44,7 @@ class CActiveRecordBehavior extends CModelBehavior
 	 * Override this method and make it public if you want to handle the corresponding
 	 * event of the {@link CBehavior::owner owner}.
 	 * You may set {@link CModelEvent::isValid} to be false to quit the saving process.
-	 * @param CModelEvent $event event parameter
+	 * @param CEvent $event event parameter
 	 */
 	protected function beforeSave($event)
 	{
@@ -54,7 +54,7 @@ class CActiveRecordBehavior extends CModelBehavior
 	 * Responds to {@link CActiveRecord::onAfterSave} event.
 	 * Override this method and make it public if you want to handle the corresponding event
 	 * of the {@link CBehavior::owner owner}.
-	 * @param CModelEvent $event event parameter
+	 * @param CEvent $event event parameter
 	 */
 	protected function afterSave($event)
 	{


### PR DESCRIPTION
Argument 1 passed to XXXBehavior::afterSave() must be an instance of CModelEvent, instance of CEvent given, called in /path/to/yii/framework/base/CComponent.php on line 561 and defined
