### PR TITLE
Fix Redis cache with mb_strlen

### DIFF
--- a/framework/caching/CRedisCache.php
+++ b/framework/caching/CRedisCache.php
@@ -125,7 +125,7 @@ class CRedisCache extends CCache
 		array_unshift($params,$name);
 		$command='*'.count($params)."\r\n";
 		foreach($params as $arg)
-			$command.='$'.strlen($arg)."\r\n".$arg."\r\n";
+			$command.='$'.$this->lenBytes($arg)."\r\n".$arg."\r\n";
 
 		fwrite($this->_socket,$command);
 
@@ -162,7 +162,7 @@ class CRedisCache extends CCache
 					if(($block=fread($this->_socket,$length))===false)
 						throw new CException('Failed reading data from redis connection socket.');
 					$data.=$block;
-					$length-=(function_exists('mb_strlen') ? mb_strlen($block,'8bit') : strlen($block));
+					$length-=$this->lenBytes($block);
 				}
 				return substr($data,0,-2);
 			case '*': // Multi-bulk replies
@@ -174,6 +174,17 @@ class CRedisCache extends CCache
 			default:
 				throw new CException('Unable to parse data received from redis.');
 		}
+	}
+
+	/**
+	 * Counting amount of bytes in a string.
+	 *
+	 * @param string $str
+	 * @return int
+	 */
+	private function lenBytes($str)
+	{
+		return function_exists('mb_strlen') ? mb_strlen($str, '8bit') : strlen($str);
 	}
 
 	/**


### PR DESCRIPTION
If you use a setting ..
```ini
mbstring.internal_encoding = UTF-8
mbstring.func_overload = 7
```
.. you can see the error ..
```
Redis error: ERR Protocol error: unbalanced quotes in request
```
in CRedisCache.php : 151
```php
case '-': // Error reply
    throw new CException('Redis error: '.$line);
```
The patch corrects the calculation of the lengths of strings.