### PR TITLE
#3045: CGridView: added rowSelectionSelector option to filter the elements in a row that can trigger a row selection on click

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ Version 1.1.17 work in progress
 - Bug #3715: 1.1.16 `CSecurityManager::legacyDecrypt` was not compatible with 1.1.15 method (DanaLuther)
 - Bug #3724: Fixed namespace prefix in WSDL generator for arrayType. (ametad)
 - Enh #2399: It is now possible to use table names containing spaces by introducing alias (devivan)
+- Enh #3045: CGridView: added rowSelectionSelector option to filter the elements in a row that can trigger a row selection on click (Sibilino)
 - Enh #3686: Wrapper div of hidden fields in CForm now have style `display:none` instead of `visibility:hidden` to not affect the layout (cebe, alaabadran)
 - Enh #3738: It is now possible to override the value of 'required' html option in `CHtml::activeLabelEx()` (matteosistisette)
 

--- a/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
+++ b/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
@@ -60,7 +60,8 @@
 					loadingClass: 'loading',
 					filterClass: 'filters',
 					tableClass: 'items',
-					selectableRows: 1
+					selectableRows: 1,
+					rowSelectionSelector: ''
 					// updateSelector: '#id .pager a, '#id .grid thead th a',
 					// beforeAjaxUpdate: function (id) {},
 					// afterAjaxUpdate: function (id, data) {},
@@ -76,13 +77,15 @@
 					id = $grid.attr('id'),
 					pagerSelector = '#' + id + ' .' + settings.pagerClass.replace(/\s+/g, '.') + ' a',
 					sortSelector = '#' + id + ' .' + settings.tableClass + ' thead th a.sort-link',
-					inputSelector = '#' + id + ' .' + settings.filterClass + ' input, ' + '#' + id + ' .' + settings.filterClass + ' select';
+					inputSelector = '#' + id + ' .' + settings.filterClass + ' input, ' + '#' + id + ' .' + settings.filterClass + ' select',
+					rowSelector = '#' + id + ' .' + settings.tableClass + ' > tbody > tr';
 
 				settings.updateSelector = settings.updateSelector
 								.replace('{page}', pagerSelector)
 								.replace('{sort}', sortSelector);
 				settings.filterSelector = settings.filterSelector
 								.replace('{filter}', inputSelector);
+				settings.rowSelectionSelector = $.trim(rowSelector + ' ' + settings.rowSelectionSelector);
 
 				gridSettings[id] = settings;
 
@@ -153,7 +156,7 @@
 
 				if (settings.selectableRows > 0) {
 					selectCheckedRows(this.id);
-					$(document).on('click.yiiGridView', '#' + id + ' .' + settings.tableClass + ' > tbody > tr', function (e) {
+					$(document).on('click.yiiGridView', settings.rowSelectionSelector, function (e) {
 						var $currentGrid, $row, isRowSelected, $checks,
 							$target = $(e.target);
 
@@ -161,7 +164,7 @@
 							return;
 						}
 
-						$row = $(this);
+						$row = $(this).closest('tr');
 						$currentGrid = $('#' + id);
 						$checks = $('input.select-on-check', $currentGrid);
 						isRowSelected = $row.toggleClass('selected').hasClass('selected');

--- a/framework/zii/widgets/grid/CGridView.php
+++ b/framework/zii/widgets/grid/CGridView.php
@@ -240,7 +240,6 @@ class CGridView extends CBaseListView
 	 * rows (gridID is the DOM selector of the grid).
 	 */
 	public $selectableRows=1;
-	
 	/**
 	 * @var string the jQuery selector of the HTML elements that may trigger the selection of their row when they are clicked.
 	 * The default value is an empty string, meaning that the selection may be triggered by clicking anywhere on the row itself.

--- a/framework/zii/widgets/grid/CGridView.php
+++ b/framework/zii/widgets/grid/CGridView.php
@@ -240,6 +240,21 @@ class CGridView extends CBaseListView
 	 * rows (gridID is the DOM selector of the grid).
 	 */
 	public $selectableRows=1;
+	
+	/**
+	 * @var string the jQuery selector of the HTML elements that may trigger the selection of their row when they are clicked.
+	 * The default value is an empty string, meaning that the selection may be triggered by clicking anywhere on the row itself.
+	 * 
+	 * Example (row selection is only triggered by a CCheckBoxColumn input element in the row):
+	 * <pre>
+	 *  ...
+	 *  'rowSelectionSelector'=>'input.select-on-check',
+	 *  ...
+	 * </pre>
+	 * @see selectableRows
+	 * @since 1.1.17
+	 */
+	public $rowSelectionSelector='';
 	/**
 	 * @var string the base script URL for all grid view resources (eg javascript, CSS file, images).
 	 * Defaults to null, meaning using the integrated grid view resources (which are published as assets).
@@ -438,6 +453,7 @@ class CGridView extends CBaseListView
 			'filterClass'=>$this->filterCssClass,
 			'tableClass'=>$this->itemsCssClass,
 			'selectableRows'=>$this->selectableRows,
+			'rowSelectionSelector'=>$this->rowSelectionSelector,
 			'enableHistory'=>$this->enableHistory,
 			'updateSelector'=>$this->updateSelector,
 			'filterSelector'=>$this->filterSelector


### PR DESCRIPTION
Enh #3045 

Originally, when CGridView is configured to enable selectable rows, clicking anywhere on a row will select the row. However, the user may want to click on a row element without wanting to select the row; for example, when copying some row content to the clipboard.

After merge, CGridView will accept the `rowSelectionSelector` option, which specifies a jQuery selector so that only the row's children that are matched will trigger the row's selection. The default value for this option is an empty string, which leaves the original selection behavior unmodified.

For example:

``` php
//...
'rowSelectionSelector' => 'input.select-on-check',
//...
```

Will restrict row selection to clicking on the checkboxes generated by a CCheckBoxColumn.
