### PR TITLE
Fix limit = NULL

### DIFF
--- a/framework/db/schema/CDbCommandBuilder.php
+++ b/framework/db/schema/CDbCommandBuilder.php
@@ -510,7 +510,7 @@ class CDbCommandBuilder extends CComponent
 	 */
 	public function applyLimit($sql,$limit,$offset)
 	{
-		if($limit>=0)
+		if($limit>0)
 			$sql.=' LIMIT '.(int)$limit;
 		if($offset>0)
 			$sql.=' OFFSET '.(int)$offset;


### PR DESCRIPTION
I have block `SELECT 0` on $limit=null.

Actual: SELECT ... LIMIT 0
Expected: SELECT ...

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
