### PR TITLE
Fix for PHP 7.2 incompatibility of count() in renderDynamic()

### DIFF
--- a/framework/yiilite.php
+++ b/framework/yiilite.php
@@ -3986,7 +3986,7 @@ class CController extends CBaseController
 	}
 	public function renderDynamic($callback)
 	{
-		$n=count($this->_dynamicOutput);
+		$n=($this->_dynamicOutput === null ? 0 : count($this->_dynamicOutput));
 		echo "<###dynamic-$n###>";
 		$params=func_get_args();
 		array_shift($params);


### PR DESCRIPTION
Fix for PHP 7.2 incompatibility of count() in renderDynamic(), file: `yiilite.php`

Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | -

Relevant `PR`: https://github.com/yiisoft/yii/pull/4204