### PR TITLE
Fixes the requires paths

### DIFF
--- a/framework/gii/components/Pear/Text/Diff/Renderer/inline.php
+++ b/framework/gii/components/Pear/Text/Diff/Renderer/inline.php
@@ -14,7 +14,7 @@
  */
 
 /** Text_Diff_Renderer */
-require_once 'Text/Diff/Renderer.php';
+require_once '../Renderer.php';
 
 /**
  * "Inline" diff renderer.

--- a/framework/gii/components/Pear/Text/Diff/Renderer/unified.php
+++ b/framework/gii/components/Pear/Text/Diff/Renderer/unified.php
@@ -16,7 +16,7 @@
  */
 
 /** Text_Diff_Renderer */
-require_once 'Text/Diff/Renderer.php';
+require_once '../Renderer.php';
 
 /**
  * @package Text_Diff

--- a/framework/gii/components/Pear/Text/Diff/ThreeWay.php
+++ b/framework/gii/components/Pear/Text/Diff/ThreeWay.php
@@ -14,7 +14,7 @@
  */
 
 /** Text_Diff */
-require_once 'Text/Diff.php';
+require_once '../Diff.php';
 
 /**
  * A class for computing three way diffs.

--- a/framework/gii/components/TextDiff.php
+++ b/framework/gii/components/TextDiff.php
@@ -3,9 +3,9 @@
 error_reporting(E_ALL);
 
 Yii::import('gii.components.Pear.*');
-require_once 'Text/Diff.php';
-require_once 'Text/Diff/Renderer.php';
-require_once 'Text/Diff/Renderer/inline.php';
+require_once 'Pear/Text/Diff.php';
+require_once 'Pear/Text/Diff/Renderer.php';
+require_once 'Pear/Text/Diff/Renderer/inline.php';
 
 class TextDiff extends CComponent
 {


### PR DESCRIPTION
Hello,

When I use HHVM and pre-compiling will get the following warns:

`Unable to stat file /yii/framework/gii/components/Pear/Text/Diff/Renderer/Text/Diff/Renderer.php`

`Unable to stat file /yii/framework/gii/components/Pear/Text/Diff/Text/Diff.php`

`Unable to stat file /yii/framework/gii/components/Text/Diff.php`

`Unable to stat file /yii/framework/gii/components/Text/Diff/Renderer.php`

`Unable to stat file /yii/framework/gii/components/Text/Diff/Renderer/inline.php`

And I resolved with this commit.

