### PR TITLE
Update CJavaScript::quote to accept null value. Backward compatibility change.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ Version 1.1.21 under development
 - Bug #4229: Remove deprecation errors from framework/web/js/source/jquery.yiiactiveform.js when using jQuery 3.1.1 (kenguest)
 - Bug #4234: CVE-2018-14773. Drop support for HTTP_X_REWRITE_URL (kenguest)
 - Chg #4236: Freeze session before changing ini settings to be compatible with PHP 7.2 (vxk7m)
+- Bug #4238: Fixed intolerance to nulls in `CJavaScript::quote()` (stevoh6, ddziaduch)
 
 Version 1.1.20 July 6, 2018
 ---------------------------

--- a/framework/web/helpers/CJavaScript.php
+++ b/framework/web/helpers/CJavaScript.php
@@ -21,7 +21,7 @@ class CJavaScript
 	 * Quotes a javascript string.
 	 * After processing, the string can be safely enclosed within a pair of
 	 * quotation marks and serve as a javascript string.
-	 * @param null|string $js string to be quoted
+	 * @param string $js string to be quoted
 	 * @param boolean $forUrl whether this string is used as a URL
 	 * @return string the quoted string
 	 */

--- a/framework/web/helpers/CJavaScript.php
+++ b/framework/web/helpers/CJavaScript.php
@@ -25,18 +25,19 @@ class CJavaScript
 	 * @param boolean $forUrl whether this string is used as a URL
 	 * @return null|string the quoted string
 	 */
-	public static function quote($js,$forUrl=false)
+        public static function quote($js,$forUrl=false)
 	{
-		if ($js === null) { // backward compability before Yii 1.1.20
-			return $js;
-		}
+		if($js===null)
+		{
+			return null;
+                }
 		
-        Yii::import('system.vendors.zend-escaper.Escaper');
-        $escaper=new Escaper(Yii::app()->charset);
-        if($forUrl)
-            return $escaper->escapeUrl($js);
-        else
-            return $escaper->escapeJs($js);
+		Yii::import('system.vendors.zend-escaper.Escaper');
+		$escaper=new Escaper(Yii::app()->charset);
+		if($forUrl)
+			return $escaper->escapeUrl($js);
+		else
+			return $escaper->escapeJs($js);
 	}
 
 	/**

--- a/framework/web/helpers/CJavaScript.php
+++ b/framework/web/helpers/CJavaScript.php
@@ -23,12 +23,11 @@ class CJavaScript
 	 * quotation marks and serve as a javascript string.
 	 * @param null|string $js string to be quoted
 	 * @param boolean $forUrl whether this string is used as a URL
-	 * @return null|string the quoted string
+	 * @return string the quoted string
 	 */
         public static function quote($js,$forUrl=false)
 	{
-		if($js===null)
-			return null;
+		$js = (string)$js;
 		
 		Yii::import('system.vendors.zend-escaper.Escaper');
 		$escaper=new Escaper(Yii::app()->charset);

--- a/framework/web/helpers/CJavaScript.php
+++ b/framework/web/helpers/CJavaScript.php
@@ -28,9 +28,7 @@ class CJavaScript
         public static function quote($js,$forUrl=false)
 	{
 		if($js===null)
-		{
 			return null;
-                }
 		
 		Yii::import('system.vendors.zend-escaper.Escaper');
 		$escaper=new Escaper(Yii::app()->charset);

--- a/framework/web/helpers/CJavaScript.php
+++ b/framework/web/helpers/CJavaScript.php
@@ -25,7 +25,7 @@ class CJavaScript
 	 * @param boolean $forUrl whether this string is used as a URL
 	 * @return string the quoted string
 	 */
-        public static function quote($js,$forUrl=false)
+	public static function quote($js,$forUrl=false)
 	{
 		$js = (string)$js;
 		

--- a/framework/web/helpers/CJavaScript.php
+++ b/framework/web/helpers/CJavaScript.php
@@ -21,12 +21,16 @@ class CJavaScript
 	 * Quotes a javascript string.
 	 * After processing, the string can be safely enclosed within a pair of
 	 * quotation marks and serve as a javascript string.
-	 * @param string $js string to be quoted
+	 * @param null|string $js string to be quoted
 	 * @param boolean $forUrl whether this string is used as a URL
-	 * @return string the quoted string
+	 * @return null|string the quoted string
 	 */
 	public static function quote($js,$forUrl=false)
 	{
+		if ($js === null) { // backward compability before Yii 1.1.20
+			return $js;
+		}
+		
         Yii::import('system.vendors.zend-escaper.Escaper');
         $escaper=new Escaper(Yii::app()->charset);
         if($forUrl)

--- a/tests/framework/web/helpers/CJavaScriptTest.php
+++ b/tests/framework/web/helpers/CJavaScriptTest.php
@@ -47,7 +47,7 @@ class CJavaScriptTest extends CTestCase
     {
         $input=null;
         $output=CJavaScript::quote($input);
-        $this->assertEquals('',$output);
+        $this->assertSame('',$output);
     }
 	
 }

--- a/tests/framework/web/helpers/CJavaScriptTest.php
+++ b/tests/framework/web/helpers/CJavaScriptTest.php
@@ -43,7 +43,7 @@ class CJavaScriptTest extends CTestCase
         $this->assertEquals('test%20%E2%80%A8%0Atest%20%E2%80%A9',$output);
     }
 	
-	public function testQuoteWithNull()
+    public function testQuoteWithNull()
     {
         $input=null;
         $output=CJavaScript::quote($input);

--- a/tests/framework/web/helpers/CJavaScriptTest.php
+++ b/tests/framework/web/helpers/CJavaScriptTest.php
@@ -42,4 +42,12 @@ class CJavaScriptTest extends CTestCase
         $output=CJavaScript::quote($input,true);
         $this->assertEquals('test%20%E2%80%A8%0Atest%20%E2%80%A9',$output);
     }
+	
+	public function testQuoteWithNull()
+    {
+        $input=null;
+        $output=CJavaScript::quote($input);
+        $this->assertEquals('',$output);
+    }
+	
 }


### PR DESCRIPTION
Add backward compatibility to do not escape null value. As it was before Yii 1.1.20

Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #4238
