### PR TITLE
fix incorrect count of line breaks between client and server side

### DIFF
--- a/framework/validators/CStringValidator.php
+++ b/framework/validators/CStringValidator.php
@@ -142,7 +142,9 @@ class CStringValidator extends CValidator
 			'{max}'=>$this->max,
 		));
 
-		$js='';
+		$js="
+value = value.replace(/(\\r\\n|\\r|\\n)/g, \"\\r\\n\");
+";
 		if($this->min!==null)
 		{
 			$js.="


### PR DESCRIPTION
Hello,

stumbled upon a bug where the line breaks are miscounted in client side.

with this bug the client side validation passes and server side validation fails

Please review
