### PR TITLE
yiigridview.getChecked should return array of checkbox's values instead of keys

### DIFF
--- a/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
+++ b/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
@@ -392,14 +392,14 @@
 		 */
 		getChecked: function (column_id) {
 			var settings = gridSettings[this.attr('id')],
-				keys = this.find('.keys span'),
+				keys = this.find("input[name='" + column_id + "[]']"),
 				checked = [];
 			if (column_id.substring(column_id.length - 2) !== '[]') {
 				column_id = column_id + '[]';
 			}
 			this.find('.' + settings.tableClass).children('tbody').children('tr').children('td').children('input[name="' + column_id + '"]').each(function (i) {
 				if (this.checked) {
-					checked.push(keys.eq(i).text());
+					checked.push(keys.eq(i).val());
 				}
 			});
 			return checked;


### PR DESCRIPTION
It allow to change 'name' parameter of CCheckBoxColumn.

I use MANY-MANY (Child-ChildSchool-School) relation, so I select records from ChildSchool but display related Childs like this:

```
'columns'      => array(
    array(
        'class' => 'CCheckBoxColumn',
        'id' => 'child-boxes',
        'name' => 'child.id',
        'selectableRows' => 2,
    ),
    array(
        'name' => 'child.lastname',
        'value' => 'CHtml::link(CHtml::encode($data->child->lastname),
                                 array("view","id" => $data->child->id))',
        'type' => 'raw',
        'filter' => CHtml::activeTextField($model, 'lastname'),
    ), 
    etc
```

In this case even if I use 'name' in CCheckBoxColumn yiigridview.getChecked returns keys of ChildSchool instead of 'child.id'.
