### PR TITLE
Fix duplicate apply_time field SQL error in DB.

### DIFF
--- a/framework/cli/commands/MigrateCommand.php
+++ b/framework/cli/commands/MigrateCommand.php
@@ -384,11 +384,12 @@ class MigrateCommand extends CConsoleCommand
 		$migration=$this->instantiateMigration($class);
 		if($migration->up()!==false)
 		{
+			sleep(1);
 			$this->getDbConnection()->createCommand()->insert($this->migrationTable, array(
 				'version'=>$class,
 				'apply_time'=>time(),
 			));
-			$time=microtime(true)-$start;
+			$time=microtime(true)-$start-1;
 			echo "*** applied $class (time: ".sprintf("%.3f",$time)."s)\n\n";
 		}
 		else


### PR DESCRIPTION
When we do a few little megration (less than 1 sec long), we get the duplicate values error in the 'apply_time' field.
I think the change of timeformat (accurate to the microseconds) would solve this problem. But not to break backward compatibility I suggest to do "sleep(1)" for 1 second during the any mergation up process. 
In this case the timestamp would be different.
