### PR TITLE
Fix PHP Fatal Error: Nesting level too deep - recursive dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "kf99916/yii",
+	"name": "yiisoft/yii",
 	"description": "Yii Web Programming Framework",
 	"keywords": ["yii", "framework"],
 	"homepage": "http://www.yiiframework.com/",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "yiisoft/yii",
+	"name": "kf99916/yii",
 	"description": "Yii Web Programming Framework",
 	"keywords": ["yii", "framework"],
 	"homepage": "http://www.yiiframework.com/",

--- a/framework/web/CArrayDataProvider.php
+++ b/framework/web/CArrayDataProvider.php
@@ -149,10 +149,10 @@ class CArrayDataProvider extends CDataProvider
 		}
 
 		// This fix is used for cases when main sorting specified by columns has equal values
-        // Without it it will lead to Fatal Error: Nesting level too deep - recursive dependency?
-        $args[] = range(1, count($this->rawData));
-        $args[] = SORT_ASC;
-        $args[] = SORT_NUMERIC;
+		// Without it it will lead to Fatal Error: Nesting level too deep - recursive dependency?
+		$args[] = range(1, count($this->rawData));
+		$args[] = SORT_ASC;
+		$args[] = SORT_NUMERIC;
 		
 		$args[]=&$this->rawData;
 		call_user_func_array('array_multisort', $args);

--- a/framework/web/CArrayDataProvider.php
+++ b/framework/web/CArrayDataProvider.php
@@ -147,6 +147,13 @@ class CArrayDataProvider extends CDataProvider
 			$dummy[]=&$direction;
 			unset($direction);
 		}
+
+		// This fix is used for cases when main sorting specified by columns has equal values
+        // Without it it will lead to Fatal Error: Nesting level too deep - recursive dependency?
+        $args[] = range(1, count($this->rawData));
+        $args[] = SORT_ASC;
+        $args[] = SORT_NUMERIC;
+		
 		$args[]=&$this->rawData;
 		call_user_func_array('array_multisort', $args);
 	}

--- a/framework/web/CArrayDataProvider.php
+++ b/framework/web/CArrayDataProvider.php
@@ -129,7 +129,7 @@ class CArrayDataProvider extends CDataProvider
 	 */
 	protected function sortData($directions)
 	{
-		if(empty($directions))
+		if(empty($directions) || empty($this->rawData))
 			return;
 		$args=array();
 		$dummy=array();

--- a/tests/framework/web/CArrayDataProviderTest.php
+++ b/tests/framework/web/CArrayDataProviderTest.php
@@ -202,4 +202,37 @@ class CArrayDataProviderTest extends CTestCase
 
 		$this->assertEquals($sortedProjects, $dataProvider->getData());
 	}
+
+	public function testNestedObjectsSort()
+	{
+		$obj1 = new \stdClass();
+		$obj1->type = "def";
+		$obj1->owner = $obj1;
+		$obj2 = new \stdClass();
+		$obj2->type = "abc";
+		$obj2->owner = $obj2;
+		$obj3 = new \stdClass();
+		$obj3->type = "abc";
+		$obj3->owner = $obj3;
+		$models = array($obj1, $obj2, $obj3);
+
+		$this->assertEquals($obj2, $obj3);
+		$dataProvider = new CArrayDataProvider($models, array(
+			'sort'=>array(
+				'attributes'=>array(
+					'sort'=>array(
+						'asc'=>'type ASC',
+						'desc'=>'type DESC',
+						'label'=>'Type',
+						'default'=>'asc',
+					),
+				),
+				'defaultOrder'=>array(
+					'sort'=>CSort::SORT_ASC,
+				)
+			),
+		));
+		$sortedArray = array($obj2, $obj3, $obj1);
+		$this->assertEquals($sortedArray, $dataProvider->getData());
+	}
 }


### PR DESCRIPTION
Fix PHP Fatal Error: Nesting level too deep - recursive dependency.
The reference of this solution is from the issue of Yii2: https://github.com/yiisoft/yii2/issues/8348