### PR TITLE
don't call afterDelete when delete failed

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -1228,7 +1228,8 @@ abstract class CActiveRecord extends CModel
 			if($this->beforeDelete())
 			{
 				$result=$this->deleteByPk($this->getPrimaryKey())>0;
-				$this->afterDelete();
+				if($result)
+					$this->afterDelete();
 				return $result;
 			}
 			else


### PR DESCRIPTION
when catch delete exception (fk, etc...) and return rowsCount=0 afterDelete still calling

Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
