### PR TITLE
Fix ignoring timezone in CFormatter::date with DateTimes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@ Version 1.1.17 work in progress
 - Enh #3948: Enhanced CHttpRequest path info extraction for compatibility with PHP 7 (dmitrivereshchagin)
 - Enh #3949: Added `$overwriteAll` argument to `CConsoleCommand::copyFiles()` which can be set to true in noninteractive commands (dmitrivereshchagin)
 - Chg #3776: Autoloader now doesn't error in case of non-existing namespaced classes so other autoloaders have chance to handle these (alexandernst)
+- Bug #?: CFormatter::normalizeDateValue now deals correctly with DateTime timezones when getting it's timestamp
 
 Version 1.1.16 December 21, 2014
 --------------------------------

--- a/framework/utils/CFormatter.php
+++ b/framework/utils/CFormatter.php
@@ -235,7 +235,7 @@ class CFormatter extends CApplicationComponent
 				return strtotime($time);
 		}
 		elseif (class_exists('DateTime', false) && $time instanceof DateTime)
-			return $time->getTimestamp();
+			return $time->getTimestamp() + $time->getOffset();
 		else
 			return (int)$time;
 	}


### PR DESCRIPTION
Yii 1.1.16 introduced the ability to pass DateTime objects to CFormatter.

The problem is that `DateTime::getTimestamp()` ignores completely timezones, as it can be seen in the following code:

```php
$a = new DateTime('now', new DateTimeZone('UTC'));
$b = new DateTime('now', new DateTimeZone('America/Los_Angeles'));

if ($a->getTimestamp() === $b->getTimestamp()) {
    echo 'This line is printed' . PHP_EOL;
} else {
    echo 'This line isn't printed' . PHP_EOL;
}
```

using `DateTime::getTimestamp() + DateTime::getOffset()` solves the problem.

PD: I haven't found any test that currently evaluates this function, so adding a test case wasn't as easy as expected. Because of this, i provide this fix without any test. And being such an small fix, I haven't opened an issue.