### PR TITLE
Added consistency between date/time format/parse

### DIFF
--- a/framework/utils/CDateTimeParser.php
+++ b/framework/utils/CDateTimeParser.php
@@ -103,6 +103,13 @@ class CDateTimeParser
 					$i+=strlen($year);
 					break;
 				}
+				case 'y':
+				{
+					if(($year=self::parseInteger($value,$i,4,4))===false)
+						return false;
+					$i+=4;
+					break;
+				}
 				case 'MMMM':
 				{
 					$monthName='';


### PR DESCRIPTION
The way CDateFormatter formats dates and interprets formats is inconsistent
with CDateTimeParser, in that "y" will be transformed to "2014" by
CDateFormatter's formatting functions, whereas to read all four digits,
the year part of the format string passed to CDateTimeParser.parse must
contain all four digits. Thus, in the following code, the resulting
value of $date would be false rather than the original timestamp:

$date = 1392424866;
$dateTimeFormat = Yii::app()->locale->getDateFormat('medium').' '.Yii::app()->locale->getTimeFormat('medium');
$date = Yii::app()->dateFormatter->format($dateTimeFormat,$date);
$date = CDateTimeParser::parse($date,$dateTimeFormat);

This change makes CDateTimeParser behave more like the inverse map of
CDateTimeFormatter's formatting functions, and $date in the above code
would evaluate to 1392424866 at the end.
