### PR TITLE
4269 bind values null

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Version 1.1.22 under development
 
 - Bug #4256: PHP 7 compatibility issues: PHP4 style constructor in Pear/Text/Diff3.php (kenguest)
 - Bug #4261: PHP 7.2 compatibility issues: INTL_IDNA_VARIANT_2003 has been depreacated (machour)
+- Bug #4269: PHP 7.2 compatibility issues: bindValues() not defaulting to array when null causing error with count() (krunder)
 
 Version 1.1.21 April 2, 2019
 ----------------------------

--- a/framework/db/schema/CDbCommandBuilder.php
+++ b/framework/db/schema/CDbCommandBuilder.php
@@ -552,7 +552,7 @@ class CDbCommandBuilder extends CComponent
 	 */
 	public function bindValues($command, $values)
 	{
-        $values = is_array($values) ? $values : [];
+	    $values = is_array($values) ? $values : [];
 
 		if(($n=count($values))===0)
 			return;

--- a/framework/db/schema/CDbCommandBuilder.php
+++ b/framework/db/schema/CDbCommandBuilder.php
@@ -552,7 +552,7 @@ class CDbCommandBuilder extends CComponent
 	 */
 	public function bindValues($command, $values)
 	{
-	    $values = is_array($values) ? $values : [];
+		$values = is_array($values) ? $values : [];
 
 		if(($n=count($values))===0)
 			return;

--- a/framework/db/schema/CDbCommandBuilder.php
+++ b/framework/db/schema/CDbCommandBuilder.php
@@ -552,6 +552,8 @@ class CDbCommandBuilder extends CComponent
 	 */
 	public function bindValues($command, $values)
 	{
+        $values = is_array($values) ? $values : [];
+
 		if(($n=count($values))===0)
 			return;
 		if(isset($values[0])) // question mark placeholders


### PR DESCRIPTION
PHP 7.2 compatibility issues: bindValues() not defaulting to array when null causing error with count().

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #4269 
