### PR TITLE
1257 fix c file validator safe mass assignment

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Version 1.1.15 under development
 --------------------------------
 - Bug #268: Fixed Active Record count error when some field name starting from 'count' (nineinchnick)
 - Bug #788: createIndex is not using the recommended way to create unique indexes on Postgres (nineinchnick)
+- Bug #1257: CFileValidator is no longer unsafe by default to prevent setting arbitrary values. Instead, when no file is uploaded attribute is set to null (marcovtwout)
 - Bug #2235: CPgsqlColumnSchema can't parse default value for numeric field (cebe, pavimus)
 - Bug #2378: CActiveRecord::tableName() in namespaced model returned fully qualified class name (velosipedist, cebe)
 - Bug #2654: Allow CDbCommand to compose queries without 'from' clause (klimov-paul)

--- a/framework/validators/CFileValidator.php
+++ b/framework/validators/CFileValidator.php
@@ -64,6 +64,8 @@ class CFileValidator extends CValidator
 	/**
 	 * @var boolean whether the attribute requires a file to be uploaded or not.
 	 * Defaults to false, meaning a file is required to be uploaded.
+	 * When no file is uploaded, the owner attribute is set to null to prevent
+	 * setting arbitrary values.
 	 */
 	public $allowEmpty=false;
 	/**
@@ -130,12 +132,6 @@ class CFileValidator extends CValidator
 	 * limit.
 	 */
 	public $tooMany;
-	/**
-	 * @var boolean whether attributes listed with this validator should be considered safe for massive assignment.
-	 * For this validator it defaults to false.
-	 * @since 1.1.12
-	 */
-	public $safe=false;
 
 	/**
 	 * Set the attribute and then validates using {@link validateFile}.
@@ -254,11 +250,13 @@ class CFileValidator extends CValidator
 
 	/**
 	 * Raises an error to inform end user about blank attribute.
+	 * Sets the owner attribute to null to prevent setting arbitrary values.
 	 * @param CModel $object the object being validated
 	 * @param string $attribute the attribute being validated
 	 */
 	protected function emptyAttribute($object, $attribute)
 	{
+		$object->$attribute=null;
 		if(!$this->allowEmpty)
 		{
 			$message=$this->message!==null?$this->message : Yii::t('yii','{attribute} cannot be blank.');


### PR DESCRIPTION
CFileValidator is no longer unsafe by default to prevent setting arbitrary values. Instead, when no file is uploaded attribute is set to null.
