### PR TITLE
Yii jQuery 向下兼容

### DIFF
--- a/framework/web/js/packages.php
+++ b/framework/web/js/packages.php
@@ -78,4 +78,8 @@ return array(
 	'punycode'=>array(
 		'js'=>array(YII_DEBUG ? 'punycode.js' : 'punycode.min.js'),
 	),
+	'migrate'=>array(
+		'js'=>array(YII_DEBUG ? 'jquery-migrate.js' : 'jquery-migrate.min.js'),
+		'depends'=>array('jquery'),
+	),
 );


### PR DESCRIPTION
可以的话你们可以把 jquery-migrate.js  jquery-migrate.min.js 文件添加到 source 文件夹下。
Yii.1.1.15 使用的是 jquery.1.8.x 新版本使用的是1.11.x 
加了这个 老版本的 js 兼容起来也就很方便了。当然你们也可以使用更好的方式
https://github.com/jquery/jquery-migrate/#readme @qiangxue
