### PR TITLE
Added port check timeout to CEmailValidator

### DIFF
--- a/framework/validators/CEmailValidator.php
+++ b/framework/validators/CEmailValidator.php
@@ -155,7 +155,7 @@ if(".($this->allowEmpty ? "jQuery.trim(value)!='' && " : '').$condition.") {
 		usort($records,array($this,'mxSort'));
 		foreach($records as $record)
 		{
-			$handle=@fsockopen($record['target'],25);
+			$handle=@fsockopen($record['target'],25,$errno,$errstr,10);
 			if($handle!==false)
 			{
 				fclose($handle);


### PR DESCRIPTION
With `checkPort = true` and without port check timeout email validation takes too long on some malformed addresses.
