### PR TITLE
when use the reverse proxy ,the app will still get the real client ip.

### DIFF
--- a/framework/web/CHttpRequest.php
+++ b/framework/web/CHttpRequest.php
@@ -712,8 +712,15 @@ class CHttpRequest extends CApplicationComponent
 	 * Returns the user agent, null if not present.
 	 * @return string user agent, null if not present
 	 */
-	public function getUserAgent()
+	static function getUserHostAddress($proxy_set_header ='HTTP_X_FORWARDED_FOR')
 	{
+		if(isset($_SERVER[$proxy_set_header])){
+			$ip = $_SERVER[$proxy_set_header];
+			$pos = strpos($ip,',');
+			if($pos===false)
+				return $ip;
+			return substr($ip,0,$pos);
+		}
 		return isset($_SERVER['HTTP_USER_AGENT'])?$_SERVER['HTTP_USER_AGENT']:null;
 	}
 


### PR DESCRIPTION
Fix #3864.when use the reverse proxy ,the app will still get the real client ip. Default  http header key  would  be  x-forwarded-for
