### PR TITLE
Fixed: activeTab was not selected in CTabView

### DIFF
--- a/framework/web/widgets/CTabView.php
+++ b/framework/web/widgets/CTabView.php
@@ -131,7 +131,7 @@ class CTabView extends CWidget
 		if($this->activeTab===null || !isset($this->tabs[$this->activeTab]))
 		{
 			reset($this->tabs);
-			$this->activeTab = current($this->tabs);
+			$this->activeTab = key($this->tabs);
 		}
 
 		$htmlOptions=$this->htmlOptions;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
