### PR TITLE
Add autoload section to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,5 +69,8 @@
 	],
 	"require": {
 		"php": ">=5.1.0"
-	}
+	},
+	"autoload": {
+		"classmap": ["framework/"]
+        }
 }


### PR DESCRIPTION
I added autoload classmap so you can use the composer autoloader for yii 1.
There is no good workaround to autoload yii using composer without this, so I created this pull request.
I also don't think it would really affect anything else since Yii also uses a classmap for autoloading.
