### PR TITLE
Fix CRedisCache::executeCommand() error when the previous connection timeout exception was catched

### DIFF
--- a/framework/caching/CRedisCache.php
+++ b/framework/caching/CRedisCache.php
@@ -95,7 +95,10 @@ class CRedisCache extends CCache
 			$this->executeCommand('SELECT',array($this->database));
 		}
 		else
+		{
+			$this->_socket = null;
 			throw new CException('Failed to connect to redis: '.$errorDescription,(int)$errorNumber);
+		}
 	}
 
 	/**


### PR DESCRIPTION
try {
            Yii::app()->redisCache->executeCommand('INCR', ["key"]);
     } catch (Exception $e) {
            //catch the exception
}
try {
        Yii::app()->redisCache->executeCommand('GET', ["key"]);//[error] [php] fwrite() expects parameter 1 to be resource, boolean given 
      } catch (Exception $e) {
}