### PR TITLE
CRedisCache Socket Options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ Version 1.1.17 work in progress
 - Enh #3686: Wrapper div of hidden fields in CForm now have style `display:none` instead of `visibility:hidden` to not affect the layout (cebe, alaabadran)
 - Enh #3738: It is now possible to override the value of 'required' html option in `CHtml::activeLabelEx()` (matteosistisette)
 - Chg #3776: Autoloader now doesn't error in case of non-existing namespaced classes so other autoloaders have chance to handle these (alexandernst)
+- Enh #3827: Added the $options parameter to be used in stream_socket_client in CRedisCache.
 
 Version 1.1.16 December 21, 2014
 --------------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,8 +15,8 @@ Version 1.1.17 work in progress
 - Enh #2399: It is now possible to use table names containing spaces by introducing alias (devivan)
 - Enh #3686: Wrapper div of hidden fields in CForm now have style `display:none` instead of `visibility:hidden` to not affect the layout (cebe, alaabadran)
 - Enh #3738: It is now possible to override the value of 'required' html option in `CHtml::activeLabelEx()` (matteosistisette)
-- Chg #3776: Autoloader now doesn't error in case of non-existing namespaced classes so other autoloaders have chance to handle these (alexandernst)
 - Enh #3827: Added the $options parameter to be used in stream_socket_client in CRedisCache.
+- Chg #3776: Autoloader now doesn't error in case of non-existing namespaced classes so other autoloaders have chance to handle these (alexandernst)
 
 Version 1.1.16 December 21, 2014
 --------------------------------

--- a/framework/caching/CRedisCache.php
+++ b/framework/caching/CRedisCache.php
@@ -60,6 +60,10 @@ class CRedisCache extends CCache
 	 */
 	public $database=0;
 	/**
+	 * @var int the options to use for stream_socket_client options to the redis server. Defaults to STREAM_CLIENT_CONNECT.
+	 */
+	public $options=STREAM_CLIENT_CONNECT;
+	/**
 	 * @var float timeout to use for connection to redis. If not set the timeout set in php.ini will be used: ini_get("default_socket_timeout")
 	 */
 	public $timeout=null;
@@ -79,7 +83,8 @@ class CRedisCache extends CCache
 			$this->hostname.':'.$this->port,
 			$errorNumber,
 			$errorDescription,
-			$this->timeout ? $this->timeout : ini_get("default_socket_timeout")
+			$this->timeout ? $this->timeout : ini_get("default_socket_timeout"),
+			$options
 		);
 		if ($this->_socket)
 		{

--- a/framework/caching/CRedisCache.php
+++ b/framework/caching/CRedisCache.php
@@ -84,7 +84,7 @@ class CRedisCache extends CCache
 			$errorNumber,
 			$errorDescription,
 			$this->timeout ? $this->timeout : ini_get("default_socket_timeout"),
-			$options
+			$this->options
 		);
 		if ($this->_socket)
 		{

--- a/framework/caching/CRedisCache.php
+++ b/framework/caching/CRedisCache.php
@@ -30,6 +30,7 @@
  *             'hostname'=>'localhost',
  *             'port'=>6379,
  *             'database'=>0,
+ *             'options'=>STREAM_CLIENT_CONNECT,
  *         ),
  *     ),
  * )


### PR DESCRIPTION
When you connect to every access to the Redis server application is slow.
Therefore I think it is often used STREAM_CLIENT_PERSISTENT option.