### PR TITLE
Fix "Incorrect datetime value"

### DIFF
--- a/framework/db/schema/mysql/CMysqlColumnSchema.php
+++ b/framework/db/schema/mysql/CMysqlColumnSchema.php
@@ -44,7 +44,7 @@ class CMysqlColumnSchema extends CDbColumnSchema
 	{
 		if(strncmp($this->dbType,'bit',3)===0)
 			$this->defaultValue=bindec(trim($defaultValue,'b\''));
-		elseif(($this->dbType==='timestamp' || $this->dbType==='datetime')  && $defaultValue==='CURRENT_TIMESTAMP')
+		elseif(($this->dbType==='timestamp' || $this->dbType==='datetime')  && ($defaultValue==='CURRENT_TIMESTAMP' || $defaultValue==='current_timestamp()'))
 			$this->defaultValue=null;
 		else
 			parent::extractDefault($defaultValue);


### PR DESCRIPTION
Fix 1292 Incorrect datetime value: 'current_timestamp()' for Mariadb 10.3

Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
