### PR TITLE
Fixed CPgsqlColumnSchema.php to support resource type.

### DIFF
--- a/framework/validators/CEmailValidator.php
+++ b/framework/validators/CEmailValidator.php
@@ -78,7 +78,6 @@ class CEmailValidator extends CValidator
 
 	/**
 	 * Validates a static value to see if it is a valid email.
-	 * Note that this method does not respect {@link allowEmpty} property.
 	 * This method is provided so that you can call it directly without going through the model validation rule mechanism.
 	 * @param mixed $value the value to be validated
 	 * @return boolean whether the value is a valid email


### PR DESCRIPTION
Fixed CPgsqlColumnSchema.php to support resource type.

It is related to yiisoft#1181

When we load model with bytea column dbtype - Yii column type is "string" by default. (type of data is resource)
In this case when we trying to save this model after execution method \CDbColumnSchema::typecast value cast to string. And we have Resource #2 string in database.
