### PR TITLE
Added support for stream ciphers in CSecurityManager

### DIFF
--- a/framework/base/CSecurityManager.php
+++ b/framework/base/CSecurityManager.php
@@ -198,7 +198,7 @@ class CSecurityManager extends CApplicationComponent
 		$module=$this->openCryptModule();
 		$key=$this->substr($key===null ? md5($this->getEncryptionKey()) : $key,0,mcrypt_enc_get_key_size($module));
 		srand();
-		$iv=mcrypt_create_iv(mcrypt_enc_get_iv_size($module), MCRYPT_RAND);
+		$iv=mcrypt_enc_get_iv_size($module) ? mcrypt_create_iv(mcrypt_enc_get_iv_size($module), MCRYPT_RAND) : '';
 		mcrypt_generic_init($module,$key,$iv);
 		$encrypted=$iv.mcrypt_generic($module,$data);
 		mcrypt_generic_deinit($module);
@@ -239,7 +239,10 @@ class CSecurityManager extends CApplicationComponent
 			if(is_array($this->cryptAlgorithm))
 				$module=@call_user_func_array('mcrypt_module_open',$this->cryptAlgorithm);
 			else
-				$module=@mcrypt_module_open($this->cryptAlgorithm,'', MCRYPT_MODE_CBC,'');
+			{
+				$cipherMode=mcrypt_module_is_block_algorithm($this->cryptAlgorithm) ? MCRYPT_MODE_CBC : MCRYPT_MODE_STREAM;
+				$module=@mcrypt_module_open($this->cryptAlgorithm, '', $cipherMode, '');
+			}
 
 			if($module===false)
 				throw new CException(Yii::t('yii','Failed to initialize the mcrypt module.'));

--- a/tests/framework/base/CSecurityManagerTest.php
+++ b/tests/framework/base/CSecurityManagerTest.php
@@ -86,11 +86,11 @@ class CSecurityManagerTest extends CTestCase
 			$this->markTestSkipped('Mcrypt ARCFOUR module required to test encryption with a stream cipher.');
 		$securityManager=new CSecurityManager();
 		$securityManager->cryptAlgorithm='arcfour';
-		$securityManager->encryptionKey="\x72\x88\xFC\x31\xBF";
+		$securityManager->setEncryptionKey("\x72\x88\xFC\x31\xBF");
 		$plaintext="\xD2\x4D\x0C\x59\xEB\x33\x38\x1C\x9A\xC6";
 		$ciphertext=$securityManager->encrypt($plaintext);
 		$decrypted=$securityManager->decrypt($ciphertext);
-		$this->assertEquals($plaintext, $decrypted);
+		$this->assertEquals($plaintext,$decrypted);
 	}
 
 	public function providerComputeHMAC()

--- a/tests/framework/base/CSecurityManagerTest.php
+++ b/tests/framework/base/CSecurityManagerTest.php
@@ -77,6 +77,22 @@ class CSecurityManagerTest extends CTestCase
 		$this->assertEquals($data,$data2);
 	}
 
+	/*
+	 * Test encryption and decryption with a stream cipher (ARCFOUR).
+	 */
+	public function testStreamEncryptData()
+	{
+		if (!in_array('arcfour', mcrypt_list_algorithms()))
+			$this->markTestSkipped('Mcrypt ARCFOUR module required to test encryption with a stream cipher.');
+		$securityManager=new CSecurityManager();
+		$securityManager->cryptAlgorithm='arcfour';
+		$securityManager->encryptionKey="\x72\x88\xFC\x31\xBF";
+		$plaintext="\xD2\x4D\x0C\x59\xEB\x33\x38\x1C\x9A\xC6";
+		$ciphertext=$securityManager->encrypt($plaintext);
+		$decrypted=$securityManager->decrypt($ciphertext);
+		$this->assertEquals($plaintext, $decrypted);
+	}
+
 	public function providerComputeHMAC()
 	{
 		return array(


### PR DESCRIPTION
Trying to encrypt data with a stream cipher like ARCFOUR triggers an exception with the message “Failed to initialize the mcrypt module.”.

The problem is that the class uses CBC as the default cipher mode and always tries to generate an initialization vector. However, stream ciphers require the “stream” mode and generally don't support an initialization vector.