### PR TITLE
Check for file existence before trying to include

### DIFF
--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -427,9 +427,15 @@ class YiiBase
 							break;
 						}
 					}
+				} else {
+					$file=$className.'.php';
+
+					if (file_exists($file)) {
+						return include($file);
+					} else {
+						return false;
+					}
 				}
-				else
-					include($className.'.php');
 			}
 			else  // class name with namespace in PHP 5.3
 			{


### PR DESCRIPTION
This was throwing errors when testing with PHPUnit (in a kind of jury-rigged Composer + Yii mix). Changed it to check to see if the file exists before trying to `include()` it.
