### PR TITLE
Fix #3846: Fetch as CDbDataReader for cases expecting arrays

### DIFF
--- a/framework/db/CDbCommand.php
+++ b/framework/db/CDbCommand.php
@@ -509,14 +509,18 @@ class CDbCommand extends CComponent
 			else
 				$this->_statement->execute($params);
 
-			if($method==='')
-				$result=new CDbDataReader($this);
-			else
-			{
+			if (in_array($method,['fetchColumn','fetch'])) {
 				$mode=(array)$mode;
 				call_user_func_array(array($this->_statement, 'setFetchMode'), $mode);
 				$result=$this->_statement->$method();
 				$this->_statement->closeCursor();
+			}
+			else {
+				$result = new CDbDataReader($this);
+				if (!empty($mode)) {
+					// $mode could be an array - so can't use just $result->setFetchMode($mode).
+					call_user_func_array([$result,'setFetchMode'],(array)$mode);
+				}
 			}
 
 			if($this->_connection->enableProfiling)

--- a/framework/web/CController.php
+++ b/framework/web/CController.php
@@ -390,9 +390,10 @@ class CController extends CBaseController
 	protected function replaceDynamicOutput($matches)
 	{
 		$content=$matches[0];
-		if(isset($this->_dynamicOutput[$matches[1]]))
+		if(isset($this->_dynamicOutput[$matches[1]]) && is_array($this->_dynamicOutput[$matches[1]]))
 		{
-			$content=$this->_dynamicOutput[$matches[1]];
+			list($callback, $parameters) = $this->_dynamicOutput[$matches[1]];
+			$content=call_user_func_array($callback,$parameters);
 			$this->_dynamicOutput[$matches[1]]=null;
 		}
 		return $content;
@@ -940,7 +941,7 @@ class CController extends CBaseController
 		$this->recordCachingAction('','renderDynamicInternal',array($callback,$params));
 		if(is_string($callback) && method_exists($this,$callback))
 			$callback=array($this,$callback);
-		$this->_dynamicOutput[]=call_user_func_array($callback,$params);
+		$this->_dynamicOutput[]=array($callback,$params);
 	}
 
 	/**


### PR DESCRIPTION
Otherwise it causes fatal error of memory exhausting for big queries as it deals with arrays of incredible size.
Fix #3846.

PS Sorry for alien commit, it is from another pull-request https://github.com/yiisoft/yii/pull/3788 .