### PR TITLE
Generate model input id attribute based on modelName and attribute

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2653,10 +2653,12 @@ EOD;
 	 */
 	public static function resolveNameID($model,&$attribute,&$htmlOptions)
 	{
+		$defaultName=self::resolveName($model,$attribute);
+
 		if(!isset($htmlOptions['name']))
-			$htmlOptions['name']=self::resolveName($model,$attribute);
+			$htmlOptions['name']=$defaultName;
 		if(!isset($htmlOptions['id']))
-			$htmlOptions['id']=self::getIdByName($htmlOptions['name']);
+			$htmlOptions['id']=self::getIdByName($defaultName);
 		elseif($htmlOptions['id']===false)
 			unset($htmlOptions['id']);
 	}


### PR DESCRIPTION
There is a problem when setting `name` attribute explicitly(for whatever reason) on input element like this:

```
echo $form->labelEx($model,'title');
echo $form->textField($model,'title',array('name' => 'someCustomName'));
```

then the generated markup looks like:

```
<label for="Post_title">Title</label>
<input name="someCustomName" id="someCustomName" type="text">
```

therefore clicking on label no longer works (for attribute is different from input id value).

My idea is to generate id attributes of inputs independently of it's name. Just use `model` and `attribute` (see diff), and i get:

```
<label for="Post_title">Title</label>
<input name="someCustomName" id="Post_title" type="text">
```
