### PR TITLE
Update CBreadcrumbs fix homeLink Edit

### DIFF
--- a/framework/zii/widgets/CBreadcrumbs.php
+++ b/framework/zii/widgets/CBreadcrumbs.php
@@ -113,7 +113,7 @@ class CBreadcrumbs extends CWidget
 		echo CHtml::openTag($this->tagName,$this->htmlOptions)."\n";
 		$links=array();
 		if($this->homeLink===null)
-			$links[]=CHtml::link(Yii::t('zii','Home'),Yii::app()->homeUrl);
+			$this->links = array_merge(array(Yii::t('zii','Home') => array(Yii::app()->homeUrl)), $this->links);
 		elseif($this->homeLink!==false)
 			$links[]=$this->homeLink;
 		foreach($this->links as $label=>$url)


### PR DESCRIPTION
this will keep using activeLinkTemplate with home
activeLinkTemplate could be useful while try to use ul >> li

just replace

$links[]=CHtml::link(Yii::t('zii','Home'),Yii::app()->homeUrl);

with

$this->links = array_merge(array(Yii::t('zii','Home') => array(Yii::app()->homeUrl)), $this->links);
