### PR TITLE
Fixed: PHP 7.2 each() function in CTabView is deprecated #4199

### DIFF
--- a/framework/gii/components/Pear/Text/Diff/Engine/native.php
+++ b/framework/gii/components/Pear/Text/Diff/Engine/native.php
@@ -192,7 +192,9 @@ class Text_Diff_Engine_native {
                 }
                 $matches = $ymatches[$line];
                 reset($matches);
-                while (list(, $y) = each($matches)) {
+                foreach($matches as $match) {
+                    reset($match);
+                    $y = next($match);
                     if (empty($this->in_seq[$y])) {
                         $k = $this->_lcsPos($y);
                         assert($k > 0);
@@ -200,7 +202,9 @@ class Text_Diff_Engine_native {
                         break;
                     }
                 }
-                while (list(, $y) = each($matches)) {
+                foreach($matches as $match) {
+                    reset($match);
+                    $y = next($match);
                     if ($y > $this->seq[$k - 1]) {
                         assert($y <= $this->seq[$k]);
                         /* Optimization: this is a common case: next match is

--- a/framework/web/widgets/CTabView.php
+++ b/framework/web/widgets/CTabView.php
@@ -131,7 +131,7 @@ class CTabView extends CWidget
 		if($this->activeTab===null || !isset($this->tabs[$this->activeTab]))
 		{
 			reset($this->tabs);
-			list($this->activeTab, )=each($this->tabs);
+			$this->activeTab = current($this->tabs);
 		}
 
 		$htmlOptions=$this->htmlOptions;


### PR DESCRIPTION
- Fixed each usages in CTabView.php
- Fixed each usages in native.php

Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
