### PR TITLE
Add an ability to migrate to applyed time

### DIFF
--- a/framework/cli/commands/MigrateCommand.php
+++ b/framework/cli/commands/MigrateCommand.php
@@ -248,7 +248,7 @@ class MigrateCommand extends CConsoleCommand
 		->select('version, apply_time')
 		->from($this->migrationTable)
 		->order('apply_time DESC')
-		->where('apply_time < :apply_time', array(':apply_time'=>$time))
+		->where('apply_time <= :apply_time', array(':apply_time'=>$time))
 		->limit(1)
 		->queryRow();
 
@@ -271,7 +271,7 @@ class MigrateCommand extends CConsoleCommand
 			$this->usageError('Please specify which version to migrate to.');
 
 		// If it's unix time stamp
-		if (is_numeric($args[0]) && strlen($args[0]) == 11)
+		if (preg_match('/^1\d{9}$/', $args[0]))
 			$this->migrateToTime($args[0]);
 
 		// If it's date time in string


### PR DESCRIPTION
Hi,
I made some changes)
It's can be used in CI, when you need to revert migrations to some time.

You can use:

```
yiic migrate to "2014-01-01 00:00:00"
```

Script find a migration applyed before "2014-01-01 00:00:00" and revert to it

You can use any date/time syntax wich be convertet via strtotime().
Also you can use int(11)

```
yiic migrate to 1292265716
```
