### PR TITLE
Adds maxlength to input with "length is" validator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -115,6 +115,7 @@ Version 1.1.16 under development
 - Enh #3359: Added merge parameter to CModule::setModules (KJLJon)
 - Enh #3391: Exception and log for not existed ClientScript package (rusalex)
 - Enh #3513: Added 'getExtensionByMimeType' method to CFileHelper class (UA2004)
+- Enh #3552: `CStringValidator:$is` now adds maxlength to input fields as well (igorsantos07)
 - Chg #3137: Upgraded HTMLPurifier to 4.6.0 (samdark)
 - Chg #3298: ListView and GridView: Added check for the existence of a href attribute in link pager (dutchakdev)
 - New #2955: Added official support for MariaDB (cebe, DaSourcerer)

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2434,9 +2434,9 @@ EOD;
 			{
 				foreach($model->getValidators($attribute) as $validator)
 				{
-					if($validator instanceof CStringValidator && $validator->max!==null)
+					if($validator instanceof CStringValidator && ((($max = $validator->is) || ($max = $validator->max)) || $max !== null))
 					{
-						$htmlOptions['maxlength']=$validator->max;
+						$htmlOptions['maxlength']=$max;
 						break;
 					}
 				}


### PR DESCRIPTION
Using `CStringValidator::$max` would yield an input field with `maxlength` attribute, but using `$is` would not - this also blocks the maximum size of an input, so it was added there as well.