### PR TITLE
Wrong pager url in GridView when ajaxUrl attribute is set

### DIFF
--- a/framework/zii/widgets/CBaseListView.php
+++ b/framework/zii/widgets/CBaseListView.php
@@ -133,6 +133,9 @@ abstract class CBaseListView extends CWidget
 			$this->enableSorting=false;
 		if($this->enablePagination && $this->dataProvider->getPagination()===false)
 			$this->enablePagination=false;
+			
+		if($this->ajaxUrl!==null && $this->enablePagination)
+			$this->dataProvider->getPagination()->route = CHtml::normalizeUrl($this->ajaxUrl);
 	}
 
 	/**


### PR DESCRIPTION
Wrong pager url in GridView when ajaxUrl attribute is set
