### PR TITLE
Fix: wrong multiple selection when having string keys

### DIFF
--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2548,6 +2548,8 @@ EOD;
 			{
 				if(is_object($item))
 					$selection[$i]=$item->$key;
+				
+				$selection[$i] = (string)$selection[$i];
 			}
 		}
 		elseif(is_object($selection))
@@ -2555,6 +2557,8 @@ EOD;
 
 		foreach($listData as $key=>$value)
 		{
+			$key = (string)$key;
+			
 			if(is_array($value))
 			{
 				$content.='<optgroup label="'.($raw?$key : self::encode($key))."\">\n";


### PR DESCRIPTION
This fix applies only when listOptions() first argument $selection is an array. Single selection should be OK.

Example:

the array ["145" => "foo", "145B" => "bar"] will be converted by php to [145 => "foo", "145B" => "bar"]. 

If $selection is ["145B"] then both elements will be selected because PHP converted the array.

Note that this fix cannot be done by setting in_array's third argument to true (strict comparison) on line 2574 because the array keys are converted to integers by PHP and the $selection array values can be a strings.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -
