### PR TITLE
Fix for #3819

### DIFF
--- a/tests/framework/validators/CExistValidatorTest.php
+++ b/tests/framework/validators/CExistValidatorTest.php
@@ -34,8 +34,11 @@ class CExistValidatorTest extends CTestCase
 
 	protected function tearDown()
 	{
-		$this->_connection->createCommand()->dropTable($this->_tableName);
-		$this->_connection->active=false;
+		if($this->_connection instanceof CDbConnection)
+		{
+			$this->_connection->createCommand()->dropTable($this->_tableName);
+			$this->_connection->active=false;
+		}
 	}
 
 	/**

--- a/tests/framework/validators/CUniqueValidatorTest.php
+++ b/tests/framework/validators/CUniqueValidatorTest.php
@@ -34,8 +34,11 @@ class CUniqueValidatorTest extends CTestCase
 
 	protected function tearDown()
 	{
-		$this->_connection->createCommand()->dropTable($this->_tableName);
-		$this->_connection->active=false;
+		if($this->_connection instanceof CDbConnection)
+		{
+			$this->_connection->createCommand()->dropTable($this->_tableName);
+			$this->_connection->active=false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
I found how could be reproduced the error. If you do not have installed "php5-sqlite" extension and run the tests the error will rise, even in the code is placed check for existing php sqllite installation in the same class take a look at "setUp" method.

Bug fix applied:
Affected files: 
	tests/framework/validators/CExistValidatorTest.php
	tests/framework/validators/CUniqueValidatorTest.php
4a7127b..16410a6  master -> master

Fix for #3819