### PR TITLE
Bug fix in jQuery Yii GridView plugin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ Version 1.1.17 work in progress
 - Enh #3738: It is now possible to override the value of 'required' html option in `CHtml::activeLabelEx()` (matteosistisette)
 - Enh #3827: Added the $options parameter to be used in stream_socket_client in CRedisCache.
 - Chg #3776: Autoloader now doesn't error in case of non-existing namespaced classes so other autoloaders have chance to handle these (alexandernst)
+- Bug #3869: jQuery Yii GridView now doesn't fail when refreshing grid via POST request (a-t)
 
 Version 1.1.16 December 21, 2014
 --------------------------------

--- a/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
+++ b/framework/zii/widgets/assets/gridview/jquery.yiigridview.js
@@ -327,7 +327,10 @@
 					}
 				} else {
 					if (options.data === undefined) {
-						options.data = $(settings.filterSelector).serialize();
+						options.data = {};
+						$.each($(settings.filterSelector).serializeArray(), function () {
+							options.data[this.name] = this.value;
+						});
 					}
 				}
 				if (settings.csrfTokenName && settings.csrfToken) {


### PR DESCRIPTION
When updating grid with a POST request, and the request data is not provided and thus is collected from form with the jQuery `.serialize()` method, the script fails at [this line](https://github.com/yiisoft/yii/blob/8c30239dce366a70bc7486cd605c00c4938f0c9e/framework/zii/widgets/assets/gridview/jquery.yiigridview.js#L366) because `options.data` is a string at this point and can't act as an argument for `$.each()`. This fix makes `options.data` a plain object instead of a string in the described circumstances.