### PR TITLE
Use both baseUrl and basePath in loading scripts

### DIFF
--- a/framework/web/CClientScript.php
+++ b/framework/web/CClientScript.php
@@ -541,6 +541,8 @@ class CClientScript extends CApplicationComponent
 			if($baseUrl==='' || $baseUrl[0]!=='/' && strpos($baseUrl,'://')===false)
 				$baseUrl=Yii::app()->getRequest()->getBaseUrl().'/'.$baseUrl;
 			$baseUrl=rtrim($baseUrl,'/');
+			if(isset($package['basePath']))
+				$baseUrl=$baseUrl.Yii::app()->getAssetManager()->publish(Yii::getPathOfAlias($package['basePath']));
 		}
 		elseif(isset($package['basePath']))
 			$baseUrl=Yii::app()->getAssetManager()->publish(Yii::getPathOfAlias($package['basePath']));


### PR DESCRIPTION
I'm not sure if you are interested in this, but I've found it useful when I had to add a client script in my own CDN pointing inside the assets folder.

I know that Yii1 is closed for enhancements, but I thought this was a very small change that might benefit someone else :)