### PR TITLE
Fix for delete operation in gridview with non-ajax mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
 
 Version 1.1.17 work in progress
 -------------------------------
-
+- Bug #3745: Fixed delete operation in gridview with non-ajax mode (psrustik)
 - Bug #2921: Fixed CStatePersister read/write concurrency issue causing state data corruption (matteosistisette, samdark)
 - Bug #3497: CErrorHandler messages for HTTP response codes were not matching RFCs (TeMPOraL)
 - Bug #3637: Fixed not quoting primary key in count statements (applee)

--- a/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
+++ b/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
@@ -354,6 +354,15 @@
 						$form = $('<form action="' + options.url + '" method="post"></form>').appendTo('body');
 						if (options.data === undefined) {
 							options.data = {};
+						} else if (typeof options.data == 'string') {
+							var map = {};
+							$.each(options.data.split("&"), function () {
+								var nv = this.split("="),
+									n = decodeURIComponent(nv[0]),
+									v = nv.length > 1 ? decodeURIComponent(nv[1]) : null;
+								map[n] = v;
+							});
+							options.data = map;
 						}
 
 						if (options.data.returnUrl === undefined) {


### PR DESCRIPTION
When using CGridView with ajaxUpdate=false delete operation does not work. 
Client performs delete operation by GET method due to errors in the yiigridview.js.

See jquery.yiigridview.js:372

``` js
$.each(options.data, function (name, value) {
    /* ^^ error ^^ */
     $form.append($('<input type="hidden" name="t" value="" />').attr('name', name).val(value));
});
$form.submit();
```

jQuery.each() require list(array) for first argument, but code below create string:

``` js
/*  jquery.yiigridview.js:327*/
if (options.data === undefined) {
    options.data = $(settings.filterSelector).serialize();
}
```

This merge request fixed this problem and options.data converted to list (array).
