### PR TITLE
Decreasing visible columns in the grid view admin

### DIFF
--- a/framework/gii/generators/crud/templates/default/admin.php
+++ b/framework/gii/generators/crud/templates/default/admin.php
@@ -59,11 +59,11 @@ or <b>=</b>) at the beginning of each of your search values to specify how the c
 $count=0;
 foreach($this->tableSchema->columns as $column)
 {
-	if(++$count==7)
+	if(++$count==5)
 		echo "\t\t/*\n";
 	echo "\t\t'".$column->name."',\n";
 }
-if($count>=7)
+if($count>=5)
 	echo "\t\t*/\n";
 ?>
 		array(


### PR DESCRIPTION
Ok, 7 visible columns sometimes bursts the screen size, it would be ideal to use only 5.

This in a context of a model of products, would tend to show colunsa base as id, name, description, value ... Other columns would be hidden (commented)
