### PR TITLE
Enhancement for #3549

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 Version 1.1.17 work in progress
 -------------------------------
 
+- Enh #3549: Prevent text filters from being triggered on change event. Only trigger when using ENTER key (georaldc)
 - Bug #2881: CGridView was blocking refresh on filter field change event after previous filtering using ENTER key (sivir)
 - Bug #2921: Fixed CStatePersister read/write concurrency issue causing state data corruption (matteosistisette, samdark)
 - Bug #3497: CErrorHandler messages for HTTP response codes were not matching RFCs (TeMPOraL)

--- a/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
+++ b/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
@@ -110,6 +110,8 @@
 				}
 
 				$(document).on('change.yiiGridView keydown.yiiGridView', settings.filterSelector, function (event) {
+					var $this = $(this);
+
 					if (event.type === 'keydown') {
 						if (event.keyCode !== 13) {
 							return; // only react to enter key
@@ -118,8 +120,8 @@
 							eventTarget = event.target;
 						}
 					} else {
-						// prevent processing for both keydown and change events on the same element
-						if (eventType === 'keydown' && eventTarget === event.target) {
+						// prevent processing for both keydown and change events on the same element. Also prevent change event processing only on text elements
+						if ((eventType === 'keydown' && eventTarget === event.target) || (event.type === 'change' && $this.is('input[type=text]'))) {
 							eventType = '';
 							eventTarget = null;
 							return;


### PR DESCRIPTION
- Prevent text element filters from being triggered on change event. Text
  filters will only fire on ENTER keypress. Other elements like Select
  dropdowns' functionality should stay unaffected.

This should stop tab keypresses in cgridview from triggering filters
