### PR TITLE
Fix for #3555

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -57,6 +57,7 @@ Version 1.1.16 under development
 - Bug #3327: Gii did not generate empty directories properly (gureedo)
 - Bug #3406: Fixed Object of class Imagick could not be converted to string (eXprojects)
 - Bug #3410: Fixed wrong translation parameter name in CPhpAuthManager::addItemChild() (klimov-paul)
+- Bug #3555: Updated CActiveRecord::update() to only set pk value if the primary key (or composite key) was included in the attributes list. Should fix CActiveRecord::getOldPrimaryKey() in this method. (georaldc)
 - Bug #3569: CConsoleCommand::copyFiles() did not replace DIRECTORY_SEPARATOR correctly (jmxhit)
 - Bug #3582: make sure `build autoload` produces the same output on both Windows and Unix platforms (GerHobbelt)
 - Bug: Fixed the bug that backslashes are not escaped by CDbCommandBuilder::buildSearchCondition() (qiangxue)

--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -1122,10 +1122,20 @@ abstract class CActiveRecord extends CModel
 		if($this->beforeSave())
 		{
 			Yii::trace(get_class($this).'.update()','system.db.ar.CActiveRecord');
+			$table=$this->getTableSchema();
 			if($this->_pk===null)
 				$this->_pk=$this->getPrimaryKey();
 			$this->updateByPk($this->getOldPrimaryKey(),$this->getAttributes($attributes));
-			$this->_pk=$this->getPrimaryKey();
+			if($attributes === null || (is_string($table->primaryKey) && in_array($table->primaryKey,$attributes)))
+				$this->_pk=$this->getPrimaryKey();
+			elseif(is_array($table->primaryKey))
+			{
+				foreach($table->primaryKey as $name)
+				{
+					if(in_array($name,$attributes))
+						$this->_pk[$name]=$this->$name;
+				}
+			}
 			$this->afterSave();
 			return true;
 		}


### PR DESCRIPTION
Fix for #3555 

CActiveRecord::_pk should only be updated if the primary key was included
as part of the attributes passed to CActiveRecord::update().

This should also fix the value returned by CActiveRecord::getOldPrimaryKey() when using the update method, without passing the primary key.
