### PR TITLE
Fix deprecation error in jquery3.x by not using shortcuts.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Version 1.1.21 under development
 --------------------------------
 
 - Bug #4220: Fixed PHP 7.2 incompatibility caused by the use of `create_function` in CHttpRequest (martinpetrasch)
+- Enh #4229: Remove deprecation errors from framework/web/js/source/jquery.yiiactiveform.js when using jQuery3.1.1
 
 Version 1.1.20 July 6, 2018
 ---------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ Version 1.1.21 under development
 --------------------------------
 
 - Bug #4220: Fixed PHP 7.2 incompatibility caused by the use of `create_function` in CHttpRequest (martinpetrasch)
-- Enh #4229: Remove deprecation errors from framework/web/js/source/jquery.yiiactiveform.js when using jQuery3.1.1
+- Bug #4229: Remove deprecation errors from framework/web/js/source/jquery.yiiactiveform.js when using jQuery 3.1.1 (kenguest)
 
 Version 1.1.20 July 6, 2018
 ---------------------------

--- a/framework/web/js/source/jquery.yiiactiveform.js
+++ b/framework/web/js/source/jquery.yiiactiveform.js
@@ -110,9 +110,9 @@
 
 			$.each(settings.attributes, function (i, attribute) {
 				if (this.validateOnChange) {
-					$form.find('#' + this.inputID).change(function () {
+					$form.find('#' + this.inputID).on('change', function () {
 						validate(attribute, false);
-					}).blur(function () {
+					}).on('blur', function () {
 						if (attribute.status !== 2 && attribute.status !== 3) {
 							validate(attribute, !attribute.status);
 						}
@@ -132,7 +132,7 @@
 					$form.data('submitObject', $(this));
 				});
 				var validated = false;
-				$form.submit(function () {
+				$form.on('submit', function () {
 					if (validated) {
 						validated = false;
 						return true;
@@ -154,9 +154,9 @@
 									var $button = $form.data('submitObject') || $form.find(':submit:first');
 									// TODO: if the submission is caused by "change" event, it will not work
 									if ($button.length) {
-										$button.click();
+										$button.trigger('click');
 									} else {  // no submit button in the form
-										$form.submit();
+										$form.trigger('submit');
 									}
 									return;
 								}
@@ -209,7 +209,7 @@
 					$('#' + settings.summaryID).hide().find('ul').html('');
 					//.. set to initial focus on reset
 					if (settings.focus !== undefined && !window.location.hash) {
-						$form.find(settings.focus).focus();
+						$form.find(settings.focus).trigger('focus');
 					}
 				}, 1);
 			});
@@ -218,7 +218,7 @@
 			 * set to initial focus
 			 */
 			if (settings.focus !== undefined && !window.location.hash) {
-				$form.find(settings.focus).focus();
+				$form.find(settings.focus).trigger('focus');
 			}
 		});
 	};


### PR DESCRIPTION
remove deprecation errors from framework/web/js/source/jquery.yiiactiveform.js  when using jQuery3.1.1

jquery.yiiactiveform.js has some issues in it that are highlighted when using jquery3.1.1 instead of old jquery1.12.4 library. 

Important as there are security issues in 1.12.4.

This PR fixes them.