### PR TITLE
docs [docs/guide/topics.i18n.txt] fix URL to "Language Plural Rules"

### DIFF
--- a/docs/guide/de/topics.i18n.txt
+++ b/docs/guide/de/topics.i18n.txt
@@ -318,7 +318,7 @@ zu dieser Ausgabe führen:
 
 > Info: Weitere Informationen darüber, wieviele Werte man in welcher
 > Reihenfolge angeben kann finden auf der Seite mit den 
-> [Pluralregeln einzelner Sprachen](http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html)
+> [Pluralregeln einzelner Sprachen](http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#de)
 > des CLDR.
 
 

--- a/docs/guide/id/topics.i18n.txt
+++ b/docs/guide/id/topics.i18n.txt
@@ -297,7 +297,7 @@ akan memberikan hasil
 
 > Info: untuk mempelajari berapa banyak nilai yang harus anda sediakan dan
 bagaimana urutan yang seharusnya, silahkan merujuk ke CLDR
-[halaman Language Plural Rules] (http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html).
+[halaman Language Plural Rules] (http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#id).
 
 ### Terjemahan File
 

--- a/docs/guide/ja/topics.i18n.txt
+++ b/docs/guide/ja/topics.i18n.txt
@@ -251,7 +251,7 @@ Yii::t('app', '{n} cucumber|{n} cucumbers', 7);
 ~~~
 
 
-> Info|情報: 何個の表示形式をどういう順序で記述すべきかについては、CLDR [Language Plural Rules page](http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html) を参照して下さい。
+> Info|情報: 何個の表示形式をどういう順序で記述すべきかについては、CLDR [Language Plural Rules page](http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#ja) を参照して下さい。
 
 
 ### ファイル翻訳

--- a/docs/guide/pl/topics.i18n.txt
+++ b/docs/guide/pl/topics.i18n.txt
@@ -284,7 +284,7 @@ co w rezultacie da nam
 
 
 > Info|Info: aby dowiedzieć się jak wiele wartości możesz wprowadzić oraz w jakiej kolejności
- powinny się one znajdować zajrzyj na stronę [reguł liczy mnogiej dla różnych języków](http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html).
+ powinny się one znajdować zajrzyj na stronę [reguł liczy mnogiej dla różnych języków](http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#pl).
 
 ### Tłumaczenie pliku
 

--- a/docs/guide/ru/topics.i18n.txt
+++ b/docs/guide/ru/topics.i18n.txt
@@ -272,7 +272,7 @@ Yii::t('app', '{n} cucumber|{n} cucumbers', 7);
 
 
 > Info|Информация: число и порядок выражений можно узнать в разделе
- [Language Plural Rules](http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html)
+ [Language Plural Rules](http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#ru)
  на сайте CLDR.
 
 ### Перевод файлов

--- a/docs/guide/sv/topics.i18n.txt
+++ b/docs/guide/sv/topics.i18n.txt
@@ -290,7 +290,7 @@ blir resultatet
  
 
 > Info: För detaljer om hur många värden som skall lämnas med och i vilken ordning, 
-vänligen se CLDR [Language Plural Rules page](http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html).
+vänligen se CLDR [Language Plural Rules page](http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#sv).
 
 ### Översättning av fil
 

--- a/docs/guide/topics.i18n.txt
+++ b/docs/guide/topics.i18n.txt
@@ -301,7 +301,7 @@ which will produce:
 
 > Info: to learn about how many expressions you should supply and in which
  order they should be, please refer to CLDR
- [Language Plural Rules page](http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html).
+ [Language Plural Rules page](http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html).
 
 ### File Translation
 

--- a/docs/guide/uk/topics.i18n.txt
+++ b/docs/guide/uk/topics.i18n.txt
@@ -248,7 +248,7 @@ Yii::t('app', '{n} cucumber|{n} cucumbers', 7);
 
 
 > Info|Інформація: число і порядок виразів можна дізнатися у розділі
- [Language Plural Rules](http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html)
+ [Language Plural Rules](http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#uk)
  на сайті CLDR.
 
 ### Переклад файлів


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

I've not changed code, only docs.
Replaced old deprecated link:
http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html 
with new one:
http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html