### PR TITLE
#4034 Fixed PHP 7 CHttpSession::getIsStarted() is not work

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Version 1.1.18 under development
 - Bug #4015: Fixed bug with missing "disabled" attribute in internally rendered hidden fields (rob006)
 - Bug #4020: Fixed PHP 7 related bug in CCacheHttpSession when destroying not cached sessions (dirx)
 - Chg #4033: Updated Pear/Text used by Gii so it's PHP 7 compatible (samdark)
+- Bug #4034: Fixed PHP 7 CHttpSession::getIsStarted() is not work (tomotomo)
 
 Version 1.1.17 January 13, 2016
 ------------------------------

--- a/framework/web/CHttpSession.php
+++ b/framework/web/CHttpSession.php
@@ -151,6 +151,10 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 	 */
 	public function getIsStarted()
 	{
+		if(function_exists('session_status'))
+		{
+			return session_status() == PHP_SESSION_ACTIVE;
+		}
 		return session_id()!=='';
 	}
 


### PR DESCRIPTION
Cannot regenerate session id - session is not active #4034