### PR TITLE
Change to support SQL server functions as default values

### DIFF
--- a/framework/db/schema/mssql/CMssqlColumnSchema.php
+++ b/framework/db/schema/mssql/CMssqlColumnSchema.php
@@ -27,9 +27,10 @@ class CMssqlColumnSchema extends CDbColumnSchema
 	 */
 	public function init($dbType, $defaultValue)
 	{
-		if ($defaultValue=='(NULL)')
+		// Also check if $defaultValue is one of known Mssql functions
+		if ($defaultValue=='(NULL)' || in_array(str_replace(array('(', ')'), '', $defaultValue), ['getdate', 'sysdatetime'])!==false)
 		{
-			$defaultValue=null;
+		    $defaultValue=null;
 		}
 		parent::init($dbType, $defaultValue);
 	}


### PR DESCRIPTION
SQL server functions was being cast to string, inserting string 'getdate' into date/datetime columns.
The expected behavior is to framework set column to NULL and database runs SQL Server function present in default column value.