### PR TITLE
[Travis CI] Include nightly HHVM builds into the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,8 @@ php:
 matrix:
   fast_finish: true
   allow_failures:
-    - php:
-      - hhvm
-      - hhvm-nightly
+    - php: hhvm
+    - php: hhvm-nightly
 
 services:
   - redis-server


### PR DESCRIPTION
Nightly HHVM builds have been available since [April this year](http://blog.travis-ci.com/2014-04-28-upcoming-build-environment-updates/). This PR extends the build matrix so these are being included. As with "stable" HHVM, these builds are allowed to fail.
