### PR TITLE
#4020 fixes bug in CCacheHttpSession when destroying not cached sessions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Version 1.1.18 under development
 --------------------------------
 
 - Bug #4015: Fixed bug with missing "disabled" attribute in internally rendered hidden fields (rob006)
+- Bug #4020: Fixed PHP 7 related bug in CCacheHttpSession when destroying not cached sessions (dirx)
 
 Version 1.1.17 January 13, 2016
 ------------------------------

--- a/framework/web/CCacheHttpSession.php
+++ b/framework/web/CCacheHttpSession.php
@@ -49,7 +49,7 @@ class CCacheHttpSession extends CHttpSession
 	public function init()
 	{
 		$this->_cache=Yii::app()->getComponent($this->cacheID);
-		if(!($this->_cache instanceof ICache))
+		if (!($this->_cache instanceof ICache))
 			throw new CException(Yii::t('yii','CCacheHttpSession.cacheID is invalid. Please make sure "{id}" refers to a valid cache application component.',
 				array('{id}'=>$this->cacheID)));
 		parent::init();
@@ -92,12 +92,18 @@ class CCacheHttpSession extends CHttpSession
 	/**
 	 * Session destroy handler.
 	 * Do not call this method directly.
+	 *
+	 * Since 1.1.18 release, this method always returns true.
+	 * Please refer to the following issue for more details:
+	 * {@link https://github.com/yiisoft/yii/issues/4020}
+	 *
 	 * @param string $id session ID
-	 * @return boolean whether session is destroyed successfully
+	 * @return boolean true if no error happens during deletion
 	 */
 	public function destroySession($id)
 	{
-		return $this->_cache->delete($this->calculateKey($id));
+		$this->_cache->delete($this->calculateKey($id));
+		return true;
 	}
 
 	/**

--- a/tests/framework/web/CCacheHttpSessionTest.php
+++ b/tests/framework/web/CCacheHttpSessionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+
+class CCacheHttpSessionTest extends CTestCase
+{
+	/**
+	 * @covers CCacheHttpSession::writeSession
+	 * @covers CCacheHttpSession::readSession
+	 * @covers CCacheHttpSession::destroySession
+	 */
+	public function testCustomSessionHandler()
+	{
+		$config = array(
+			'components' => array(
+				'cache' => array(
+					'class' => 'CFileCache',
+				),
+			),
+		);
+		new TestApplication($config);
+
+		$test = @unlink('/tmp/notavail');
+
+		$session = new CCacheHttpSession();
+		$session->init();
+
+		$this->assertTrue($session->destroySession('test'));
+		$this->assertEquals('', $session->readSession('test'));
+
+		$this->assertTrue($session->writeSession('test', 'any value'));
+		$this->assertEquals('any value', $session->readSession('test'));
+
+		$this->assertTrue($session->destroySession('test'));
+		$this->assertEquals('', $session->readSession('test'));
+	}
+
+	/**
+	 * @covers CCacheHttpSession::init
+	 */
+	public function testInvalidCache()
+	{
+		$session = new CCacheHttpSession();
+		$session->cacheID = 'invalidCacheID';
+
+		$this->setExpectedException('CException');
+
+		$session->init();
+	}
+}


### PR DESCRIPTION
* CCacheHttpSession::destroySession now always returns true
* added CCacheHttpSessionTest