### PR TITLE
Remove base path from getId

### DIFF
--- a/framework/yiilite.php
+++ b/framework/yiilite.php
@@ -1227,7 +1227,7 @@ abstract class CApplication extends CModule
 		if($this->_id!==null)
 			return $this->_id;
 		else
-			return $this->_id=sprintf('%x',crc32($this->getBasePath().$this->name));
+			return $this->_id=sprintf('%x',crc32($this->name));
 	}
 	public function setId($id)
 	{


### PR DESCRIPTION
My production setup uses a new directory per deployment and then creates a symlink back to the webroot.

The problem I'm having is this method is used to create the session key. When I deploy, the realpath actually changes which causes the app to generate a new session key which results in my users getting logged due to lost of previous session.
