### PR TITLE
#3890 - Always use `php://input` since HTTP_RAW_POST_DATA is deprecated

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@ Version 1.1.17 work in progress
 - Enh #3738: It is now possible to override the value of 'required' html option in `CHtml::activeLabelEx()` (matteosistisette)
 - Enh #3827: Added the $options parameter to be used in stream_socket_client in CRedisCache.
 - Chg #3776: Autoloader now doesn't error in case of non-existing namespaced classes so other autoloaders have chance to handle these (alexandernst)
+- Chg #3890: Always use `php://input` since HTTP_RAW_POST_DATA is deprecated in PHP 5.6 and causes a warning
 
 Version 1.1.16 December 21, 2014
 --------------------------------

--- a/framework/web/services/CWebService.php
+++ b/framework/web/services/CWebService.php
@@ -236,10 +236,7 @@ class CWebService extends CComponent
 	{
 		if($this->_method===null)
 		{
-			if(isset($HTTP_RAW_POST_DATA))
-				$request=$HTTP_RAW_POST_DATA;
-			else
-				$request=file_get_contents('php://input');
+			$request=file_get_contents('php://input');
 			if(preg_match('/<.*?:Body[^>]*>\s*<.*?:(\w+)/mi',$request,$matches))
 				$this->_method=$matches[1];
 			else

--- a/framework/web/services/CWebService.php
+++ b/framework/web/services/CWebService.php
@@ -236,7 +236,10 @@ class CWebService extends CComponent
 	{
 		if($this->_method===null)
 		{
-			$request=file_get_contents('php://input');
+			if (version_compare(phpversion(),'5.6.0','<') && isset($HTTP_RAW_POST_DATA))
+				$request=$HTTP_RAW_POST_DATA;
+			else
+				$request=file_get_contents('php://input');
 			if(preg_match('/<.*?:Body[^>]*>\s*<.*?:(\w+)/mi',$request,$matches))
 				$this->_method=$matches[1];
 			else
@@ -346,7 +349,7 @@ class CDocumentSoapObjectWrapper
 		{
 			$result = call_user_func_array(array($this->object, $name), $arguments);
 		}
-		return $result === null ? $result : array($name . 'Result' => $result); 
+		return $result === null ? $result : array($name . 'Result' => $result);
 	}
 }
 


### PR DESCRIPTION
HTTP_RAW_POST_DATA is deprecated in since of PHP 5.6.0 and causes a warning