### PR TITLE
fixes: #4043

### DIFF
--- a/framework/web/helpers/CJavaScript.php
+++ b/framework/web/helpers/CJavaScript.php
@@ -28,9 +28,14 @@ class CJavaScript
 	public static function quote($js,$forUrl=false)
 	{
 		if($forUrl)
-			return strtr($js,array('%'=>'%25',"\t"=>'\t',"\n"=>'\n',"\r"=>'\r','"'=>'\"','\''=>'\\\'','\\'=>'\\\\','</'=>'<\/'));
+			$js=strtr($js,array('%'=>'%25',"\t"=>'\t',"\n"=>'\n',"\r"=>'\r','"'=>'\"','\''=>'\\\'','\\'=>'\\\\','</'=>'<\/'));
 		else
-			return strtr($js,array("\t"=>'\t',"\n"=>'\n',"\r"=>'\r','"'=>'\"','\''=>'\\\'','\\'=>'\\\\','</'=>'<\/'));
+			$js=strtr($js,array("\t"=>'\t',"\n"=>'\n',"\r"=>'\r','"'=>'\"','\''=>'\\\'','\\'=>'\\\\','</'=>'<\/'));
+
+		$js=str_replace("\xe2\x80\xa8",'\u2028',$js);
+		$js=str_replace("\xe2\x80\xa9",'\u2029',$js);
+
+		return $js;
 	}
 
 	/**


### PR DESCRIPTION
refs #4043

Based on http://stackoverflow.com/questions/14179377/how-to-replace-escape-u2028-or-u2029-characters-in-php-to-stop-my-jsonp-api-br i have tried to fix this issue.

additional to U+2028 character (Unicode line separator) it replaces the U+2029 character (Unicode paragraph separator).

the only way, i was able to test it, was to add following lines to a Controller and check the output for javascript errors. (copied "rocks" from https://web.archive.org/web/20150502034803/http://timelessrepo.com/json-isnt-a-javascript-subset)

``` php
$text = 'ro cks!
    test';
$text = CJavaScript::encode($text);

Yii::app()->clientScript->registerScript('invalid-character-js', 'var x = ' . $text . '; console.log(x);');
```

I don't thinks its possible to write unit tests for it.

``` php
'ro cks!
    test';
```

will be replaced with 

``` php
'ro\u2028cks!\n\ttest'
```
