### PR TITLE
Fixed: PHP 7.2 sqlserver lastInsertId #4198

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,7 +14,7 @@ Version 1.1.20 under development
 - Bug #4203: Fixed `CHttpCacheFilter::sendCacheControlHeader` PHP 7.2 compatibility (b1rdex)
 - Enh #4191: Added option for filter classes loaded by YiiBase autoloader (daniel1302)
 - Chg #4160: Updated HTMLPurifier to version 4.9.3 (takobell)
-- Bug #4198: Fixed PHP 7.2 SQLSRV lastInsertId
+- Bug #4198: Fixed PHP 7.2 SQLSRV lastInsertId (agusdrs)
 
 Version 1.1.19 June 8, 2017
 ---------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ Version 1.1.20 under development
 - Bug #4203: Fixed `CHttpCacheFilter::sendCacheControlHeader` PHP 7.2 compatibility (b1rdex)
 - Enh #4191: Added option for filter classes loaded by YiiBase autoloader (daniel1302)
 - Chg #4160: Updated HTMLPurifier to version 4.9.3 (takobell)
+- Bug #4198: Fixed PHP 7.2 SQLSRV lastInsertId
 
 Version 1.1.19 June 8, 2017
 ---------------------------

--- a/framework/db/schema/mssql/CMssqlSqlsrvPdoAdapter.php
+++ b/framework/db/schema/mssql/CMssqlSqlsrvPdoAdapter.php
@@ -32,7 +32,7 @@ class CMssqlSqlsrvPdoAdapter extends PDO
 	 */
 	public function lastInsertId($sequence=null)
 	{
-		$sqlsrvVer = phpversion('pdo_sqlsrv') ? intval(explode('.', phpversion('pdo_sqlsrv'))[0]) : false;
+		$sqlsrvVer = phpversion('pdo_sqlsrv') ? intval(explode('.', phpversion('pdo_sqlsrv'))[0]) : 0;
 
 		if(!$sequence || $sqlsrvVer >= 5)
 			return parent::lastInsertId();

--- a/framework/db/schema/mssql/CMssqlSqlsrvPdoAdapter.php
+++ b/framework/db/schema/mssql/CMssqlSqlsrvPdoAdapter.php
@@ -20,16 +20,21 @@ class CMssqlSqlsrvPdoAdapter extends PDO
 {
 	/**
 	 * Returns last inserted ID value.
-	 * SQLSRV driver supports PDO::lastInsertId() with one peculiarity: when $sequence's value is null or empty
-	 * string it returns empty string. But when parameter is not specified at all it's working as expected
-	 * and returns actual last inserted ID (like other PDO drivers).
+	 * Before version 5.0, the SQLSRV driver supports PDO::lastInsertId() with one peculiarity: when $sequence's 
+	 * value is null or empty string it returns empty string. But when parameter is not specified at all it's working as 
+	 * expected and returns actual last inserted ID (like other PDO drivers).
+	 * Version 5.0 of the Microsoft PHP Drivers for SQL Server changes the behaviour of PDO::lastInsertID to be 
+	 * consistent with the behaviour outlined in the PDO documentation. It returns the ID of the 
+	 * last inserted sequence or row.
 	 *
-	 * @param string|null $sequence the sequence name. Defaults to null.
+	 * @param string|null $sequence the sequence/table name. Defaults to null.
 	 * @return integer last inserted ID value.
 	 */
 	public function lastInsertId($sequence=null)
 	{
-		if(!$sequence)
+		$sqlsrvVer = phpversion('pdo_sqlsrv') ? intval(explode('.', phpversion('pdo_sqlsrv'))[0]) : false;
+
+		if(!$sequence || $sqlsrvVer >= 5)
 			return parent::lastInsertId();
 		return parent::lastInsertId($sequence);
 	}


### PR DESCRIPTION
If SQLSRV version is >= 5 then the lastInsertId function will be called without parameters, maintaining the workaround for the old versions. 

Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #4198
