### PR TITLE
fix error with array_diff when one of criteria->select contains "false"

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -2022,8 +2022,10 @@ class CBaseActiveRelation extends CComponent
 			$criteria=$criteria->toArray();
 		if(isset($criteria['select']) && $this->select!==$criteria['select'])
 		{
-			if($this->select==='*')
+			if($this->select==='*'||$this->select===false)
 				$this->select=$criteria['select'];
+			elseif($criteria['select']===false)
+				$this->select=false;
 			elseif($criteria['select']!=='*')
 			{
 				$select1=is_string($this->select)?preg_split('/\s*,\s*/',trim($this->select),-1,PREG_SPLIT_NO_EMPTY):$this->select;


### PR DESCRIPTION
Hello!
I made little patch to fix this error
`2015/09/21 14:55:26 [error] [php] array_diff(): Argument #1 is not an array (/vendor/yiisoft/yii/framework/db/ar/CActiveRecord.php:2031)`

To reproduce error you have to do following steps:
* add into you model a relation with `select` value differences from `'*'`
  ```php
  // Post.php
class Post extends CActiveRecord
{
	...
	public function relations()
	{
		return [
			'author' => [
				self::BELONGS_TO,
				'Author',
				'author_id',
				'select' => ['id', 'name']
			],
		];
	}
	...
}
```

* try to use this relation for example to filter main model without getting related models
  ```php
// Post.php
public function filterByAuthor($author_id)
{
	$this->getDbCriteria()->mergeWith([
		'with' => [
			'author' => [
				'select' => false,
				'joinType' => 'INNER JOIN',
				'together' => true,
				'condition' => "author.id = $author_id"
			],
		],
	]);

        return $this;
}
```
Patch resolves the situation in favor of the latter added criteria.
