### PR TITLE
Test against the current hhvm version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
         - postgresql
         - redis-server
   allow_failures:
+    - php: 7.1
     - php: nightly
     - php: hhvm # run build against hhvm but allow them to fail
 # http://docs.travis-ci.com/user/build-configuration/#Rows-That-are-Allowed-To-Fail

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,31 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
+  - nightly
 
-# run build against hhvm but allow them to fail
-# http://docs.travis-ci.com/user/build-configuration/#Rows-That-are-Allowed-To-Fail
 matrix:
   fast_finish: true
-  allow_failures:
+  include:
     - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # Use edge image until the next travis CI image update
+      addons:
+        postgresql: "9.3"
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
+      services:
+        - mysql
+        - postgresql
+        - redis-server
+  allow_failures:
+    - php: nightly
+    - php: hhvm # run build against hhvm but allow them to fail
+# http://docs.travis-ci.com/user/build-configuration/#Rows-That-are-Allowed-To-Fail
 
 services:
   - redis-server


### PR DESCRIPTION
This PR provides the current HHVM version (3.15.2 as of this PR) and will track with each release (i.e. will be 3.16 when 3.16 is released).

If testing against HHVM LST versions is desired follow this guide. https://docs.travis-ci.com/user/languages/php#HHVM-versions

Should be able to change to container based Trusty after Q1-17 https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/

Also adds testing against php 7.1 and nightly

Related to https://github.com/yiisoft/yii2/pull/12971