### PR TITLE
Update CDbCommand.php

### DIFF
--- a/framework/db/CDbCommand.php
+++ b/framework/db/CDbCommand.php
@@ -703,6 +703,12 @@ class CDbCommand extends CComponent
 				$tables=preg_split('/\s*,\s*/',trim($tables),-1,PREG_SPLIT_NO_EMPTY);
 			foreach($tables as $i=>$table)
 			{
+				if(empty($table))
+				{
+					unset($tables[$i]);
+					continue;
+				}
+			
 				if(strpos($table,'(')===false)
 				{
 					if(preg_match('/^(.*?)(?i:\s+as\s+|\s+)(.*)$/',$table,$matches))  // with alias


### PR DESCRIPTION
The from function will ignore any empty table definition when $tables are passed as an array

ex before fix: 
$table = someLogic(); // return the table sql from somelogic
createCommand(array('from'=>array('table1', $table))); // $table is null or empty string in this case
The SQL generated will be somthing like this => SELECT \* FROM table1,

after fix: SELECT \* FROM table1
