### PR TITLE
Overriding applyJoin() to comply with the DELETE command syntax.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ Version 1.1.17 work in progress
 - Bug #3869: jQuery Yii GridView now doesn't fail when refreshing grid via POST request (a-t)
 - Bug #3879: Numeric labels in CBreadCrumbs reindex after using array_merge (AloneCoder)
 - Bug #3947: Fix error with `array_diff` when one of CDbCriteria->select contains "false" (askobara, cebe)
+- Bug #3976: Overriding applyJoin() to comply with the DELETE command syntax. (odalecne)
 - Enh #2399: It is now possible to use table names containing spaces by introducing alias (devivan)
 - Enh #3686: Wrapper div of hidden fields in CForm now have style `display:none` instead of `visibility:hidden` to not affect the layout (cebe, alaabadran)
 - Enh #3738: It is now possible to override the value of 'required' html option in `CHtml::activeLabelEx()` (matteosistisette)

--- a/framework/db/schema/mssql/CMssqlCommandBuilder.php
+++ b/framework/db/schema/mssql/CMssqlCommandBuilder.php
@@ -142,7 +142,7 @@ class CMssqlCommandBuilder extends CDbCommandBuilder
 	 */
 	public function applyJoin($sql,$join)
 	{
-		if(trim($join)!='')
+		if(trim($join)!=='')
 			$sql=preg_replace('/^\s*DELETE\s+FROM\s+((\[.+\])|([^\s]+))\s*/i',"DELETE \\1 FROM \\1",$sql);
 		return parent::applyJoin($sql,$join);
 	}

--- a/framework/db/schema/mssql/CMssqlCommandBuilder.php
+++ b/framework/db/schema/mssql/CMssqlCommandBuilder.php
@@ -134,6 +134,20 @@ class CMssqlCommandBuilder extends CDbCommandBuilder
 	}
 
 	/**
+	 * Alters the SQL to apply JOIN clause.
+	 * Overrides parent implementation to comply with the DELETE command syntax required when multiple tables are referenced.
+	 * @param string $sql the SQL statement to be altered
+	 * @param string $join the JOIN clause (starting with join type, such as INNER JOIN)
+	 * @return string the altered SQL statement
+	 */
+	public function applyJoin($sql,$join)
+	{
+		if(trim($join)!='')
+			$sql=preg_replace('/^\s*DELETE\s+FROM\s+((\[.+\])|([^\s]+))\s*/i',"DELETE \\1 FROM \\1",$sql);
+		return parent::applyJoin($sql,$join);
+	}
+
+	/**
 	 * This is a port from Prado Framework.
 	 *
 	 * Overrides parent implementation. Alters the sql to apply $limit and $offset.


### PR DESCRIPTION
In SQL Server, when multiple tables are joined in a DELETE statement, the FROM clause in which JOIN clauses are declared must be preceded by an additional FROM clause (whose keyword is optional and usually omitted for readability and consistency) that specifies the target table name.
See syntax and examples at https://msdn.microsoft.com/en-us/library/ms189835.aspx.