### PR TITLE
hasComponent loadedOnly option

### DIFF
--- a/framework/base/CModule.php
+++ b/framework/base/CModule.php
@@ -364,11 +364,12 @@ abstract class CModule extends CComponent
 	/**
 	 * Checks whether the named component exists.
 	 * @param string $id application component ID
+	 * @param bool $loadedOnly check loaded components only
 	 * @return boolean whether the named application component exists (including both loaded and disabled.)
 	 */
-	public function hasComponent($id)
+	public function hasComponent($id, $loadedOnly = false)
 	{
-		return isset($this->_components[$id]) || isset($this->_componentConfig[$id]);
+		return isset($this->_components[$id]) || (!$loadedOnly && isset($this->_componentConfig[$id]));
 	}
 
 	/**


### PR DESCRIPTION
We've faced a quite awkward problem in connection with <code>allowAutoLogin</code>. Every time it comes to restore from cookie we get the <code>Undefined property: CWebApplication::$user</code> PHP notice which breaks the site.

IMO it's all about the user component loading too slow (btw we overrode the <code>CWebUser</code>). I tried to use <code>Yii::app()->hasComponent('user')</code> but it didn't help beacuse the component itself exists and there is no way to check whether the component's got loaded or not. If I'm not mistaken the loaded ones are  in the <code>$_components</code> array so I extended a little bit the <code>hasComponent()</code> function.
