### PR TITLE
CActiveRecord::model() defaults to called class

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -388,6 +388,9 @@ abstract class CActiveRecord extends CModel
 	 */
 	public static function model($className=__CLASS__)
 	{
+                if($className===__CLASS__ && function_exists('get_called_class')){
+                    $className = get_called_class();
+                }
 		if(isset(self::$_models[$className]))
 			return self::$_models[$className];
 		else


### PR DESCRIPTION
*Purpose*
The `CActiveRecord::model()` method uses `__CLASS__` magical constant as a default fallback for class name. It must not use it as this constant is early static binding, hence it will always return *CActiveRecord*. Instead, the class must use PHP `get_called_class()` (PHP 5 >= 5.3) to get late static binding class name. So that every class that implements `CActiveRecord` doesn't have to override `model()` method.

*Changes*
- `CActiveRecord::model()` signature changed; `__CLASS__` replaced with `NULL`
- If `$className` is `NULL`, it will fall back to the name of the calling class
- Backward compatible with PHP 5<5.3