### PR TITLE
Ignore copying a file if its source or destination address is missing.

### DIFF
--- a/framework/console/CConsoleCommand.php
+++ b/framework/console/CConsoleCommand.php
@@ -362,6 +362,9 @@ abstract class CConsoleCommand extends CComponent
 		$overwriteAll=false;
 		foreach($fileList as $name=>$file)
 		{
+			if (!isset($file['source']) || !isset($file['target'])){
+				continue;
+			}
 			$source=strtr($file['source'],'/\\',DIRECTORY_SEPARATOR);
 			$target=strtr($file['target'],'/\\',DIRECTORY_SEPARATOR);
 			$callback=isset($file['callback']) ? $file['callback'] : null;


### PR DESCRIPTION
Ignore copying a file if its source or destination address is missing. Issue #2915 @ yiisoft/yii

Useful when modifying the protected folder, index.php or index_test.php
