### PR TITLE
Fix #3476: Database sessions with Postgres did not work properly

### DIFF
--- a/framework/db/CDbConnection.php
+++ b/framework/db/CDbConnection.php
@@ -583,6 +583,25 @@ class CDbConnection extends CApplicationComponent
 	}
 
 	/**
+	 * Quotes a string value for use in a query.
+	 * @param string $str string to be quoted
+	 * @param integer $quoteParam Parameter for PDO::quote function.
+	 * @return string the properly quoted string
+	 * @see http://www.php.net/manual/en/function.PDO-quote.php
+	 */
+	public function quoteValueExtended($str, $quoteParam)
+	{
+		if(is_int($str) || is_float($str))
+			return $str;
+
+		$this->setActive(true);
+		if(($value=$this->_pdo->quote($str, $quoteParam))!==false)
+			return $value;
+		else  // the driver doesn't support quote (e.g. oci)
+			return "'" . addcslashes(str_replace("'", "''", $str), "\000\n\r\\\032") . "'";
+	}
+
+	/**
 	 * Quotes a table name for use in a query.
 	 * If the table name contains schema prefix, the prefix will also be properly quoted.
 	 * @param string $name table name

--- a/framework/web/CDbHttpSession.php
+++ b/framework/web/CDbHttpSession.php
@@ -247,7 +247,7 @@ class CDbHttpSession extends CHttpSession
 			$expire=time()+$this->getTimeout();
 			$db=$this->getDbConnection();
 			if($db->getDriverName()=='pgsql')
-				$data=new CDbExpression("convert_to(".$db->quoteValue($data).", 'UTF8')");
+				$data=new CDbExpression($db->quoteValueExtended($data, PDO::PARAM_LOB)."::bytea");
 			if($db->getDriverName()=='sqlsrv' || $db->getDriverName()=='mssql' || $db->getDriverName()=='dblib')
 				$data=new CDbExpression('CONVERT(VARBINARY(MAX), '.$db->quoteValue($data).')');
 			if($db->createCommand()->select('id')->from($this->sessionTableName)->where('id=:id',array(':id'=>$id))->queryScalar()===false)


### PR DESCRIPTION
In the case when the session contains a class, the fix from https://github.com/yiisoft/yii/commit/74934b0a5856af5052b8127920622c9826862a26 doesn't work because $db->quoteValue truncate the value. 
PDO::quote for postgresql calls the function PQescapeStringConn which stops to parse the string at the first \0 (EOL) and PHP uses the char \0 as a mark to serialize class. (http://www.postgresql.org/docs/9.4/interactive/libpq-exec.html)

My fix calls PDO::quote with the parameter PDO::PARAM_LOB which calls PQescapeByteaConn instead of PQescapeStringConn and so convert_to is useless.
#3476
