### PR TITLE
#4179 Fix MariaDB 10.2 current_timestamp()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,10 @@
-                   Yii Framework Change Log
+﻿                   Yii Framework Change Log
                    ========================
 
 Version 1.1.20 under development
 --------------------------------
 
+- Bug #4179: Fixed MariaDB 10.2 current_timestamt() (yaBliznyk)
 - Bug #4167: Fixed PHP 7.2 incompatibility of "count()" in `CActiveFinder` (softark)
 - Chg #4160: Updated HTMLPurifier to version 4.9.3 (takobell)
 - Bug #4162: Adjusted Zend Escaper to be compatible with PHP <5.3 and fixed usage of non-existing Exceptions (cebe)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 Version 1.1.20 under development
 --------------------------------
 
-- Bug #4179: Fixed MariaDB 10.2 current_timestamt() (yaBliznyk)
+- Bug #4179: Fixed MariaDB 10.2 current_timestamp() (yaBliznyk)
 - Bug #4167: Fixed PHP 7.2 incompatibility of "count()" in `CActiveFinder` (softark)
 - Chg #4160: Updated HTMLPurifier to version 4.9.3 (takobell)
 - Bug #4162: Adjusted Zend Escaper to be compatible with PHP <5.3 and fixed usage of non-existing Exceptions (cebe)

--- a/framework/db/schema/mysql/CMysqlColumnSchema.php
+++ b/framework/db/schema/mysql/CMysqlColumnSchema.php
@@ -44,7 +44,7 @@ class CMysqlColumnSchema extends CDbColumnSchema
 	{
 		if(strncmp($this->dbType,'bit',3)===0)
 			$this->defaultValue=bindec(trim($defaultValue,'b\''));
-		elseif(($this->dbType==='timestamp' || $this->dbType==='datetime')  && $defaultValue==='CURRENT_TIMESTAMP')
+		elseif(($this->dbType==='timestamp' || $this->dbType==='datetime')  && ($defaultValue==='CURRENT_TIMESTAMP' || $defaultValue==='current_timestamp()'))
 			$this->defaultValue=null;
 		else
 			parent::extractDefault($defaultValue);


### PR DESCRIPTION
Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes, i think
| Fixed issues  | #4179 
