### PR TITLE
Implement parsing of namespaces in class names included from include pat...

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,7 @@ Version 1.1.16 under development
 - Bug #3288: Check if PHPUnit_Runner_Version exists before requiring (hjellek)
 - Bug #3321: Clear stat cache after rotating log files so later file size check is not cached (cebe, jjdunn)
 - Bug #3410: Fixed wrong translation parameter name in CPhpAuthManager::addItemChild() (klimov-paul)
+- Bug #3418: Fixed issue when parsing the class name in autoload() in YiiBase. This bug surfaced when PHPUnit was updated. PHP Warning:  include(PHPUnit_Extensions_Story_TestCase.php): failed to open stream: No such file or directory in... (sharpdressedcodes)
 - Bug: Fixed the bug that backslashes are not escaped by CDbCommandBuilder::buildSearchCondition() (qiangxue)
 - Bug: Fixed URL parsing so it's now properly giving 404 for URLs like "http://example.com//////site/about/////" (samdark)
 - Bug: Fixed an issue with CFilehelper and not accessable directories which resulted in endless loop (cebe)

--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -429,7 +429,31 @@ class YiiBase
 					}
 				}
 				else
-					include($className.'.php');
+				{
+
+					/*
+					 * Fix for issue: 3418
+					 * This should now work with new version of PHPUnit.
+					 *
+					 * */
+
+					$ip = get_include_path();
+					$includes = strstr($ip, PATH_SEPARATOR) ? explode(PATH_SEPARATOR, $ip) : array($ip);
+					$found = false;
+
+					foreach ($includes as $include)
+					{
+						if (file_exists($include . DIRECTORY_SEPARATOR . $className . '.php'))
+						{
+							$found = true;
+							break;
+						}
+					}
+
+					include_once(($found ? $className : str_replace('_', DIRECTORY_SEPARATOR, $className)) . '.php');
+
+				}
+
 			}
 			else  // class name with namespace in PHP 5.3
 			{


### PR DESCRIPTION
Fix issue #3418 when parsing the class name in autoload() in YiiBase. This bug surfaced when PHPUnit was updated. Every time you would try to run a test, it would say:

PHP Warning:  include(PHPUnit_Extensions_Story_TestCase.php): failed to open stream: No such file or directory in... (path/to/SOME_INCLUDED_PATH)
