### PR TITLE
Update yii.php

### DIFF
--- a/framework/messages/pl/yii.php
+++ b/framework/messages/pl/yii.php
@@ -232,7 +232,7 @@ return array (
   '{attribute} must be greater than or equal to "{compareValue}".' => 'Atrybut {attribute} musi być większy lub równy "{compareValue}".',
   '{attribute} must be less than "{compareValue}".' => 'Atrybut {attribute} musi być mniejszy od "{compareValue}".',
   '{attribute} must be less than or equal to "{compareValue}".' => 'Atrybut {attribute} musi być mniejszy lub równy "{compareValue}".',
-  '{attribute} must be repeated exactly.' => '{attribute} musi być powtórzony ponownie.',
+  '{attribute} must be repeated exactly.' => 'Atrybut {attribute} musi być dokładnie powtórzony.',
   '{attribute} must be {type}.' => 'Zawartość pola {attribute} musi być typu {type}.',
   '{attribute} must be {value}.' => 'Pole {attribute} musi posiadać wartość {value}.',
   '{attribute} must not be equal to "{compareValue}".' => 'Pole {attribute} nie może być równy "{compareValue}".',


### PR DESCRIPTION
Without word "Atrybut" (english "attribute") this phrase is grammatically incorrect when noun representing field name isn't masculine (e.g. "Hasło musi być powtórzony" should be "Hasło musi być powtórzone". "Hasło" means english "Password"). 
Also, I added missing word "exactly" (polish "dokładnie") and removed word "ponownie" (this is pleonasm http://en.wikipedia.org/wiki/Pleonasm)
