### PR TITLE
extractType modification

### DIFF
--- a/framework/db/schema/mysql/CMysqlColumnSchema.php
+++ b/framework/db/schema/mysql/CMysqlColumnSchema.php
@@ -29,7 +29,7 @@ class CMysqlColumnSchema extends CDbColumnSchema
 			$this->type='double';
 		elseif(strpos($dbType,'bool')!==false)
 			$this->type='boolean';
-		elseif(strpos($dbType,'int')===0 && strpos($dbType,'unsigned')===false || preg_match('/(bit|tinyint|smallint|mediumint)/',$dbType))
+		elseif(strpos($dbType,'bigint')===0 && strpos($dbType,'unsigned')===false || preg_match('/(bit|tinyint|smallint|mediumint|int)/',$dbType))
 			$this->type='integer';
 		else
 			$this->type='string';


### PR DESCRIPTION
Several slow queries dump problems working with unsigned int values. They become strings.
PHP_INT_MAX 9223372036854775807 (2^63-1) amd64
MySQL UNSIGNED INT 4294967295
MySQL BIGINT +/- 9223372036854775807
MySQL UNSIGNED BIGINT 18446744073709551615