### PR TITLE
Update CFileHelper::removeDirectory()

### DIFF
--- a/framework/utils/CFileHelper.php
+++ b/framework/utils/CFileHelper.php
@@ -66,41 +66,15 @@ class CFileHelper
 	/**
 	 * Removes a directory recursively.
 	 * @param string $directory to be deleted recursively.
-	 * @param array $options for the directory removal. Valid options are:
-	 * <ul>
-	 * <li>traverseSymlinks: boolean, whether symlinks to the directories should be traversed too.
-	 * Defaults to `false`, meaning that the content of the symlinked directory would not be deleted.
-	 * Only symlink would be removed in that default case.</li>
-	 * </ul>
-	 * Note, options parameter is available since 1.1.16
-	 * @since 1.1.14
+	 * @return boolean Returns the result of rmdir().
 	 */
-	public static function removeDirectory($directory,$options=array())
+	public static function removeDirectory($dir)
 	{
-		if(!isset($options['traverseSymlinks']))
-			$options['traverseSymlinks']=false;
-		$items=glob($directory.DIRECTORY_SEPARATOR.'{,.}*',GLOB_MARK | GLOB_BRACE);
-		foreach($items as $item)
-		{
-			if(basename($item)=='.' || basename($item)=='..')
-				continue;
-			if(substr($item,-1)==DIRECTORY_SEPARATOR)
-			{
-				if(!$options['traverseSymlinks'] && is_link(rtrim($item,DIRECTORY_SEPARATOR)))
-					unlink(rtrim($item,DIRECTORY_SEPARATOR));
-				else
-					self::removeDirectory($item,$options);
-			}
-			else
-				unlink($item);
+		$files = array_diff(scandir($dir), array('.','..'));
+		foreach ($files as $file) {
+			(is_dir("$dir/$file")) ? self::removeDirectory("$dir/$file") : unlink("$dir/$file");
 		}
-		if(is_dir($directory=rtrim($directory,'\\/')))
-		{
-			if(is_link($directory))
-				unlink($directory);
-			else
-				rmdir($directory);
-		}
+		return rmdir($dir);
 	}
 
 	/**

--- a/framework/utils/CFileHelper.php
+++ b/framework/utils/CFileHelper.php
@@ -68,7 +68,7 @@ class CFileHelper
 	 * @param string $directory to be deleted recursively.
 	 * @return boolean Returns the result of rmdir().
 	 */
-	public static function removeDirectory($dir)
+	public static function removeDirectory($dir, $options=null)
 	{
 		$files = array_diff(scandir($dir), array('.','..'));
 		foreach ($files as $file) {


### PR DESCRIPTION
Swapped function with a more efficient and reliable way to delete an entire folder and it's contents recursively.