### PR TITLE
fix PHP 5.1 incomp. in CMssqlSqlsrvPdoAdapter caused by PHP 7.2 fix

### DIFF
--- a/framework/db/schema/mssql/CMssqlSqlsrvPdoAdapter.php
+++ b/framework/db/schema/mssql/CMssqlSqlsrvPdoAdapter.php
@@ -32,8 +32,8 @@ class CMssqlSqlsrvPdoAdapter extends PDO
 	 */
 	public function lastInsertId($sequence=null)
 	{
-		$tmp = explode('.', phpversion('pdo_sqlsrv'));
-		$sqlsrvVer = phpversion('pdo_sqlsrv') ? intval(array_shift($tmp)) : 0;
+		$parts = explode('.', phpversion('pdo_sqlsrv'));
+		$sqlsrvVer = phpversion('pdo_sqlsrv') ? intval(array_shift($parts)) : 0;
 
 		if(!$sequence || $sqlsrvVer >= 5)
 			return parent::lastInsertId();

--- a/framework/db/schema/mssql/CMssqlSqlsrvPdoAdapter.php
+++ b/framework/db/schema/mssql/CMssqlSqlsrvPdoAdapter.php
@@ -32,7 +32,8 @@ class CMssqlSqlsrvPdoAdapter extends PDO
 	 */
 	public function lastInsertId($sequence=null)
 	{
-		$sqlsrvVer = phpversion('pdo_sqlsrv') ? intval(explode('.', phpversion('pdo_sqlsrv'))[0]) : 0;
+		$tmp = explode('.', phpversion('pdo_sqlsrv'));
+		$sqlsrvVer = phpversion('pdo_sqlsrv') ? intval(array_shift($tmp)) : 0;
 
 		if(!$sequence || $sqlsrvVer >= 5)
 			return parent::lastInsertId();


### PR DESCRIPTION
not a PHP 7.2 fix per se, but the bug was introduced in #4198 (which fixed a PHP 7.2 issue)

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | <a href="https://github.com/yiisoft/yii/issues/4198#issuecomment-394151912">#4198 (comment)</a>
