### PR TITLE
fix English typos in `UPGRADE` file

### DIFF
--- a/UPGRADE
+++ b/UPGRADE
@@ -26,12 +26,12 @@ Upgrading from v1.1.14
 - CErrorHandler now runs errorAction for errors, which appear via AJAX request.
   If you use CErrorHandler::errorAction, make sure it handles AJAX request properly.
 
-- The possibility to use callables for values of CDetailView introduced a problem with string beeing interpreted as
+- The possibility to use callables for values of CDetailView introduced a problem with string being interpreted as
   PHP functions. CDetailView now only allows anonymous functions to be called, all other values will be taken as value.
 
 - We updated the `framework/utils/mimeTypes.php` with more file extensions from the http apache project.
   Due to this fact some of the assignments have changed so if you rely on the mimeType detection of `CFileHelper`
-  you need to check if your code works with the new mime type assigments.
+  you need to check if your code works with the new mime type assignments.
   You can use a custom `mimeTypes.php` file to bring back the old behavior if needed by specifying the second parameter
   of `CFileHelper::getMimeTypeByExtension($file, $magicFile='path/to/your/mimeTypes.php')`.
 


### PR DESCRIPTION
Simple text fix; no separate issue filed for this trivial thing.
