### PR TITLE
Allow absolute URLs to start with '//' instead of just 'http' - e.g. …

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 Version 1.1.18 under development
 --------------------------------
 
+- Enh #4049: Added '//' as a proper beginning of absolute URL in createAbsoluteUrl() method (ksowa)
 - Bug #4015: Fixed bug with missing "disabled" attribute in internally rendered hidden fields (rob006)
 - Bug #4020: Fixed PHP 7 related bug in CCacheHttpSession when destroying not cached sessions (dirx)
 - Chg #4033: Updated Pear/Text used by Gii so it's PHP 7 compatible (samdark)

--- a/framework/base/CApplication.php
+++ b/framework/base/CApplication.php
@@ -572,7 +572,7 @@ abstract class CApplication extends CModule
 	public function createAbsoluteUrl($route,$params=array(),$schema='',$ampersand='&')
 	{
 		$url=$this->createUrl($route,$params,$ampersand);
-		if(strpos($url,'http')===0)
+		if(strpos($url,'http')===0 || strpos($url,'//')===0)
 			return $url;
 		else
 			return $this->getRequest()->getHostInfo($schema).$url;


### PR DESCRIPTION
…'//google.com' is valid absolute URL