### PR TITLE
Update CGridView.php

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
                    Yii Framework Change Log
                    ========================
+Version 1.1.17
+- Enh #3571: Extracted rendering of data cell in CGridView.renderTableRow() to separate method for extensibility (hijarian).
 
 Version 1.1.16 under development
 --------------------------------

--- a/framework/zii/widgets/grid/CGridView.php
+++ b/framework/zii/widgets/grid/CGridView.php
@@ -631,6 +631,7 @@ class CGridView extends CBaseListView
 	 * 
 	 * @param CGridColumn $column The Column instance to 
 	 * @param integer $row
+	 * @since 1.1.17
 	 */
 	protected function renderDataCell($column, $row)
 	{


### PR DESCRIPTION
Added a seam to override only a data cell rendering process, without the need to override the whole `CGridView.renderTableRow()`.

Probably don't need a CHANGELOG entry for this one (too technical).
