### PR TITLE
In Postgresql 12 pg_attrdev.adsrc column is removed (https://www.post…

### DIFF
--- a/framework/db/schema/pgsql/CPgsqlSchema.php
+++ b/framework/db/schema/pgsql/CPgsqlSchema.php
@@ -166,7 +166,7 @@ class CPgsqlSchema extends CDbSchema
 	protected function findColumns($table)
 	{
 		$sql=<<<EOD
-SELECT a.attname, LOWER(format_type(a.atttypid, a.atttypmod)) AS type, d.adsrc, a.attnotnull, a.atthasdef,
+SELECT a.attname, LOWER(format_type(a.atttypid, a.atttypmod)) AS type, pg_get_expr(d.adbin, d.adrelid) as adsrc, a.attnotnull, a.atthasdef,
 	pg_catalog.col_description(a.attrelid, a.attnum) AS comment
 FROM pg_attribute a LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
 WHERE a.attnum > 0 AND NOT a.attisdropped
@@ -228,11 +228,7 @@ EOD;
 SELECT conname, consrc, contype, indkey FROM (
 	SELECT
 		conname,
-		CASE WHEN contype='f' THEN
-			pg_catalog.pg_get_constraintdef(oid)
-		ELSE
-			'CHECK (' || consrc || ')'
-		END AS consrc,
+		pg_catalog.pg_get_constraintdef(oid) AS consrc,
 		contype,
 		conrelid AS relid,
 		NULL AS indkey


### PR DESCRIPTION
…gresql.org/docs/12/release-12.html): This column has been deprecated for a long time, because it did not update in response to other catalog changes (such as column renamings). The recommended way to get a text version of a default-value expression from pg_attrdef is pg_get_expr(adbin, adrelid).

<!--
Note that only PHP 7 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | don't know
| Tests pass?   | ✔️
| Fixed issues  | #4294
