### PR TITLE
Enh #3457: CHttpRequest able to decode JSON REST parameters.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ Version 1.1.17 work in progress
 - Bug #3715: 1.1.16 `CSecurityManager::legacyDecrypt` was not compatible with 1.1.15 method (DanaLuther)
 - Bug #3724: Fixed namespace prefix in WSDL generator for arrayType. (ametad)
 - Enh #2399: It is now possible to use table names containing spaces by introducing alias (devivan)
+- Enh #3457: CHttpRequest can now detect content type and decode JSON in REST method bodies. (Sibilino)
 - Enh #3686: Wrapper div of hidden fields in CForm now have style `display:none` instead of `visibility:hidden` to not affect the layout (cebe, alaabadran)
 - Enh #3738: It is now possible to override the value of 'required' html option in `CHtml::activeLabelEx()` (matteosistisette)
 

--- a/framework/web/CHttpRequest.php
+++ b/framework/web/CHttpRequest.php
@@ -293,7 +293,7 @@ class CHttpRequest extends CApplicationComponent
 		if($this->_restParams===null)
 		{
 			$result=array();
-			if ($this->getContentType() === 'application/json')
+			if (strncmp($this->getContentType(), 'application/json', 16) === 0)
 				$result = CJSON::decode($this->getRawBody(), $this->jsonAsArray);
 			elseif(function_exists('mb_parse_str'))
 				mb_parse_str($this->getRawBody(), $result);

--- a/framework/web/CHttpRequest.php
+++ b/framework/web/CHttpRequest.php
@@ -64,7 +64,7 @@
 class CHttpRequest extends CApplicationComponent
 {
 	/**
-	 * @var boolean whether parsing objects in the body of a JSON request should result in associative arrays.
+	 * @var boolean whether the parsing of JSON REST requests should return associative arrays for object data.
 	 * @see getRestParams
 	 * @since 1.1.17
 	 */


### PR DESCRIPTION
Enh #3457

Originally, REST requests such as PUT, PATCH and DELETE  had their body parsed using `mb_parse_str()` or `parse_str()`, which means that JSON data would not be properly parsed.

The merge is basically a backport of the solution existing in Yii 2. It will add `CJSON::decode()` to the possible parsing functions, activated only if the request's content type is `application/json`. This content type can be retrieved by the new public function `getContentType()`.

In addition, as in Yii 2, the JSON decoding function can be configured to use associative arrays (by default) for JSON object data, according to the new boolean property `$jsonAsArray`.