### PR TITLE
WIP: Quick fix #4182 - mcrypt dependency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 Version 1.1.20 under development
 --------------------------------
 
-- Bug #4182: CSecurityManager requires mcrypt extension, and for PHP 7.2 we need to install it from pecl (sergey-dryabzhinsky)
+- Bug #4182: CSecurityManager requires mcrypt extension to work, and for PHP 7.2 we need to install it from pecl (sergey-dryabzhinsky)
 - Bug #4162: Adjusted Zend Escaper to be compatible with PHP <5.3 and fixed usage of non-existing Exceptions (cebe)
 - Bug #4167: Fixed PHP 7.2 incompatibility of "count()" in `CActiveFinder` and CController::renderDynamic() (softark, ThePepster)
 - Bug #4168: Fixed `CDbHttpSession` PHP 7.1 compatibility (csears123)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 Version 1.1.20 under development
 --------------------------------
 
+- Bug #4182: CSecurityManager requires mcrypt extension, and for PHP 7.2 we need to install it from pecl (sergey-dryabzhinsky)
 - Bug #4162: Adjusted Zend Escaper to be compatible with PHP <5.3 and fixed usage of non-existing Exceptions (cebe)
 - Bug #4167: Fixed PHP 7.2 incompatibility of "count()" in `CActiveFinder` and CController::renderDynamic() (softark, ThePepster)
 - Bug #4168: Fixed `CDbHttpSession` PHP 7.1 compatibility (csears123)

--- a/composer.json
+++ b/composer.json
@@ -73,8 +73,10 @@
 		]
 	},
 	"require": {
-		"php": ">=5.1.0",
-		"ext-mcrypt": "*"
+		"php": ">=5.1.0"
+	},
+	"suggest": {
+		"ext-mcrypt": "Required by encrypt and decrypt methods of CSecurityManager"
 	},
 	"autoload": {
 		"classmap" : [

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,8 @@
 		]
 	},
 	"require": {
-		"php": ">=5.1.0"
+		"php": ">=5.1.0",
+		"ext-mcrypt": "*"
 	},
 	"autoload": {
 		"classmap" : [


### PR DESCRIPTION
As of php-7.2 mcrypt extension moved to pecl.
But it's required to use CSecurityManager.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #4182
