### PR TITLE
Updated the CMemCache test case such that we can also test with memcached

### DIFF
--- a/tests/framework/caching/CMemCacheTest.php
+++ b/tests/framework/caching/CMemCacheTest.php
@@ -6,6 +6,8 @@ if(!defined('MEMCACHE_TEST_HOST'))
 if(!defined('MEMCACHE_TEST_PORT'))
 	define('MEMCACHE_TEST_PORT', 11211);
 
+if (!defined('MEMCACHE_USE_MEMCACHED'))
+	define('MEMCACHE_USE_MEMCACHED', false);
 
 class CMemCacheTest extends CTestCase
 {
@@ -14,6 +16,7 @@ class CMemCacheTest extends CTestCase
 		'components'=>array(
 			'cache'=>array(
 	            'class'=>'CMemCache',
+		    'useMemcached' => MEMCACHE_USE_MEMCACHED,
 	            'servers'=>array(
 	                array('host'=>MEMCACHE_TEST_HOST, 'port'=>MEMCACHE_TEST_PORT, 'weight'=>100),
 	    		),


### PR DESCRIPTION
The current test script allows for the tests to be executed if either the memcache or memcached php module has been loaded into the php engine. But the test case does not set the property $useMemcached if you want to use that. Therefor I introduced the MEMCACHE_USE_MEMCACHED constant to allow for a tester to enable the use of memcached if that has been installed on your machine. Before this fix the test case would throw Exceptions if you would try to use memcached instead of memcache. In the bootstrap you can overwrite the MEMCACHE_USE_MEMCACHED constant by doing 

defined('MEMCACHE_USE_MEMCACHED') or define('MEMCACHE_USE_MEMCACHED', true);
