### PR TITLE
PHP 7.1 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ Desktop.ini
 .*.sw[a-z]
 *.un~
 Session.vim
+
+/composer.lock
+/vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,20 @@ services:
   - redis-server
   - memcached
 
+# cache vendor dirs
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
+
 install:
   - travis_retry composer self-update && composer --version
+  - travis_retry composer update --prefer-dist --no-interaction
 
 before_script:
   - ./tests/travis/mysql-setup.sh
   - ./tests/travis/postgresql-setup.sh
   - ./tests/travis/memcache-setup.sh
-  - cd tests
 
-script: phpunit --verbose --colors --no-globals-backup --exclude-group mssql,oci framework
+script: cd tests && ../vendor/bin/phpunit --verbose --colors --no-globals-backup --exclude-group mssql,oci framework
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ matrix:
         - postgresql
         - redis-server
   allow_failures:
-    - php: 7.1
     - php: nightly
     - php: hhvm # run build against hhvm but allow them to fail
 # http://docs.travis-ci.com/user/build-configuration/#Rows-That-are-Allowed-To-Fail

--- a/composer.json
+++ b/composer.json
@@ -80,5 +80,9 @@
 			"framework/YiiBase.php",
 			"framework/yii.php"
 		]
+	},
+	"require-dev": {
+		"phpunit/phpunit": "~3.7",
+		"phpunit/phpunit-selenium": "~1.4.0"
 	}
 }

--- a/framework/vendors/TextHighlighter/Text/Highlighter.php
+++ b/framework/vendors/TextHighlighter/Text/Highlighter.php
@@ -46,7 +46,9 @@ if (!defined('HL_NUMBERS_LI')) {
 /**
  * for our purpose, it is infinity
  */
-define ('HL_INFINITY',      1000000000);
+if (!defined('HL_INFINITY')) {
+    define('HL_INFINITY', 1000000000);
+}
 
 // }}}
 

--- a/framework/vendors/TextHighlighter/Text/Highlighter/Renderer/Array.php
+++ b/framework/vendors/TextHighlighter/Text/Highlighter/Renderer/Array.php
@@ -142,7 +142,9 @@ class Text_Highlighter_Renderer_Array extends Text_Highlighter_Renderer
      */
     function acceptToken($class, $content)
     {
-
+        if (!is_array($this->_output)) {
+            $this->_output = array();
+        }
 
         $theClass = $this->_getFullClassName($class);
         if ($this->_htmlspecialchars) {

--- a/framework/vendors/TextHighlighter/Text/Highlighter/Renderer/Html.php
+++ b/framework/vendors/TextHighlighter/Text/Highlighter/Renderer/Html.php
@@ -52,11 +52,15 @@ if (!defined('HL_NUMBERS_LI')) {
 /**
  * Use numbered list
  */
-define ('HL_NUMBERS_OL',    1);
+if (!defined('HL_NUMBERS_OL')) {
+    define('HL_NUMBERS_OL', 1);
+}
 /**
  * Use non-numbered list
  */
-define ('HL_NUMBERS_UL',    3);
+if (!defined('HL_NUMBERS_UL')) {
+    define('HL_NUMBERS_UL', 3);
+}
 /**#@-*/
 
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,10 @@
 <?php
 
+if (PHP_MAJOR_VERSION >= 7 && PHP_MINOR_VERSION >= 1) {
+	// skip deprecation errors in PHP 7.1 and above
+	error_reporting(E_ALL & ~E_DEPRECATED);
+}
+
 defined('YII_ENABLE_EXCEPTION_HANDLER') or define('YII_ENABLE_EXCEPTION_HANDLER',false);
 defined('YII_ENABLE_ERROR_HANDLER') or define('YII_ENABLE_ERROR_HANDLER',false);
 defined('YII_DEBUG') or define('YII_DEBUG',true);

--- a/tests/travis/memcache-setup.sh
+++ b/tests/travis/memcache-setup.sh
@@ -2,7 +2,7 @@
 
 if (php --version | grep -i HipHop > /dev/null); then
   echo "skipping memcache on HHVM"
-elif [ $(phpenv version-name) = "7.0" ]; then
+elif [ $(phpenv version-name) = 7.* ]; then
   echo "skipping memcache on php 7"
 else
   mkdir -p ~/.phpenv/versions/$(phpenv version-name)/etc

--- a/tests/travis/memcache-setup.sh
+++ b/tests/travis/memcache-setup.sh
@@ -2,7 +2,7 @@
 
 if (php --version | grep -i HipHop > /dev/null); then
   echo "skipping memcache on HHVM"
-elif [ $(phpenv version-name) = "7.0" ] || [ $(phpenv version-name) = "7.1" ]; then
+elif [ $(phpenv version-name) = "7.0" ] || [ $(phpenv version-name) = "7.1" ] || [ $(phpenv version-name) = "nightly" ]; then
   echo "skipping memcache on php 7"
 else
   mkdir -p ~/.phpenv/versions/$(phpenv version-name)/etc

--- a/tests/travis/memcache-setup.sh
+++ b/tests/travis/memcache-setup.sh
@@ -2,7 +2,7 @@
 
 if (php --version | grep -i HipHop > /dev/null); then
   echo "skipping memcache on HHVM"
-elif [ $(phpenv version-name) = 7.* ]; then
+elif [ $(phpenv version-name) = "7.0" ] || [ $(phpenv version-name) = "7.1" ]; then
   echo "skipping memcache on php 7"
 else
   mkdir -p ~/.phpenv/versions/$(phpenv version-name)/etc


### PR DESCRIPTION
Mainly build environment adjustments to make sure tests run fine. Additionally some fixes in TextHighlighter:

- adjusted `TextHighlighter` to load fine with constants.
- adjusted `TextHighlighter` to work the same on PHP 7.1. as on other versions by introducing an explicit cast to array() which is not allowed to be implicit anymore in PHP 7.1.

Is there an upstream repo of the TextHighlighter where we could contribute these back?