### PR TITLE
Trim namespace separators before checking string

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Version 1.1.22 under development
 
 - Bug #4256: PHP 7 compatibility issues: PHP4 style constructor in Pear/Text/Diff3.php (kenguest)
 - Bug #4261: PHP 7.2 compatibility issues: INTL_IDNA_VARIANT_2003 has been depreacated (machour)
+- Chg #4274: PHP 7.2 compatibility issues: Autoloader failing with third-party libraries using PSR-0 namespaces with a `\` prefix.
 
 Version 1.1.21 April 2, 2019
 ----------------------------

--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -440,7 +440,8 @@ class YiiBase
 		else
 		{
 			// include class file relying on include_path
-			if(strpos($className,'\\')===false)  // class without namespace
+			$trimmedClassName = ltrim($className, '\\');
+			if(strpos($trimmedClassName,'\\')===false)  // class without namespace
 			{
 				if(self::$enableIncludePath===false)
 				{


### PR DESCRIPTION
See https://github.com/paragonie/sodium_compat/issues/105

Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
