### PR TITLE
Prevent for both keydown and change events process

### DIFF
--- a/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
+++ b/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
@@ -72,6 +72,7 @@
 
 			return this.each(function () {
 				var eventType,
+					eventTarget,
 					$grid = $(this),
 					id = $grid.attr('id'),
 					pagerSelector = '#' + id + ' .' + settings.pagerClass.replace(/\s+/g, '.') + ' a',
@@ -114,11 +115,13 @@
 							return; // only react to enter key
 						} else {
 							eventType = 'keydown';
+							eventTarget = event.target;
 						}
 					} else {
-						// prevent processing for both keydown and change events
-						if (eventType === 'keydown') {
+						// prevent processing for both keydown and change events on the same element
+						if (eventType === 'keydown' && eventTarget === event.target) {
 							eventType = '';
+							eventTarget = null;
 							return;
 						}
 					}


### PR DESCRIPTION
Check that keydown and change event prevented only on the same element. It fixes bug, that can be reproduced this way:
1. Create filter for to field, one filter must be text input, other must be checkbox
2. Open any version of Firefox
3. Input text for search in text field end press Enter. At this moment this script will set variable eventType to 'keydown'
4. Click on checkbox. Filter won't run, because eventType is 'keydown', even though change event called by another element. Nothing happens.
