### PR TITLE
Update ShellCommand.php

### DIFF
--- a/framework/cli/commands/ShellCommand.php
+++ b/framework/cli/commands/ShellCommand.php
@@ -125,7 +125,7 @@ EOD;
 					$_command_->run($_args_);
 				}
 				else
-					echo eval($_line_.';');
+					echo eval('return $_line_;');
 			}
 			catch(Exception $e)
 			{


### PR DESCRIPTION
I got this error while I was trying to generate a CRUD :

PHP Parse error:  syntax error, unexpected T_STRING in ShellCommand.php(131) : eval()'d code on line 1

This change correct this error.
