### PR TITLE
CDbHttpSession Null Data for Regeneration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 Version 1.1.17 work in progress
 -------------------------------
 
+- Bug #3616: Fixed `CDbHttpSession` SQL Server exception when regenerating non-existent session by storing NULL instead of an empty string.
 - Bug #2881: CGridView was blocking refresh on filter field change event after previous filtering using ENTER key (sivir)
 - Bug #2921: Fixed CStatePersister read/write concurrency issue causing state data corruption (matteosistisette, samdark)
 - Bug #2993: Fixed Mysql datetime fields can have default CURRENT_TIMESTAMP (tomvdp)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,13 +4,13 @@
 Version 1.1.17 work in progress
 -------------------------------
 
-- Bug #3616: Fixed `CDbHttpSession` SQL Server exception when regenerating non-existent session by storing NULL instead of an empty string.
 - Bug #2881: CGridView was blocking refresh on filter field change event after previous filtering using ENTER key (sivir)
 - Bug #2921: Fixed CStatePersister read/write concurrency issue causing state data corruption (matteosistisette, samdark)
 - Bug #2993: Fixed Mysql datetime fields can have default CURRENT_TIMESTAMP (tomvdp)
 - Bug #3144: Fixed regression introduced in 1.1.16, whitespace before and after attributes in validation rules where not ignored (cebe)
 - Bug #3497: CErrorHandler messages for HTTP response codes were not matching RFCs (TeMPOraL)
 - Bug #3637: Fixed not quoting primary key in count statements (applee)
+- Bug #3616: Fixed `CDbHttpSession` SQL Server exception when regenerating non-existent session by storing NULL instead of an empty string.
 - Bug #3696: Fixed broken case insensitiveness for Active Record count expressions introduced with fixed #268 (xt99)
 - Bug #3700: Undefined variable `$acceptedLanguage` in `CHttpRequest::getPreferredLanguage()` (cebe,ddebin)
 - Bug #3704: Fixed `CSecurityManager` to work properly is case `cryptAlgorithm` specified as array (samdark)

--- a/framework/web/CDbHttpSession.php
+++ b/framework/web/CDbHttpSession.php
@@ -126,7 +126,7 @@ class CDbHttpSession extends CHttpSession
 			$db->createCommand()->insert($this->sessionTableName, array(
 				'id'=>$newID,
 				'expire'=>time()+$this->getTimeout(),
-				'data'=>'',
+				'data'=>NULL,
 			));
 		}
 	}


### PR DESCRIPTION
Bug #3616: Fixed `CDbHttpSession` SQL Server exception when regenerating non-existent session by storing NULL instead of an empty string.
