### PR TITLE
Fixes #3715  legacyDecrypt() not compatible with 1.1.15 decrypt()

### DIFF
--- a/framework/base/CSecurityManager.php
+++ b/framework/base/CSecurityManager.php
@@ -566,6 +566,7 @@ class CSecurityManager extends CApplicationComponent
 			$key=Yii::app()->getGlobalState(self::STATE_ENCRYPTION_KEY);
 			if(!$key)
 				throw new CException(Yii::t('yii','No encryption key specified.'));
+			$key = md5($key);
 		}
 
 		if(extension_loaded('mcrypt'))
@@ -581,7 +582,7 @@ class CSecurityManager extends CApplicationComponent
 		else
 			throw new CException(Yii::t('yii','CSecurityManager requires PHP mcrypt extension to be loaded in order to use data encryption feature.'));
 
-		$derivedKey=$this->substr(md5($key),0,mcrypt_enc_get_key_size($module));
+		$derivedKey=$this->substr($key,0,mcrypt_enc_get_key_size($module));
 		$ivSize=mcrypt_enc_get_iv_size($module);
 		$iv=$this->substr($data,0,$ivSize);
 		mcrypt_generic_init($module,$derivedKey,$iv);


### PR DESCRIPTION
Fixes https://github.com/yiisoft/yii/issues/3715

The old implementation of decrypt() only ran the md5 hash on the key if one was not explicitly provided.