### PR TITLE
Add `phpseclib/mcrypt_compat` polyfill as `require-dev`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
 	"require-dev": {
 		"phpunit/phpunit": "~4.8.34",
 		"phpunit/phpunit-selenium": "~1.4.0",
-		"phing/phing": "2.*"
+		"phing/phing": "2.*",
+		"phpseclib/mcrypt_compat": "^1.0"
 	}
 }


### PR DESCRIPTION
Ref #4232

Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | CI will check
| Fixed issues  | 4232
