### PR TITLE
Support of brackets syntax for attribute names in CForm for issue #3331 and #613

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ Version 1.1.17 work in progress
 - Enh #2399: It is now possible to use table names containing spaces by introducing alias (devivan)
 - Enh #3686: Wrapper div of hidden fields in CForm now have style `display:none` instead of `visibility:hidden` to not affect the layout (cebe, alaabadran)
 - Enh #3738: It is now possible to override the value of 'required' html option in `CHtml::activeLabelEx()` (matteosistisette)
+- Enh #3331: Support of square brackets in attribute names in CForm config array (SleepWalker)
 
 Version 1.1.16 December 21, 2014
 --------------------------------

--- a/framework/web/form/CFormInputElement.php
+++ b/framework/web/form/CFormInputElement.php
@@ -147,7 +147,7 @@ class CFormInputElement extends CFormElement
 		if($this->_required!==null)
 			return $this->_required;
 		else
-			return $this->getParent()->getModel()->isAttributeRequired($this->name);
+			return $this->getParent()->getModel()->isAttributeRequired($this->getAttributeName());
 	}
 
 	/**
@@ -167,7 +167,7 @@ class CFormInputElement extends CFormElement
 		if($this->_label!==null)
 			return $this->_label;
 		else
-			return $this->getParent()->getModel()->getAttributeLabel($this->name);
+			return $this->getParent()->getModel()->getAttributeLabel($this->getAttributeName());
 	}
 
 	/**
@@ -271,6 +271,14 @@ class CFormInputElement extends CFormElement
 	 */
 	protected function evaluateVisible()
 	{
-		return $this->getParent()->getModel()->isAttributeSafe($this->name);
+		return $this->getParent()->getModel()->isAttributeSafe($this->getAttributeName());
+	}
+
+	protected function getAttributeName()
+	{
+		$attribute = $this->name;
+		CHtml::resolveName($this->getParent()->getModel(), $attribute); // filtering [a][b]attribute
+
+		return $attribute;
 	}
 }


### PR DESCRIPTION
In my issue #3331 I wrote a little bit bad description. The problem was that `CFormInputElement` ignores brackets syntax for the attribute naming. The brackets are not filtered out from attribute name, while checking if attribute is safe and as result we become `false` for absolutely all (safe and unsafe) tabular attributes and the fields aren't rendered at all.

This issue is partially addressed in #613 too.