### PR TITLE
Update jquery.yiiactiveform.js

### DIFF
--- a/framework/web/js/source/jquery.yiiactiveform.js
+++ b/framework/web/js/source/jquery.yiiactiveform.js
@@ -119,7 +119,10 @@
 					});
 				}
 				if (this.validateOnType) {
-					$form.find('#' + this.inputID).keyup(function () {
+					/**
+					*Fix IE9 keyup event problem
+					*/
+					$(document).on("keyup", "#" + this.inputID, function () {
 						if (attribute.value !== getAFValue($(this))) {
 							validate(attribute, false);
 						}


### PR DESCRIPTION
Using .on("keyup", <selector>, <handler>) construction fix keyup event problem in IE9

Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
