### PR TITLE
Fix #4291: The scheme(protocol) is deleted when validateIDN is enabled after validation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 Version 1.1.23 under development
 --------------------------------
 
-no changes yet.
+- Bug #4291: The scheme (protocol) is deleted when validateIDN is enabled after validation (Argevollen)
 
 Version 1.1.22 January 16, 2020
 -------------------------------

--- a/framework/validators/CUrlValidator.php
+++ b/framework/validators/CUrlValidator.php
@@ -210,7 +210,7 @@ if(jQuery.trim(value)!='') {
 				}
 				else
 				{
-					$value=idn_to_utf8($matches[2][0]);
+					$value.=idn_to_utf8($matches[2][0]);
 				}
 				$value.=$matches[3][0];
 			}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #4291
