### PR TITLE
Reduce database usage

### DIFF
--- a/framework/db/CDbCommand.php
+++ b/framework/db/CDbCommand.php
@@ -182,6 +182,7 @@ class CDbCommand extends CComponent
 	 */
 	public function getConnection()
 	{
+		$this->_connection->setActive(true);
 		return $this->_connection;
 	}
 

--- a/framework/db/CDbConnection.php
+++ b/framework/db/CDbConnection.php
@@ -493,7 +493,6 @@ class CDbConnection extends CApplicationComponent
 	 */
 	public function createCommand($query=null)
 	{
-		$this->setActive(true);
 		return new CDbCommand($this,$query);
 	}
 

--- a/framework/yiilite.php
+++ b/framework/yiilite.php
@@ -8625,7 +8625,6 @@ class CDbConnection extends CApplicationComponent
 	}
 	public function createCommand($query=null)
 	{
-		$this->setActive(true);
 		return new CDbCommand($this,$query);
 	}
 	public function getCurrentTransaction()
@@ -9307,6 +9306,7 @@ class CDbCommand extends CComponent
 	}
 	public function getConnection()
 	{
+		$this->_connection->setActive(true);
 		return $this->_connection;
 	}
 	public function getPdoStatement()


### PR DESCRIPTION
Sample:

```
$command = Yii::app()->db->cache(60)->createCommand("SELECT * FROM some_table LIMIT 10");
```

This opens database connection even if `Yii::app()->db->autoConnect=false` and query results are already in cache.

I moved CDbConnection::setActive(true) from CDbConnection::createCommand() to CDbCommand::getConnection().
