### PR TITLE
CActiveRecord::model() defaults to called class

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -375,19 +375,16 @@ abstract class CActiveRecord extends CModel
 	 * The model returned is a static instance of the AR class.
 	 * It is provided for invoking class-level methods (something similar to static class methods.)
 	 *
-	 * EVERY derived AR class must override this method as follows,
-	 * <pre>
-	 * public static function model($className=__CLASS__)
-	 * {
-	 *     return parent::model($className);
-	 * }
-	 * </pre>
+	 * No derived class needs to override this method in order to use it.
 	 *
 	 * @param string $className active record class name.
 	 * @return static active record model instance.
 	 */
-	public static function model($className=__CLASS__)
+	public static function model($className=NULL)
 	{
+		if($className === NULL) {
+			$className = get_called_class(); // Late static binding
+		}
 		if(isset(self::$_models[$className]))
 			return self::$_models[$className];
 		else


### PR DESCRIPTION
*Purpose*
The `CActiveRecord::model()` method uses `__CLASS__` magical constant as a default fallback for class name. It must not use it as this constant is early static binding, hence it will always return *CActiveRecord*. Instead, the class must use PHP `get_called_class()` (PHP 5 >= 5.3) to get late static binding class name. So that every class that implements `CActiveRecord` doesn't have to override `model()` method.

*Changes*
- `CActiveRecord::model()` signature changed; `__CLASS__` replaced with `NULL`
- If `$className` is `NULL`, it will fall back to the name of the calling class