### PR TITLE
Postgres - ignore composite foreign keys. 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
 
 Version 1.1.17 work in progress
 -------------------------------
-
+- Bug #3438: Postgres - ignore composite foreign keys. Wrong behaviour for multiple constraints for the same field (baso10)
 - Bug #2881: CGridView was blocking refresh on filter field change event after previous filtering using ENTER key (sivir)
 - Bug #2921: Fixed CStatePersister read/write concurrency issue causing state data corruption (matteosistisette, samdark)
 - Bug #3144: Fixed regression introduced in 1.1.16, whitespace before and after attributes in validation rules where not ignored (cebe)

--- a/framework/db/schema/pgsql/CPgsqlSchema.php
+++ b/framework/db/schema/pgsql/CPgsqlSchema.php
@@ -327,6 +327,9 @@ EOD;
 		if(preg_match($pattern,str_replace('"','',$src),$matches))
 		{
 			$keys=preg_split('/,\s+/', $matches[1]);
+			//ignore composite foreign keys https://github.com/yiisoft/yii/issues/3438
+			if (count($keys) !== 1) return;
+
 			$tableName=$matches[2];
 			$fkeys=preg_split('/,\s+/', $matches[3]);
 			foreach($keys as $i=>$key)


### PR DESCRIPTION
Fix for #3438
foreignKeys property should not contain invalid records.
