### PR TITLE
Enh #3279: CJuiAutoComplete: added `inputType` option that controls the type of the generated input field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ Version 1.1.17 work in progress
 - Bug #3715: 1.1.16 `CSecurityManager::legacyDecrypt` was not compatible with 1.1.15 method (DanaLuther)
 - Bug #3724: Fixed namespace prefix in WSDL generator for arrayType. (ametad)
 - Enh #2399: It is now possible to use table names containing spaces by introducing alias (devivan)
+- Enh #3279: CJuiAutoComplete: added `inputType` option that controls the type of the generated input field (Sibilino)
 - Enh #3686: Wrapper div of hidden fields in CForm now have style `display:none` instead of `visibility:hidden` to not affect the layout (cebe, alaabadran)
 - Enh #3738: It is now possible to override the value of 'required' html option in `CHtml::activeLabelEx()` (matteosistisette)
 

--- a/framework/zii/widgets/jui/CJuiAutoComplete.php
+++ b/framework/zii/widgets/jui/CJuiAutoComplete.php
@@ -122,7 +122,7 @@ class CJuiAutoComplete extends CJuiInputWidget
 
 		$inputField = $this->inputType.'Field';
 		if ($this->hasModel())
-			$inputField = "active$inputField";
+			$inputField = 'active'.ucfirst($inputField);
 		
 		return CHtml::{$inputField}($this->model,$this->attribute,$this->htmlOptions);
 	}

--- a/framework/zii/widgets/jui/CJuiAutoComplete.php
+++ b/framework/zii/widgets/jui/CJuiAutoComplete.php
@@ -74,6 +74,7 @@ class CJuiAutoComplete extends CJuiInputWidget
 	 * <li>tel</li>
 	 * <li>url</li>
 	 * </ul>
+	 * @since 1.1.17
 	 */
 	public $inputType='text';
 

--- a/framework/zii/widgets/jui/CJuiAutoComplete.php
+++ b/framework/zii/widgets/jui/CJuiAutoComplete.php
@@ -65,6 +65,17 @@ class CJuiAutoComplete extends CJuiInputWidget
 	 * into a proper URL. When this property is set, the {@link source} property will be ignored.
 	 */
 	public $sourceUrl;
+	/**
+	 * @var string the input type of the autocomplete field. The default type is 'text'. Supported types are:
+	 * <ul>
+	 * <li>text</li>
+	 * <li>search</li>
+	 * <li>email</li>
+	 * <li>tel</li>
+	 * <li>url</li>
+	 * </ul>
+	 */
+	public $inputType='text';
 
 	/**
 	 * Run this widget.
@@ -81,11 +92,8 @@ class CJuiAutoComplete extends CJuiInputWidget
 		if(isset($this->htmlOptions['name']))
 			$name=$this->htmlOptions['name'];
 
-		if($this->hasModel())
-			echo CHtml::activeTextField($this->model,$this->attribute,$this->htmlOptions);
-		else
-			echo CHtml::textField($name,$this->value,$this->htmlOptions);
-
+		echo $this->generateField();
+		
 		if($this->sourceUrl!==null)
 			$this->options['source']=CHtml::normalizeUrl($this->sourceUrl);
 		else
@@ -93,5 +101,29 @@ class CJuiAutoComplete extends CJuiInputWidget
 
 		$options=CJavaScript::encode($this->options);
 		Yii::app()->getClientScript()->registerScript(__CLASS__.'#'.$id,"jQuery('#{$id}').autocomplete($options);");
+	}
+	
+	/**
+	 * Generates the HTML for the configured {@link inputType}.
+	 * @return string the generated input field.
+	 */
+	protected function generateField()
+	{
+		$supportedTypes = array(
+			'text',
+			'search',
+			'email',
+			'tel',
+			'url'
+		);
+		
+		if (!in_array($this->inputType, $supportedTypes))
+			$this->inputType = 'text';
+
+		$inputField = $this->inputType.'Field';
+		if ($this->hasModel())
+			$inputField = "active$inputField";
+		
+		return CHtml::{$inputField}($this->model,$this->attribute,$this->htmlOptions);
 	}
 }


### PR DESCRIPTION
Enh #3279

Originally, the CJuiAutoComplete widget always generated an input of type="text". The only way of changing the input type was to override the run() method, which contained most of the widget's code.

After merge, the CJuiAutoComplete widget will accept an additional option `inputType` which controls the autocomplete input's type. Its default value is `'text'` and accepts either `'text'`, `'search'`, `'email'`, `'tel'` or `'url'`.

Furthermore, the HTML-generating code has been moved to a separate protected function for easier overriding.
