### PR TITLE
Prevent processing for both keydown and change events on the same element

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@ Version 1.1.15 under development
 - Bug #2864: Fixed CGridView ajax calls failing CSRF validation when ajaxType is set to POST (nineinchnick)
 - Bug #2874: Fixed duplicate columns selection for HAS_MANY relation with composite primary key (borro)
 - Bug #2876: Fixed single quotes in comments column causes syntax error in model code generated  by Gii(klimov-paul)
+- Bug #2881: Fixed executing cgridview update on filter field change event after previous filtering using ENTER key (sivir)
 - Bug #2884: Fixed problem with table alias in CActiveRecord that has been introduced in 1.1.14 (cebe)
 - Bug #2887: Fixed CFormElement is missing __isset() (bijibox)
 - Bug #2912: Add options parameter to CListView beforeAjaxUpdate (spikyjt)

--- a/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
+++ b/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
@@ -72,6 +72,7 @@
 
 			return this.each(function () {
 				var eventType,
+					eventTarget,
 					$grid = $(this),
 					id = $grid.attr('id'),
 					pagerSelector = '#' + id + ' .' + settings.pagerClass.replace(/\s+/g, '.') + ' a',
@@ -114,11 +115,13 @@
 							return; // only react to enter key
 						} else {
 							eventType = 'keydown';
+							eventTarget = event.target;
 						}
 					} else {
-						// prevent processing for both keydown and change events
-						if (eventType === 'keydown') {
+						// prevent processing for both keydown and change events on the same element
+						if (eventType === 'keydown' && eventTarget === event.target) {
 							eventType = '';
+							eventTarget = null;
 							return;
 						}
 					}


### PR DESCRIPTION
Hello! This fix checks that keydown and change event prevented only on the same element. It fixes bug, that can be reproduced this way:
1. Create filter for to field, one filter must be text input, other must be checkbox
2. Open any version of Firefox
3. Input text for search in text field end press Enter. At this moment this script will set variable eventType to 'keydown'
4. Click on checkbox. Filter won't run, because eventType is 'keydown', even though change event called by another element.
I think, it's related to bug #2881 too.