### PR TITLE
Fixed #3429: CHttpRequest::decodePathInfo() incorrectly process encoded '/'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,6 +51,7 @@ Version 1.1.16 under development
 - Bug: Fixed an issue with CFilehelper and not accessable directories which resulted in endless loop (cebe)
 - Bug #3305: COciSchema column comment reading from another schema (gureedo)
 - Bug #3406: Fixed Object of class Imagick could not be converted to string (eXprojects)
+- Bug #3429: Fixed CHttpRequest::decodePathInfo() incorrectly process encoded '/' (klimov-paul)
 - Enh: Public method CFileHelper::createDirectory() has been added (klimov-paul)
 - Enh: Added proper handling and support of the symlinked directories in CFileHelper::removeDirectory(), added $options parameter in CFileHelper::removeDirectory() (resurtm)
 - Enh #89: Support for SOAP headers in WSDL generator (nineinchnick)

--- a/framework/web/CHttpRequest.php
+++ b/framework/web/CHttpRequest.php
@@ -495,27 +495,27 @@ class CHttpRequest extends CApplicationComponent
 	 */
 	protected function decodePathInfo($pathInfo)
 	{
-		$pathInfo = urldecode($pathInfo);
-
-		// is it UTF-8?
-		// http://w3.org/International/questions/qa-forms-utf-8.html
-		if(preg_match('%^(?:
-		   [\x09\x0A\x0D\x20-\x7E]            # ASCII
-		 | [\xC2-\xDF][\x80-\xBF]             # non-overlong 2-byte
-		 | \xE0[\xA0-\xBF][\x80-\xBF]         # excluding overlongs
-		 | [\xE1-\xEC\xEE\xEF][\x80-\xBF]{2}  # straight 3-byte
-		 | \xED[\x80-\x9F][\x80-\xBF]         # excluding surrogates
-		 | \xF0[\x90-\xBF][\x80-\xBF]{2}      # planes 1-3
-		 | [\xF1-\xF3][\x80-\xBF]{3}          # planes 4-15
-		 | \xF4[\x80-\x8F][\x80-\xBF]{2}      # plane 16
-		)*$%xs', $pathInfo))
-		{
-			return $pathInfo;
+		$pathInfoParts=explode('/',$pathInfo);
+		foreach($pathInfoParts as $key=>$pathInfoPart) {
+			$pathInfoPart=urldecode($pathInfoPart);
+			// is it UTF-8?
+			// http://w3.org/International/questions/qa-forms-utf-8.html
+			if(!preg_match('%^(?:
+			   [\x09\x0A\x0D\x20-\x7E]            # ASCII
+			 | [\xC2-\xDF][\x80-\xBF]             # non-overlong 2-byte
+			 | \xE0[\xA0-\xBF][\x80-\xBF]         # excluding overlongs
+			 | [\xE1-\xEC\xEE\xEF][\x80-\xBF]{2}  # straight 3-byte
+			 | \xED[\x80-\x9F][\x80-\xBF]         # excluding surrogates
+			 | \xF0[\x90-\xBF][\x80-\xBF]{2}      # planes 1-3
+			 | [\xF1-\xF3][\x80-\xBF]{3}          # planes 4-15
+			 | \xF4[\x80-\x8F][\x80-\xBF]{2}      # plane 16
+			)*$%xs', $pathInfo))
+			{
+				$pathInfoPart=utf8_encode($pathInfoPart);
+			}
+			$pathInfoParts[$key]=$pathInfoPart;
 		}
-		else
-		{
-			return utf8_encode($pathInfo);
-		}
+		return implode('/',$pathInfoParts);
 	}
 
 	/**


### PR DESCRIPTION
Fixed #3429: CHttpRequest::decodePathInfo() incorrectly process encoded '/'
