### PR TITLE
setting the table alias before applying scopes

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -1346,6 +1346,11 @@ abstract class CActiveRecord extends CModel
 	protected function query($criteria,$all=false)
 	{
 		$this->beforeFind();
+		
+		if (!empty($criteria->alias)) {
+			$this->setTableAlias($criteria->alias);
+		}
+		
 		$this->applyScopes($criteria);
 
 		if(empty($criteria->with))


### PR DESCRIPTION
this is to address this issue: https://github.com/yiisoft/yii/issues/3505
in the current version, an alias applied by the CDbCriteria is not accessible by the scopes
i hope this helps

```php
$criteria = new CDbCriteria;
$criteria->alias = 'x';

MyModel::model()->findAll($criteria);

// in the defaultScope() of MyModel:
public function defaultScope()
{
    $this->getTableAlias(false,false); // returns `t`
}
```