### PR TITLE
Session data not updating after login

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Version 1.1.20 under development
 
 - Chg #4160: Updated HTMLPurifier to version 4.9.3 (takobell)
 - Bug #4162: Adjusted Zend Escaper to be compatible with PHP <5.3 and fixed usage of non-existing Exceptions (cebe)
+- Bug #4168: Fixed `CDbHttpSession` PHP 7.1 compatibility (csears123)
 
 Version 1.1.19 June 8, 2017
 ---------------------------

--- a/framework/web/CDbHttpSession.php
+++ b/framework/web/CDbHttpSession.php
@@ -228,7 +228,7 @@ class CDbHttpSession extends CHttpSession
 			->from($this->sessionTableName)
 			->where('expire>:expire AND id=:id',array(':expire'=>time(),':id'=>$id))
 			->queryScalar();
-		return $data===false?'':$data;
+		return ($data===null || $data===false)?'':$data;
 	}
 
 	/**


### PR DESCRIPTION
Updating from PHP 5.6 to PHP 7.1 introduced an issue where the session data no longer was updating, preventing the user from logging in. After debugging it was discovered the queryScalar in the readSession function was returning NULL from the empty record/row in the database with the passed in session ID.  The return statement has a strict comparison to check for boolean false, and did not account for a NULL value being returned from the empty "data" column in the database.  Changing the return statement to also check for a NULL resolves this issue, and will allow the session data to be updated correctly.  The config for the session is using CDbHttpSession class with a custom session name, and a CDbConnection that connects to IBM DB2 database.

Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
