### PR TITLE
COciSchema: read column comments from another schema

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -45,6 +45,7 @@ Version 1.1.15 under development
 - Bug: Fixed the bug that backslashes are not escaped by CDbCommandBuilder::buildSearchCondition() (qiangxue)
 - Bug: Fixed URL parsing so it's now properly giving 404 for URLs like "http://example.com//////site/about/////" (samdark)
 - Bug: Fixed an issue with CFilehelper and not accessable directories which resulted in endless loop (cebe)
+- Bug #3305: COciSchema column comment reading from another schema (gureedo)
 - Enh: Public method CFileHelper::createDirectory() has been added (klimov-paul)
 - Enh #89: Support for SOAP headers in WSDL generator (nineinchnick)
 - Enh #94: Web services: Implement document/literal encoding for WDSL (nineinchnick)

--- a/framework/db/schema/oci/COciSchema.php
+++ b/framework/db/schema/oci/COciSchema.php
@@ -186,7 +186,7 @@ SELECT a.column_name, a.data_type ||
     com.comments as column_comment
 FROM ALL_TAB_COLUMNS A
 inner join ALL_OBJECTS B ON b.owner = a.owner and ltrim(B.OBJECT_NAME) = ltrim(A.TABLE_NAME)
-LEFT JOIN user_col_comments com ON (A.table_name = com.table_name AND A.column_name = com.column_name)
+LEFT JOIN all_col_comments com ON (A.owner = com.owner AND A.table_name = com.table_name AND A.column_name = com.column_name)
 WHERE
     a.owner = '{$schemaName}'
 	and (b.object_type = 'TABLE' or b.object_type = 'VIEW')


### PR DESCRIPTION
Current query always try read column comment from current user schema.
So if target table is located in another schema comments will be always empty.
`all_col_comments` table contains all accessible comments by current user.
