### PR TITLE
Fixes yiisoft#4227: Fixed incompatibility with PHPUnit6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ Version 1.1.21 under development
 - Bug #4234: CVE-2018-14773. Drop support for HTTP_X_REWRITE_URL (kenguest)
 - Chg #4236: Freeze session before changing ini settings to be compatible with PHP 7.2 (vxk7m)
 - Bug #4238: Fixed intolerance to nulls in `CJavaScript::quote()` (stevoh6, ddziaduch)
+- Enh #4227: Fixed PHPUnit 6 compatibility (gianniszach)
 
 Version 1.1.20 July 6, 2018
 ---------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ Version 1.1.21 under development
 - Bug #4234: CVE-2018-14773. Drop support for HTTP_X_REWRITE_URL (kenguest)
 - Chg #4236: Freeze session before changing ini settings to be compatible with PHP 7.2 (vxk7m)
 - Bug #4238: Fixed intolerance to nulls in `CJavaScript::quote()` (stevoh6, ddziaduch)
-- Enh #4227: Fixed PHPUnit 6 compatibility (gianniszach)
+- Bug #4227: Fixed PHPUnit 6 compatibility (gianniszach)
 
 Version 1.1.20 July 6, 2018
 ---------------------------

--- a/tests/compatibility.php
+++ b/tests/compatibility.php
@@ -12,3 +12,8 @@ if(!class_exists('PHPUnit_Framework_TestCase') && class_exists('PHPUnit\Framewor
 {
     abstract class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
 }
+
+if(!class_exists('PHPUnit_Runner_Version') && class_exists('PHPUnit\Runner\Version'))
+{
+    abstract class PHPUnit_Runner_Version extends \PHPUnit\Runner\Version {}
+}


### PR DESCRIPTION
Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | #4227
