### PR TITLE
add php 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 dist: trusty
 
 php:
+  - 7.4snapshot
   - 7.3
   - 7.2
   - 7.1
@@ -50,7 +51,7 @@ cache:
 install:
   - travis_retry composer self-update && composer --version
   - travis_retry composer update --prefer-dist --no-interaction
-  - if [[ $TRAVIS_PHP_VERSION == 7.2 ]] || [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+  - if [[ $TRAVIS_PHP_VERSION == 7.2 ]] || [[ $TRAVIS_PHP_VERSION == "7.4snapshot" ]] || [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
         printf "autodetect\n" | pecl install mcrypt-snapshot;
     fi
 
@@ -58,7 +59,7 @@ before_script:
   # Disable the HHVM JIT for faster Unit Testing
   - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini; fi
   # Disable DEPRECATE messages during PHPUnit initialization on PHP>=7.2. To fix them, PHPUnit should be updated to 6.*
-  - if [[ $TRAVIS_PHP_VERSION == 7.2 ]] || [[ $TRAVIS_PHP_VERSION == 7.3 ]] || [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+  - if [[ $TRAVIS_PHP_VERSION == 7.2 ]] || [[ $TRAVIS_PHP_VERSION == 7.3 ]] || [[ $TRAVIS_PHP_VERSION == "nightly" ]] || [[ $TRAVIS_PHP_VERSION == "7.4snapshot" ]]; then
       echo 'Disabled DEPRECATED notifications for PHP>=7.2';
       echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> /tmp/php-config.ini;
       phpenv config-add /tmp/php-config.ini;

--- a/tests/travis/memcache-setup.sh
+++ b/tests/travis/memcache-setup.sh
@@ -2,7 +2,7 @@
 
 if (php --version | grep -i HipHop > /dev/null); then
   echo "skipping memcache on HHVM"
-elif [ $(phpenv version-name) = "7.0" ] || [ $(phpenv version-name) = "7.1" ] || [ $(phpenv version-name) = "7.2" ] || [ $(phpenv version-name) = "7.3" ] || [ $(phpenv version-name) = "nightly" ]; then
+elif [ $(phpenv version-name) = "7.0" ] || [ $(phpenv version-name) = "7.1" ] || [ $(phpenv version-name) = "7.2" ] || [ $(phpenv version-name) = "7.3" ] || [ $(phpenv version-name) = "7.4snapshot" ] || [ $(phpenv version-name) = "nightly" ]; then
   echo "skipping memcache on php 7"
 else
   mkdir -p ~/.phpenv/versions/$(phpenv version-name)/etc


### PR DESCRIPTION
I am preparing this PR. phpenv does not want to install 7.4 currently, so I'll wait until it does.

If you have any additions for PHP 7.4 support, feel free.

The amount of skipped tests intrigues me a bit. Are they all ok?

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
