### PR TITLE
Update CJavaScript.php #4043

### DIFF
--- a/framework/web/helpers/CJavaScript.php
+++ b/framework/web/helpers/CJavaScript.php
@@ -27,10 +27,8 @@ class CJavaScript
 	 */
 	public static function quote($js,$forUrl=false)
 	{
-		if($forUrl)
-			return strtr($js,array('%'=>'%25',"\t"=>'\t',"\n"=>'\n',"\r"=>'\r','"'=>'\"','\''=>'\\\'','\\'=>'\\\\','</'=>'<\/'));
-		else
-			return strtr($js,array("\t"=>'\t',"\n"=>'\n',"\r"=>'\r','"'=>'\"','\''=>'\\\'','\\'=>'\\\\','</'=>'<\/'));
+	    $encoded = strtr(substr(json_encode($js), 1, -1), array("'", "\\'"));
+	    return $forUrl ? strtr($encoded, array('%' => '%25')) : $encoded;
 	}
 
 	/**


### PR DESCRIPTION
Fixed issue with unicode characters.
Basically we just use PHP's `json_encode` which takes care of all encoding. To support the use case where the result string gets surrounded in single quotes instead of double quotes (JSON doesn't use single quotes), we escape single quotes manually.