### PR TITLE
CDbCommand warning/exception generation fix

### DIFF
--- a/framework/db/CDbCommand.php
+++ b/framework/db/CDbCommand.php
@@ -505,9 +505,9 @@ class CDbCommand extends CComponent
 
 			$this->prepare();
 			if($params===array())
-				$this->_statement->execute();
+				@$this->_statement->execute();
 			else
-				$this->_statement->execute($params);
+				@$this->_statement->execute($params);
 
 			if($method==='')
 				$result=new CDbDataReader($this);


### PR DESCRIPTION
The problem is with MySQL. When PDO gets mysql "server has gone away" error, it issues a warning and then the exception. With full error reporting the script stops on warning with no way to catch an exception.
