### PR TITLE
Fixed PHP 7.2 assert with string argument is deprecated warning using Gii

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Version 1.1.20 under development
 - Bug #4179: Fixed MariaDB 10.2 current_timestamp() (yaBliznyk)
 - Bug #4191: Fixed "Headers already sent." error in CHttpSession (daniel1302)
 - Bug #4191: Fixed "CHtml::value() behaves differently for objects" for PHP 7.2 (daniel1302)
+- Bug #4197: Fixed PHP 7.2 assert with string argument is deprecated warning using Gii (ThePepster)
 - Bug #4203: Fixed `CHttpCacheFilter::sendCacheControlHeader` PHP 7.2 compatibility (b1rdex)
 - Enh #4191: Added option for filter classes loaded by YiiBase autoloader (daniel1302)
 - Chg #4160: Updated HTMLPurifier to version 4.9.3 (takobell)

--- a/framework/gii/components/Pear/Text/Diff/Engine/native.php
+++ b/framework/gii/components/Pear/Text/Diff/Engine/native.php
@@ -332,9 +332,9 @@ class Text_Diff_Engine_native {
         $i = 0;
         $j = 0;
 
-        assert('count($lines) == count($changed)');
         $len = count($lines);
         $other_len = count($other_changed);
+        assert($len == $other_len);
 
         while (1) {
             /* Scan forward to find the beginning of another run of
@@ -353,7 +353,7 @@ class Text_Diff_Engine_native {
             }
 
             while ($i < $len && ! $changed[$i]) {
-                assert('$j < $other_len && ! $other_changed[$j]');
+                assert($j < $other_len && ! $other_changed[$j]);
                 $i++; $j++;
                 while ($j < $other_len && $other_changed[$j]) {
                     $j++;
@@ -385,11 +385,11 @@ class Text_Diff_Engine_native {
                     while ($start > 0 && $changed[$start - 1]) {
                         $start--;
                     }
-                    assert('$j > 0');
+                    assert($j > 0);
                     while ($other_changed[--$j]) {
                         continue;
                     }
-                    assert('$j >= 0 && !$other_changed[$j]');
+                    assert($j >= 0 && !$other_changed[$j]);
                 }
 
                 /* Set CORRESPONDING to the end of the changed run, at the
@@ -410,7 +410,7 @@ class Text_Diff_Engine_native {
                         $i++;
                     }
 
-                    assert('$j < $other_len && ! $other_changed[$j]');
+                    assert($j < $other_len && ! $other_changed[$j]);
                     $j++;
                     if ($j < $other_len && $other_changed[$j]) {
                         $corresponding = $i;
@@ -426,11 +426,11 @@ class Text_Diff_Engine_native {
             while ($corresponding < $i) {
                 $changed[--$start] = 1;
                 $changed[--$i] = 0;
-                assert('$j > 0');
+                assert($j > 0);
                 while ($other_changed[--$j]) {
                     continue;
                 }
-                assert('$j >= 0 && !$other_changed[$j]');
+                assert($j >= 0 && !$other_changed[$j]);
             }
         }
     }

--- a/framework/gii/components/Pear/Text/Diff/Engine/native.php
+++ b/framework/gii/components/Pear/Text/Diff/Engine/native.php
@@ -332,9 +332,9 @@ class Text_Diff_Engine_native {
         $i = 0;
         $j = 0;
 
+        assert(count($lines) == count($changed));
         $len = count($lines);
         $other_len = count($other_changed);
-        assert($len == $other_len);
 
         while (1) {
             /* Scan forward to find the beginning of another run of

--- a/framework/gii/components/Pear/Text/Diff/Engine/shell.php
+++ b/framework/gii/components/Pear/Text/Diff/Engine/shell.php
@@ -85,7 +85,7 @@ class Text_Diff_Engine_shell {
 
             if ($from_line_no < $match[1] || $to_line_no < $match[4]) {
                 // copied lines
-                assert('$match[1] - $from_line_no == $match[4] - $to_line_no');
+                assert($match[1] - $from_line_no == $match[4] - $to_line_no);
                 array_push($edits,
                     new Text_Diff_Op_copy(
                         $this->_getLines($from_lines, $from_line_no, $match[1] - 1),


### PR DESCRIPTION
Changed uses of assert with string arguments to expressions which fixes #4197

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | 4197
