### PR TITLE
Added method CModel::load() to populate the model with the data from user

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
 
 Version 1.1.17 work in progress
 -------------------------------
-
+- Enh #3737: Added method CModel::load() to populate the model with the data from end user (psrustik)
 - Bug #2921: Fixed CStatePersister read/write concurrency issue causing state data corruption (matteosistisette, samdark)
 - Bug #3497: CErrorHandler messages for HTTP response codes were not matching RFCs (TeMPOraL)
 - Bug #3637: Fixed not quoting primary key in count statements (applee)

--- a/framework/base/CModel.php
+++ b/framework/base/CModel.php
@@ -165,6 +165,35 @@ abstract class CModel extends CComponent implements IteratorAggregate, ArrayAcce
 	}
 
 	/**
+	 * Populates the model with the data from end user.
+	 * The data to be loaded is `$data[formName]`, where `formName` refers to the value of [[formName()]].
+	 * If [[formName()]] is empty, the whole `$data` array will be used to populate the model.
+	 * The data being populated is subject to the safety check by [[setAttributes()]].
+	 * @param array $data the data array. This is usually `$_POST` or `$_GET`, but can also be any valid array
+	 * supplied by end user.
+	 * @param string $formName the form name to be used for loading the data into the model.
+	 * If not set, [[ CHtml::modelName()]] will be used.
+	 * @return boolean whether the model is successfully populated with some data.
+	 * @since 1.1.17
+	 */
+	public function load($data, $formName = null)
+	{
+		$scope = $formName === null ? CHtml::modelName($this) : $formName;
+		if($scope === '' && !empty($data))
+		{
+			$this->setAttributes($data);
+			return true;
+		}
+		elseif(isset($data[$scope]))
+		{
+			$this->setAttributes($data[$scope]);
+			return true;
+		}
+		else
+			return false;
+	}
+
+	/**
 	 * This method is invoked after a model instance is created by new operator.
 	 * The default implementation raises the {@link onAfterConstruct} event.
 	 * You may override this method to do postprocessing after model creation.

--- a/tests/framework/base/CModelTest.php
+++ b/tests/framework/base/CModelTest.php
@@ -239,4 +239,23 @@ class CModelTest extends CTestCase
 				$e->getMessage());
 		}
 	}
+
+	public function testLoad()
+	{
+		$model = new NewModel();
+		$post = array('NewModel' => array('attr1' => 'value1', 'attr2' => 'value2'), 'yt0' => '');
+		$this->assertTrue($model->load($post));
+		$this->assertEquals('value1', $model->attr1);
+		$this->assertEquals('value2', $model->attr2);
+
+		$model->unsetAttributes();
+		$data = array('attr2' => 'value2');
+		$this->assertTrue($model->load($data, ''));
+		$this->assertEquals('value2', $model->attr2);
+
+		$model->unsetAttributes();
+		$data = array('modelName'=>array('attr1'=>'value1'));
+		$this->assertFalse($model->load($data, 'bad_form_name'));
+		$this->assertNull($model->attr1);
+	}
 }


### PR DESCRIPTION
This is simplify load user data from POST, GET to models in namespace.
Backported from Yii2.

Before code:
```php
public function actionUpdate($id)
{
    $model = $this->loadModel($id);
    if (isset($_POST[\CHtml::modelName($model)])) 
    {
       $model->attributes = $_POST[\CHtml::modelName($model)];
       ...
    }    
}
```
After merge request may be so:
```php
public function actionUpdate($id)
{
    $model = $this->loadModel($id);
    if ($model->load($_POST))
    { 
        ...
    }
}
```