### PR TITLE
Filters  for YiiBase::autoloader autoloader

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,7 +10,7 @@ Version 1.1.20 under development
 - Bug #4168: Fixed `CDbHttpSession` PHP 7.1 compatibility (csears123)
 - Enh #4191: Added option for filter classes loaded by YiiBase autoloader (daniel1302)
 - Bug #4191: Fixed "Headers already sent." error in CHttpSession (daniel1302)
-- Bug #4191: Fixed "CHtml::value() behaves differently for objects" for php 7.2(daniel1302)
+- Bug #4191: Fixed "CHtml::value() behaves differently for objects" for PHP 7.2 (daniel1302)
 
 Version 1.1.19 June 8, 2017
 ---------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,9 @@ Version 1.1.20 under development
 - Chg #4160: Updated HTMLPurifier to version 4.9.3 (takobell)
 - Bug #4162: Adjusted Zend Escaper to be compatible with PHP <5.3 and fixed usage of non-existing Exceptions (cebe)
 - Bug #4168: Fixed `CDbHttpSession` PHP 7.1 compatibility (csears123)
+- Enh #4191: Added option for filter classes loaded by YiiBase autoloader (daniel1302)
+- Bug #4191: Fixed "Headers already sent." error in CHttpSession (daniel1302)
+- Bug #4191: Fixed "CHtml::value() behaves differently for objects" for php 7.2(daniel1302)
 
 Version 1.1.19 June 8, 2017
 ---------------------------

--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -53,12 +53,13 @@ defined('YII_ZII_PATH') or define('YII_ZII_PATH',YII_PATH.DIRECTORY_SEPARATOR.'z
  */
 class YiiBase
 {
-    /**
-     * @var array filters for autoloading mechanism.
-     * It should be callable. For callable function autoloader pass className.
-     * If filter function returns true Yii autoloader will be skipped.
-     */
-    public static $autoloaderFilters=array();
+	/**
+	 * @var array filters for autoloading mechanism.
+	 * It should be callable. For callable function autoloader pass className.
+	 * If filter function returns true Yii autoloader will be skipped.
+	 * @since 1.1.20
+	 */
+	public static $autoloaderFilters=array();
 	/**
 	 * @var array class map used by the Yii autoloading mechanism.
 	 * The array keys are the class names and the array values are the corresponding class file paths.
@@ -405,29 +406,29 @@ class YiiBase
 	 */
 	public static function autoload($className,$classMapOnly=false)
 	{
-        foreach (self::$autoloaderFilters as $filter)
-        {
-            if (is_array($filter)
-                && isset($filter[0]) && isset($filter[1])
-                && is_string($filter[0]) && is_string($filter[1])
-                && true === call_user_func(array($filter[0], $filter[1]), $className)
-            )
-            {
-                return true;
-            }
-            elseif (is_string($filter)
-                && true === call_user_func($filter, $className)
-            )
-            {
-                return true;
-            }
-            elseif (is_callable($filter)
-                && true === $filter($className)
-            )
-            {
-                return true;
-            }
-        }
+		foreach (self::$autoloaderFilters as $filter)
+		{
+			if (is_array($filter)
+				&& isset($filter[0]) && isset($filter[1])
+				&& is_string($filter[0]) && is_string($filter[1])
+				&& true === call_user_func(array($filter[0], $filter[1]), $className)
+			)
+			{
+				return true;
+			}
+			elseif (is_string($filter)
+				&& true === call_user_func($filter, $className)
+			)
+			{
+				return true;
+			}
+			elseif (is_callable($filter)
+				&& true === $filter($className)
+			)
+			{
+				return true;
+			}
+		}
 
 		// use include so that the error PHP file may appear
 		if(isset(self::$classMap[$className]))

--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -53,6 +53,12 @@ defined('YII_ZII_PATH') or define('YII_ZII_PATH',YII_PATH.DIRECTORY_SEPARATOR.'z
  */
 class YiiBase
 {
+    /**
+     * @var array filters for autoloading mechanism.
+     * It should be callable. For callable function autoloader pass className.
+     * If filter function returns true Yii autoloader will be skipped.
+     */
+    public static $autoloaderFilters=array();
 	/**
 	 * @var array class map used by the Yii autoloading mechanism.
 	 * The array keys are the class names and the array values are the corresponding class file paths.
@@ -399,6 +405,30 @@ class YiiBase
 	 */
 	public static function autoload($className,$classMapOnly=false)
 	{
+        foreach (self::$autoloaderFilters as $filter)
+        {
+            if (is_array($filter)
+                && isset($filter[0]) && isset($filter[1])
+                && is_string($filter[0]) && is_string($filter[1])
+                && true === call_user_func(array($filter[0], $filter[1]), $className)
+            )
+            {
+                return true;
+            }
+            elseif (is_string($filter)
+                && true === call_user_func($filter, $className)
+            )
+            {
+                return true;
+            }
+            elseif (is_callable($filter)
+                && true === $filter($className)
+            )
+            {
+                return true;
+            }
+        }
+
 		// use include so that the error PHP file may appear
 		if(isset(self::$classMap[$className]))
 			include(self::$classMap[$className]);

--- a/framework/web/CHttpSession.php
+++ b/framework/web/CHttpSession.php
@@ -76,12 +76,13 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 	 */
 	public $autoStart=true;
 
-    /**
-     * @var array Store frozen session data for ini_set in PHP7.2+
-     */
-    protected static $frozenData = array();
+	/**
+	 * @var array Store frozen session data for ini_set in PHP7.2+
+	 * @since 1.1.20
+	 */
+	protected static $frozenData = array();
 
-        /**
+		/**
 	 * Initializes the application component.
 	 * This method is required by IApplicationComponent and is invoked by application.
 	 */
@@ -275,24 +276,24 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 	{
 		if($value==='none')
 		{
-		    $this->freeze();
+			$this->freeze();
 			ini_set('session.use_cookies','0');
 			ini_set('session.use_only_cookies','0');
-            $this->unfreeze();
+			$this->unfreeze();
 		}
 		elseif($value==='allow')
 		{
-            $this->freeze();
+			$this->freeze();
 			ini_set('session.use_cookies','1');
 			ini_set('session.use_only_cookies','0');
-            $this->unfreeze();
+			$this->unfreeze();
 		}
 		elseif($value==='only')
 		{
-            $this->freeze();
+			$this->freeze();
 			ini_set('session.use_cookies','1');
 			ini_set('session.use_only_cookies','1');
-            $this->unfreeze();
+			$this->unfreeze();
 		}
 		else
 			throw new CException(Yii::t('yii','CHttpSession.cookieMode can only be "none", "allow" or "only".'));
@@ -314,11 +315,11 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 	{
 		if($value>=0 && $value<=100)
 		{
-            $this->freeze();
+			$this->freeze();
 			// percent * 21474837 / 2147483647 ≈ percent * 0.01
 			ini_set('session.gc_probability',floor($value*21474836.47));
 			ini_set('session.gc_divisor',2147483647);
-            $this->unfreeze();
+			$this->unfreeze();
 		}
 		else
 			throw new CException(Yii::t('yii','CHttpSession.gcProbability "{value}" is invalid. It must be a float between 0 and 100.',
@@ -587,50 +588,52 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 		unset($_SESSION[$offset]);
 	}
 
-    /**
-     * In PHP7.2 if session is started we cannot edit session ini settings.
-     * This function save session data to temporary variable and stop session.
-     *
-     * @see CHttpSession::unfreeze();
-     */
-    protected function freeze()
-    {
-        if (version_compare(PHP_VERSION, '7.2.0', '<'))
-        {
-            return;
-        }
+	/**
+	 * In PHP7.2 if session is started we cannot edit session ini settings.
+	 * This function save session data to temporary variable and stop session.
+	 *
+	 * @see CHttpSession::unfreeze();
+	 * @since 1.1.20
+	 */
+	protected function freeze()
+	{
+		if (version_compare(PHP_VERSION, '7.2.0', '<'))
+		{
+			return;
+		}
 
-        if ($this->getIsStarted())
-        {
-            self::$frozenData = $_SESSION;
-            $this->close();
-        }
-        else
-        {
-            self::$frozenData = null;
-        }
-    }
+		if ($this->getIsStarted())
+		{
+			self::$frozenData = $_SESSION;
+			$this->close();
+		}
+		else
+		{
+			self::$frozenData = null;
+		}
+	}
 
-    /**
-     * Start session and restore data from temporary variable
-     *
-     * @see CHttpSession::freeze();
-     */
-    protected function unfreeze()
-    {
-        if (version_compare(PHP_VERSION, '7.2.0', '<'))
-        {
-            return;
-        }
+	/**
+	 * Start session and restore data from temporary variable
+	 *
+	 * @see CHttpSession::freeze();
+	 * @since 1.1.20
+	 */
+	protected function unfreeze()
+	{
+		if (version_compare(PHP_VERSION, '7.2.0', '<'))
+		{
+			return;
+		}
 
-        if (self::$frozenData !== null)
-        {
-            @session_start();
-            $_SESSION = self::$frozenData;
-        }
+		if (self::$frozenData !== null)
+		{
+			@session_start();
+			$_SESSION = self::$frozenData;
+		}
 
-        self::$frozenData = array();
+		self::$frozenData = array();
 
-    }
+	}
 
 }

--- a/framework/web/CHttpSession.php
+++ b/framework/web/CHttpSession.php
@@ -82,7 +82,7 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 	 */
 	protected static $frozenData = array();
 
-		/**
+	/**
 	 * Initializes the application component.
 	 * This method is required by IApplicationComponent and is invoked by application.
 	 */

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -996,13 +996,13 @@ class CHtml
 	 * The 'empty' option can also be an array of value-label pairs.
 	 * Each pair will be used to render a list option at the beginning. Note, the text label will NOT be HTML-encoded.</li>
 	 * <li>options: array, specifies additional attributes for each OPTION tag.
-	 *     The array keys must be the option values, and the array values are the extra
-	 *     OPTION tag attributes in the name-value pairs. For example,
+	 *	 The array keys must be the option values, and the array values are the extra
+	 *	 OPTION tag attributes in the name-value pairs. For example,
 	 * <pre>
-	 *     array(
-	 *         'value1'=>array('disabled'=>true,'label'=>'value 1'),
-	 *         'value2'=>array('label'=>'value 2'),
-	 *     );
+	 *	 array(
+	 *		 'value1'=>array('disabled'=>true,'label'=>'value 1'),
+	 *		 'value2'=>array('label'=>'value 2'),
+	 *	 );
 	 * </pre>
 	 * </li>
 	 * </ul>
@@ -1064,13 +1064,13 @@ class CHtml
 	 * The 'empty' option can also be an array of value-label pairs.
 	 * Each pair will be used to render a list option at the beginning. Note, the text label will NOT be HTML-encoded.</li>
 	 * <li>options: array, specifies additional attributes for each OPTION tag.
-	 *     The array keys must be the option values, and the array values are the extra
-	 *     OPTION tag attributes in the name-value pairs. For example,
+	 *	 The array keys must be the option values, and the array values are the extra
+	 *	 OPTION tag attributes in the name-value pairs. For example,
 	 * <pre>
-	 *     array(
-	 *         'value1'=>array('disabled'=>true,'label'=>'value 1'),
-	 *         'value2'=>array('label'=>'value 2'),
-	 *     );
+	 *	 array(
+	 *		 'value1'=>array('disabled'=>true,'label'=>'value 1'),
+	 *		 'value2'=>array('label'=>'value 2'),
+	 *	 );
 	 * </pre>
 	 * </li>
 	 * </ul>
@@ -1970,13 +1970,13 @@ EOD;
 	 * The 'empty' option can also be an array of value-label pairs.
 	 * Each pair will be used to render a list option at the beginning. Note, the text label will NOT be HTML-encoded.</li>
 	 * <li>options: array, specifies additional attributes for each OPTION tag.
-	 *     The array keys must be the option values, and the array values are the extra
-	 *     OPTION tag attributes in the name-value pairs. For example,
+	 *	 The array keys must be the option values, and the array values are the extra
+	 *	 OPTION tag attributes in the name-value pairs. For example,
 	 * <pre>
-	 *     array(
-	 *         'value1'=>array('disabled'=>true,'label'=>'value 1'),
-	 *         'value2'=>array('label'=>'value 2'),
-	 *     );
+	 *	 array(
+	 *		 'value1'=>array('disabled'=>true,'label'=>'value 1'),
+	 *		 'value2'=>array('label'=>'value 2'),
+	 *	 );
 	 * </pre>
 	 * </li>
 	 * </ul>
@@ -2037,13 +2037,13 @@ EOD;
 	 * The 'empty' option can also be an array of value-label pairs.
 	 * Each pair will be used to render a list option at the beginning. Note, the text label will NOT be HTML-encoded.</li>
 	 * <li>options: array, specifies additional attributes for each OPTION tag.
-	 *     The array keys must be the option values, and the array values are the extra
-	 *     OPTION tag attributes in the name-value pairs. For example,
+	 *	 The array keys must be the option values, and the array values are the extra
+	 *	 OPTION tag attributes in the name-value pairs. For example,
 	 * <pre>
-	 *     array(
-	 *         'value1'=>array('disabled'=>true,'label'=>'value 1'),
-	 *         'value2'=>array('label'=>'value 2'),
-	 *     );
+	 *	 array(
+	 *		 'value1'=>array('disabled'=>true,'label'=>'value 1'),
+	 *		 'value2'=>array('label'=>'value 2'),
+	 *	 );
 	 * </pre>
 	 * </li>
 	 * </ul>
@@ -2349,19 +2349,19 @@ EOD;
 			foreach(explode('.',$attribute) as $name)
 			{
 				if(is_object($model))
-                {
-                    if ((version_compare(PHP_VERSION, '7.2.0', '>=')
-                        && is_numeric($name))
-                        || !isset($model->$name)
-                    )
-                    {
-                        return $defaultValue;
-                    }
-                    else
-                    {
-                        $model=$model->$name;
-                    }
-                }
+				{
+					if ((version_compare(PHP_VERSION, '7.2.0', '>=')
+						&& is_numeric($name))
+						|| !isset($model->$name)
+					)
+					{
+						return $defaultValue;
+					}
+					else
+					{
+						$model=$model->$name;
+					}
+				}
 
 				elseif(is_array($model) && isset($model[$name]))
 					$model=$model[$name];
@@ -2498,13 +2498,13 @@ EOD;
 	 * The 'empty' option can also be an array of value-label pairs.
 	 * Each pair will be used to render a list option at the beginning. Note, the text label will NOT be HTML-encoded.</li>
 	 * <li>options: array, specifies additional attributes for each OPTION tag.
-	 *     The array keys must be the option values, and the array values are the extra
-	 *     OPTION tag attributes in the name-value pairs. For example,
+	 *	 The array keys must be the option values, and the array values are the extra
+	 *	 OPTION tag attributes in the name-value pairs. For example,
 	 * <pre>
-	 *     array(
-	 *         'value1'=>array('disabled'=>true,'label'=>'value 1'),
-	 *         'value2'=>array('label'=>'value 2'),
-	 *     );
+	 *	 array(
+	 *		 'value1'=>array('disabled'=>true,'label'=>'value 1'),
+	 *		 'value2'=>array('label'=>'value 2'),
+	 *	 );
 	 * </pre>
 	 * </li>
 	 * <li>key: string, specifies the name of key attribute of the selection object(s).

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2348,8 +2348,21 @@ EOD;
 		if(is_scalar($attribute) || $attribute===null)
 			foreach(explode('.',$attribute) as $name)
 			{
-				if(is_object($model) && isset($model->$name))
-					$model=$model->$name;
+				if(is_object($model))
+                {
+                    if ((version_compare(PHP_VERSION, '7.2.0', '>=')
+                        && is_numeric($name))
+                        || !isset($model->$name)
+                    )
+                    {
+                        return $defaultValue;
+                    }
+                    else
+                    {
+                        $model=$model->$name;
+                    }
+                }
+
 				elseif(is_array($model) && isset($model[$name]))
 					$model=$model[$name];
 				else

--- a/tests/TestAutoloader.php
+++ b/tests/TestAutoloader.php
@@ -1,64 +1,62 @@
 <?php
-
-
 class TestAutoloader extends CTestCase
 {
-    public function testAutoloaderForAnonymousCallableFilter()
-    {
-        Yii::$autoloaderFilters['smarty1'] = function($className)
-        {
-            if (strpos($className, 'Smarty') === 0) {
-                return true;
-            }
+	public function testAutoloaderForAnonymousCallableFilter()
+	{
+		Yii::$autoloaderFilters['smarty1'] = function($className)
+		{
+			if (strpos($className, 'Smarty') === 0) {
+				return true;
+			}
 
-            return false;
-        };
+			return false;
+		};
 
-        $this->assertTrue(Yii::autoload('SmartyFunctionMeta'));
-        $this->assertTrue(Yii::autoload('Smarty_Function_Meta'));
-    }
+		$this->assertTrue(Yii::autoload('SmartyFunctionMeta'));
+		$this->assertTrue(Yii::autoload('Smarty_Function_Meta'));
+	}
 
-    public function testAutoloaderForFunction()
-    {
-        function exampleFilter($className)
-        {
-            if (strpos($className, 'Zend') === 0) {
-                return true;
-            }
+	public function testAutoloaderForFunction()
+	{
+		function exampleFilter($className)
+		{
+			if (strpos($className, 'Zend') === 0) {
+				return true;
+			}
 
-            return false;
-        }
+			return false;
+		}
 
-        Yii::$autoloaderFilters['zend'] = 'exampleFilter';
+		Yii::$autoloaderFilters['zend'] = 'exampleFilter';
 
-        $this->assertTrue(Yii::autoload('ZendFunctionMeta'));
-        $this->assertTrue(Yii::autoload('Zend_Function_Meta'));
-    }
+		$this->assertTrue(Yii::autoload('ZendFunctionMeta'));
+		$this->assertTrue(Yii::autoload('Zend_Function_Meta'));
+	}
 
-    public function testAutoloaderForStaticMethod()
-    {
-        eval('Class SmartyAutoloader {
-            public static function exampleFilter($className)
-            {
-                if (strpos($className, \'Smarty\') === 0) {
-                    return true;
-                }
+	public function testAutoloaderForStaticMethod()
+	{
+		eval('Class SmartyAutoloader {
+			public static function exampleFilter($className)
+			{
+				if (strpos($className, \'Smarty\') === 0) {
+					return true;
+				}
 
-                return false;
-            }
-        }');
+				return false;
+			}
+		}');
 
 
-        Yii::$autoloaderFilters['smarty2'] = array('SmartyAutoloader', 'exampleFilter');
+		Yii::$autoloaderFilters['smarty2'] = array('SmartyAutoloader', 'exampleFilter');
 
-        $this->assertTrue(Yii::autoload('SmartyFunctionMeta'));
-        $this->assertTrue(Yii::autoload('Smarty_Function_Meta'));
-    }
+		$this->assertTrue(Yii::autoload('SmartyFunctionMeta'));
+		$this->assertTrue(Yii::autoload('Smarty_Function_Meta'));
+	}
 
-    public function testAutoloaderWithoutFilter()
-    {
-        Yii::$enableIncludePath = false;
-        $this->assertFalse(Yii::autoload('SomeClass'));
-        $this->assertTrue(Yii::autoload('Yii'));
-    }
+	public function testAutoloaderWithoutFilter()
+	{
+		Yii::$enableIncludePath = false;
+		$this->assertFalse(Yii::autoload('SomeClass'));
+		$this->assertTrue(Yii::autoload('Yii'));
+	}
 }

--- a/tests/TestAutoloader.php
+++ b/tests/TestAutoloader.php
@@ -1,0 +1,64 @@
+<?php
+
+
+class TestAutoloader extends CTestCase
+{
+    public function testAutoloaderForAnonymousCallableFilter()
+    {
+        Yii::$autoloaderFilters['smarty1'] = function($className)
+        {
+            if (strpos($className, 'Smarty') === 0) {
+                return true;
+            }
+
+            return false;
+        };
+
+        $this->assertTrue(Yii::autoload('SmartyFunctionMeta'));
+        $this->assertTrue(Yii::autoload('Smarty_Function_Meta'));
+    }
+
+    public function testAutoloaderForFunction()
+    {
+        function exampleFilter($className)
+        {
+            if (strpos($className, 'Zend') === 0) {
+                return true;
+            }
+
+            return false;
+        }
+
+        Yii::$autoloaderFilters['zend'] = 'exampleFilter';
+
+        $this->assertTrue(Yii::autoload('ZendFunctionMeta'));
+        $this->assertTrue(Yii::autoload('Zend_Function_Meta'));
+    }
+
+    public function testAutoloaderForStaticMethod()
+    {
+        eval('Class SmartyAutoloader {
+            public static function exampleFilter($className)
+            {
+                if (strpos($className, \'Smarty\') === 0) {
+                    return true;
+                }
+
+                return false;
+            }
+        }');
+
+
+        Yii::$autoloaderFilters['smarty2'] = array('SmartyAutoloader', 'exampleFilter');
+
+        $this->assertTrue(Yii::autoload('SmartyFunctionMeta'));
+        $this->assertTrue(Yii::autoload('Smarty_Function_Meta'));
+    }
+
+    public function testAutoloaderWithoutFilter()
+    {
+        Yii::$enableIncludePath = false;
+        $this->assertFalse(Yii::autoload('SomeClass'));
+        $this->assertTrue(Yii::autoload('Yii'));
+    }
+}

--- a/tests/framework/web/CHttpSessionTest.php
+++ b/tests/framework/web/CHttpSessionTest.php
@@ -14,8 +14,8 @@ class CHttpSessionTest extends CTestCase {
 	/**
 	 * @covers CHttpSession::getGCProbability
 	 * @covers CHttpSession::setGCProbability
-     *
-     * @runInSeparateProcess
+	 *
+	 * @runInSeparateProcess
 	 */
 	public function testSetGet() {
 		Yii::app()->setComponents(array('session' => array(

--- a/tests/framework/web/CHttpSessionTest.php
+++ b/tests/framework/web/CHttpSessionTest.php
@@ -14,6 +14,8 @@ class CHttpSessionTest extends CTestCase {
 	/**
 	 * @covers CHttpSession::getGCProbability
 	 * @covers CHttpSession::setGCProbability
+     *
+     * @runInSeparateProcess
 	 */
 	public function testSetGet() {
 		Yii::app()->setComponents(array('session' => array(
@@ -24,9 +26,10 @@ class CHttpSessionTest extends CTestCase {
 			'timeout' => 5,
 		)));
 		/** @var $sm CHttpSession */
-
 		$this->checkProb(1);
+
 		$this->checkProb(0);
+
 		$gcProb = 1.0;
 		while ($gcProb > 1 / 2147483647) {
 			$this->checkProb($gcProb);


### PR DESCRIPTION
Add filters  for YiiBase::autoloader autoloader that allows to skip autoloading for specific classes.

Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any



I will try to describe problem that i found in my project and I cannot fix it. 
I have legacy project in PHP5.6. This is enormous application. We cannot migrate to Yii2 at the moment.

I am trying to upgrade PHP to 7.2. We use Smarty 3.1.12 and it use a lot of deprecated and removed in php 7.2 stuff. I upgraded Smarty to 3.1.31(latest). 

We have got set YiiBase::$enableIncludePath to true in our project.
Smarty is extendable. Plugin for smarty is function. I use(https://github.com/yiiext/smarty-renderer). The latest version of smarty looking for a builtin class if it will find new tag in template file. If it not found it looking for a plugin function file. But if Smarty autoloader does not find plugin class Yii autoloader trying to find a class file. 

I will use example with plugin for meta tag {meta ...}
When YiiBase::$enableIncludePath === true autoloader throws error 
```
include(Smarty_Internal_Compile_Meta.php): failed to open stream: No such file or directory 
```

Second one solution is map all class for smarty via YiiBase::$classMap to existing file eg. yii.php. But it is awful solution (performance and code clean).

There are more info about problem. 
https://pastebin.com/RybZ0mdT

I belive a lot of people use Yii1.1 in their projects and it is hard do upgrade framework version to 2. We have upgrade php due to security issues, so my solution should be good way to avoid problem with autoloaders. In my code are not collistions with backward compability.


