### PR TITLE
YiiBase::autoload should not try to include() missing files

### DIFF
--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -460,7 +460,12 @@ class YiiBase
 					}
 				}
 				else
-					include($className.'.php');
+				{
+					if(is_file($className.'.php'))
+						include($className.'.php');
+					else
+						return false;
+				}
 			}
 			else  // class name with namespace in PHP 5.3
 			{


### PR DESCRIPTION
Make sure autoloading does not try to load files that do not exist. Else it'll cause intermittent warnings.

Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | n/a
