### PR TITLE
Check if file exists before including it

### DIFF
--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -434,7 +434,7 @@ class YiiBase
 			else  // class name with namespace in PHP 5.3
 			{
 				$namespace=str_replace('\\','.',ltrim($className,'\\'));
-				if(($path=self::getPathOfAlias($namespace))!==false)
+				if(($path=self::getPathOfAlias($namespace))!==false && is_file($path.'.php'))
 					include($path.'.php');
 				else
 					return false;


### PR DESCRIPTION
Calls to `class_exists` will, by default, call `__autoload`, which is actually handled by Yii's `autoload`. Anyways, in PHP 5.3 namespace classes, Yii will try to include a file that could not exist, and thus causing warnings like `include(): Failed opening <path> for inclusion`.

A simple check if the file exists before actually trying to include it seems like a good idea and is avoiding all those warnings.