### PR TITLE
Timeout in checkMxPorts is now configurable, using curl for better granularity.

### DIFF
--- a/framework/validators/CEmailValidator.php
+++ b/framework/validators/CEmailValidator.php
@@ -172,8 +172,11 @@ if(".($this->allowEmpty ? "jQuery.trim(value)!='' && " : '').$condition.") {
 		{
 			$url='smtp://'.$record['target'].':25/';
 			$ch=curl_init($url);
-			curl_setopt($ch,CURLOPT_CONNECT_ONLY,true);
+			if (defined('CURLOPT_CONNECT_ONLY')) {
+				curl_setopt($ch,CURLOPT_CONNECT_ONLY,true);
+			}
 			curl_setopt($ch,CURLOPT_CONNECTTIMEOUT_MS,$timeout);
+			curl_setopt($ch,CURLOPT_RETURNTRANSFER,true);
 			if (curl_exec($ch) !== false)
 			{
 				curl_close($ch);

--- a/framework/validators/CEmailValidator.php
+++ b/framework/validators/CEmailValidator.php
@@ -43,10 +43,16 @@ class CEmailValidator extends CValidator
 	/**
 	 * @var boolean whether to check port 25 for the email address.
 	 * Defaults to false. To enable it, ensure that the PHP functions 'dns_get_record' and
-	 * 'fsockopen' are available in your PHP installation.
+	 * 'curl_exec' are available in your PHP installation.
 	 * Please note that this check may fail due to temporary problems even if email is deliverable.
 	 */
 	public $checkPort=false;
+	/**
+	 * @var null|int timeout to use when attempting to open connection to port in checkMxPorts. If null (default)
+	 * use default_socket_timeout value from php.ini. If not null the timeout is set in milliseconds.
+	 * @since 1.1.19
+	 */
+	public $timeout=null;
 	/**
 	 * @var boolean whether the attribute value can be null or empty. Defaults to true,
 	 * meaning that if the attribute is empty, it is considered valid.
@@ -99,7 +105,7 @@ class CEmailValidator extends CValidator
 			$domain=rtrim(substr($value,strpos($value,'@')+1),'>');
 		if($valid && $this->checkMX && function_exists('checkdnsrr'))
 			$valid=checkdnsrr($domain,'MX');
-		if($valid && $this->checkPort && function_exists('fsockopen') && function_exists('dns_get_record'))
+		if($valid && $this->checkPort && function_exists('curl_exec') && function_exists('dns_get_record'))
 			$valid=$this->checkMxPorts($domain);
 		return $valid;
 	}
@@ -156,15 +162,24 @@ if(".($this->allowEmpty ? "jQuery.trim(value)!='' && " : '').$condition.") {
 		$records=dns_get_record($domain, DNS_MX);
 		if($records===false || empty($records))
 			return false;
+		if (is_int($this->timeout)) {
+			$timeout=$this->timeout;
+		}else {
+			$timeout=((int)ini_get("default_socket_timeout"))*1000;
+		}
 		usort($records,array($this,'mxSort'));
 		foreach($records as $record)
 		{
-			$handle=@fsockopen($record['target'],25);
-			if($handle!==false)
+			$url='smtp://'.$record['target'].':25/';
+			$ch=curl_init($url);
+			curl_setopt($ch,CURLOPT_CONNECT_ONLY,true);
+			curl_setopt($ch,CURLOPT_CONNECTTIMEOUT_MS,$timeout);
+			if (curl_exec($ch) !== false)
 			{
-				fclose($handle);
+				curl_close($ch);
 				return true;
 			}
+			curl_close($ch);
 		}
 		return false;
 	}

--- a/tests/framework/validators/CEmailValidatorTest.php
+++ b/tests/framework/validators/CEmailValidatorTest.php
@@ -77,4 +77,20 @@ class CEmailValidatorTest extends CTestCase
 		$this->assertTrue($model->hasErrors('email'));
 		$this->assertEquals(array('Email is not a valid email address.'),$model->getErrors('email'));
 	}
+
+	public function testMxPortDomainWithNoMXRecord()
+	{
+		$emailValidator = new CEmailValidator();
+		$emailValidator->checkPort = true;
+		$result = $emailValidator->validateValue('user@example.com');
+		$this->assertFalse($result);
+	}
+
+	public function testMxPortDomainWithMXRecord()
+	{
+		$emailValidator = new CEmailValidator();
+		$emailValidator->checkPort = true;
+		$result = $emailValidator->validateValue('user@hotmail.com');
+		$this->assertTrue($result);
+	}
 }


### PR DESCRIPTION
This relates to a security issue as discussed privately with @samdark

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | None, as advised.
