### PR TITLE
In rewrite mode, it will cause some routing failure

### DIFF
--- a/framework/web/CUrlManager.php
+++ b/framework/web/CUrlManager.php
@@ -368,7 +368,8 @@ class CUrlManager extends CApplicationComponent
 				if(is_array($rule))
 					$this->_rules[$i]=$rule=Yii::createComponent($rule);
 				if(($r=$rule->parseUrl($this,$request,$pathInfo,$rawPathInfo))!==false)
-					return isset($_GET[$this->routeVar]) ? $_GET[$this->routeVar] : $r;
+					//return isset($_GET[$this->routeVar]) ? $_GET[$this->routeVar] : $r;
+					return $r;	
 			}
 			if($this->useStrictParsing)
 				throw new CHttpException(404,Yii::t('yii','Unable to resolve the request "{route}".',


### PR DESCRIPTION
Thinks for your work,but i can't understand why do this
It will cause some routing failure
Example:
use nginx rewrite rewrite ^/path/(.*)$ /path/index.php?r=$1;
and set routing rules array('login'=>'account/login')

http://host/path/login
this url can't be work;
