### PR TITLE
Added the ability to bind ajax js to a class

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2632,11 +2632,19 @@ EOD;
 			else
 				$handler="return $confirm;";
 		}
-
+		
+		$scBindId = $id;
+		$scBindHtml = '#'.$id;
+		if (isset($htmlOptions['classBind']))
+		{
+			$scBindId = $htmlOptions['classBind'];
+			$scBindHtml = '.'.$htmlOptions['classBind'];
+		}
+		
 		if($live)
-			$cs->registerScript('Yii.CHtml.#' . $id,"jQuery('body').on('$event','#$id',function(){{$handler}});");
+			$cs->registerScript('Yii.CHtml.#' . $scBindId,"jQuery('body').on('$event','$scBindHtml',function(){{$handler}});");
 		else
-			$cs->registerScript('Yii.CHtml.#' . $id,"jQuery('#$id').on('$event', function(){{$handler}});");
+			$cs->registerScript('Yii.CHtml.#' . $scBindId,"jQuery('$scBindHtml').on('$event', function(){{$handler}});");
 		unset($htmlOptions['params'],$htmlOptions['submit'],$htmlOptions['ajax'],$htmlOptions['confirm'],$htmlOptions['return'],$htmlOptions['csrf']);
 	}
 


### PR DESCRIPTION
Example:

```
<div class="issue-buttons">
<?
echo CHtml::ajaxButton('Start', $this->createUrl('status', array('id'=>$issue->id, 'status' => Tasks::STATUS_START)), array(
                'type'=>'POST',
                'data'=>array('update'=>true),
                'update' => '.issue-buttons',
            ), array('class' => 'action-buttons', 'bindClass' => "action-buttons"));
?>
</div>
```

And we have js:

```
jQuery('body').on('click','.action-buttons',function(){jQuery.ajax({'type':'POST','data' ...
```

```
modified:   framework/web/helpers/CHtml.php
```
