### PR TITLE
Bug on listOptions

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2537,7 +2537,7 @@ EOD;
 				$attributes=array('value'=>(string)$key,'encode'=>!$raw);
 				if(!is_array($selection) && !strcmp($key,$selection) || is_array($selection) && in_array($key,$selection))
 					$attributes['selected']='selected';
-				if(isset($options[$key]))
+				if(isset($options[$key]) && is_array($options[$key]))
 					$attributes=array_merge($attributes,$options[$key]);
 				$content.=self::tag('option',$attributes,$raw?(string)$value : self::encode((string)$value))."\n";
 			}


### PR DESCRIPTION
When we call CHtml::dropDownList with multiple options and more then 6 items in the selected array we get a bug on the array_merge call right below the line I edited.

Example:
```php
<?php $selectedOptions = array(29, 39, 9, 74, 56, 11, 72 ) ; ?>
<?php $cuisenesOptions = array( 73 => "*As Novidades", 70 => "*Delivery", 29 => "AlemÃ£", 39 => "Americana", 9 => "Ãrabe", 74 => "Argentina", 56 => "Australiana", 11 => "Baiana", 72 => "Belga", 23 => "Brasileira", 25 => "Bruschetteria", 60 => "Chinesa", 6 => "Churrascaria", 67 => "Comidinhas", 15 => "ContemporÃ¢nea", 63 => "Creperia", 53 => "Espanhola", 26 => "Francesa", 38 => "Frutos", do Mar 71 => "Fusion", Cuisine 24 => "Galeteria", 66 => "Hamburgueria", 55 => "Havaiana", 69 => "Indiana", 58 => "Internacional", 19 => "Italiana", 18 => "Japonesa", 50 => "Judaica", 59 => "Libanesa", 62 => "MediterrÃ¢nea", 47 => "Mexicana", 35 => "Mineira", 28 => "Nordestina", 36 => "Parrilla", 57 => "Peruana", 22 => "Pizzaria", 17 => "Portuguesa", 64 => "Russa", 44 => "SaudÃ¡vel", 52 => "Sorveteria", 14 => "Tailandesa", 20 => "Tex-Mex", 65 => "Variada"); ?>
<?php echo CHtml::dropDownList('cuisine', $selectedOptions, $cuisenesOptions, array('class'=>'span2', 'multiple'=>'multiple', 'options'=>$selectedOptions)); ?>
```


When $searchForm->cuisine has more than 6 itens we get this bug.