### PR TITLE
Fix CHtml::value returning $defaultValue

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2348,7 +2348,7 @@ EOD;
 		if(is_scalar($attribute) || $attribute===null)
 			foreach(explode('.',$attribute) as $name)
 			{
-				if(is_object($model) && isset($model->$name))
+				if(is_object($model) && (isset($model->$name) || isset($model->{$name})))
 					$model=$model->$name;
 				elseif(is_array($model) && isset($model[$name]))
 					$model=$model[$name];


### PR DESCRIPTION
… when `$attribute` == 'array[like]'

We've just discovered a small regression in `CHtml::value` method.

If `$attribute` is not in a dot syntax but in an array syntax (like `product[name]`) and `$model` is an object it won't display corresponding value (even if it exists) but `$defaultValue` instead.