### PR TITLE
CConsoleCommand: control `copyFiles' interactivity

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@ Version 1.1.17 work in progress
 - Enh #3686: Wrapper div of hidden fields in CForm now have style `display:none` instead of `visibility:hidden` to not affect the layout (cebe, alaabadran)
 - Enh #3738: It is now possible to override the value of 'required' html option in `CHtml::activeLabelEx()` (matteosistisette)
 - Enh #3827: Added the $options parameter to be used in stream_socket_client in CRedisCache.
+- Enh #3949: Added `$overwriteAll` argument to `CConsoleCommand::copyFiles()` which can be set to true in noninteractive commands.
 - Chg #3776: Autoloader now doesn't error in case of non-existing namespaced classes so other autoloaders have chance to handle these (alexandernst)
 
 Version 1.1.16 December 21, 2014

--- a/framework/console/CConsoleCommand.php
+++ b/framework/console/CConsoleCommand.php
@@ -355,11 +355,11 @@ abstract class CConsoleCommand extends CComponent
 	 *   by the function will be saved into the target file.</li>
 	 * <li>params: optional, the parameters to be passed to the callback</li>
 	 * </ul>
+	 * @param boolean $overwriteAll whether to overwrite all files.
 	 * @see buildFileList
 	 */
-	public function copyFiles($fileList)
+	public function copyFiles($fileList,$overwriteAll=false)
 	{
-		$overwriteAll=false;
 		foreach($fileList as $name=>$file)
 		{
 			$source=strtr($file['source'],'/\\',DIRECTORY_SEPARATOR.DIRECTORY_SEPARATOR);


### PR DESCRIPTION
Add `overwriteAll` argument to `copyFiles` method which can be set to true in noninteractive commands.