### PR TITLE
Fixes #4064: CHtml::beginForm() produces wrong HTML when using GET and an anchor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Version 1.1.18 under development
 - Chg #4033: Updated Pear/Text used by Gii so it's PHP 7 compatible (samdark)
 - Bug #4034: Fixed `CHttpSession::getIsStarted()` PHP 7 compatibility (tomotomo)
 - Bug #4061: Fixed "Fatal Error: Nesting level too deep - recursive dependency" error in `CArrayDataProvider` (kf99916, andrewnester)
+- Bug #4064: Fixed CHtml::beginForm which produced wrong HTML when using an anchor in the action URL of a GET form (Mytskine)
 
 Version 1.1.17 January 13, 2016
 ------------------------------

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -353,7 +353,7 @@ class CHtml
 		$hiddens=array();
 		if(!strcasecmp($method,'get') && ($pos=strpos($url,'?'))!==false)
 		{
-			foreach(explode('&',substr($url,$pos+1)) as $pair)
+			foreach(explode('&',substr(preg_replace('/#.+$/','',$url),$pos+1)) as $pair)
 			{
 				if(($pos=strpos($pair,'='))!==false)
 					$hiddens[]=self::hiddenField(urldecode(substr($pair,0,$pos)),urldecode(substr($pair,$pos+1)),array('id'=>false));

--- a/tests/framework/web/helpers/CHtmlTest.php
+++ b/tests/framework/web/helpers/CHtmlTest.php
@@ -98,8 +98,8 @@ class CHtmlTest extends CTestCase
 		return array(
 				array("index", "get", array(), '<form action="index" method="get">'),
 				array("index", "post", array(), '<form action="index" method="post">'),
-				array("index?myFirstParam=3&mySecondParam=true", "get", array(),
-"<form action=\"index?myFirstParam=3&amp;mySecondParam=true\" method=\"get\">\n".
+				array("index?myFirstParam=3&mySecondParam=true#anchor", "get", array(),
+"<form action=\"index?myFirstParam=3&amp;mySecondParam=true#anchor\" method=\"get\">\n".
 "<input type=\"hidden\" value=\"3\" name=\"myFirstParam\" />\n".
 "<input type=\"hidden\" value=\"true\" name=\"mySecondParam\" />"),
 


### PR DESCRIPTION
CHtml::beginForm() was splitting the action URL by &
in order to extract the GET parameters.
When an anchor was appended to the URL, it was mixed with the last GET parameter.

An existing unit test was extended to cover this case.
