### PR TITLE
Add PostgreSQL 12 support, rel #4294

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 Version 1.1.23 under development
 --------------------------------
 
+- Enh #4294: Add PostgreSQL 12 support (bio)
 - Bug #4291: The scheme (protocol) is deleted when validateIDN is enabled after validation (Argevollen)
 
 Version 1.1.22 January 16, 2020

--- a/framework/db/schema/pgsql/CPgsqlSchema.php
+++ b/framework/db/schema/pgsql/CPgsqlSchema.php
@@ -165,13 +165,13 @@ class CPgsqlSchema extends CDbSchema
 	 */
 	protected function findColumns($table)
 	{
-        $serverVersion = $this->getDbConnection()->getServerVersion();
-        $columnDefValue = version_compare($serverVersion, '12.0', '<')
-            ? 'd.adsrc' : 'CAST(pg_get_expr(d.adbin, d.adrelid) AS varchar)';
+		$serverVersion = $this->getDbConnection()->getServerVersion();
+		$columnDefValue = version_compare($serverVersion, '12.0', '<')
+			? 'd.adsrc' : 'CAST(pg_get_expr(d.adbin, d.adrelid) AS varchar)';
 
 		$sql=<<<EOD
 SELECT a.attname, LOWER(format_type(a.atttypid, a.atttypmod)) AS type,
-    {$columnDefValue} AS column_def_value, a.attnotnull, a.atthasdef,
+	{$columnDefValue} AS column_def_value, a.attnotnull, a.atthasdef,
 	pg_catalog.col_description(a.attrelid, a.attnum) AS comment
 FROM pg_attribute a LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
 WHERE a.attnum > 0 AND NOT a.attisdropped
@@ -218,8 +218,7 @@ EOD;
 		$c->isForeignKey=false;
 		$c->comment=$column['comment']===null ? '' : $column['comment'];
 
-        $c->init($column['type'],$column['atthasdef']
-            ? $column['column_def_value'] : null);
+		$c->init($column['type'],$column['atthasdef'] ? $column['column_def_value'] : null);
 
 		return $c;
 	}
@@ -230,9 +229,9 @@ EOD;
 	 */
 	protected function findConstraints($table)
 	{
-        $serverVersion = $this->getDbConnection()->getServerVersion();
-        $checkExpr = version_compare($serverVersion, '12.0', '<')
-            ? 'consrc' : 'conbin';
+		$serverVersion = $this->getDbConnection()->getServerVersion();
+		$checkExpr = version_compare($serverVersion, '12.0', '<')
+			? 'consrc' : 'conbin';
 
 		$sql=<<<EOD
 SELECT conname, check_constr_definition, contype, indkey FROM (

--- a/framework/db/schema/pgsql/CPgsqlSchema.php
+++ b/framework/db/schema/pgsql/CPgsqlSchema.php
@@ -165,8 +165,13 @@ class CPgsqlSchema extends CDbSchema
 	 */
 	protected function findColumns($table)
 	{
+        $serverVersion = $this->getDbConnection()->getServerVersion();
+        $columnDefValue = version_compare($serverVersion, '12.0', '<')
+            ? 'd.adsrc' : 'CAST(pg_get_expr(d.adbin, d.adrelid) AS varchar)';
+
 		$sql=<<<EOD
-SELECT a.attname, LOWER(format_type(a.atttypid, a.atttypmod)) AS type, d.adsrc, a.attnotnull, a.atthasdef,
+SELECT a.attname, LOWER(format_type(a.atttypid, a.atttypmod)) AS type,
+    {$columnDefValue} AS column_def_value, a.attnotnull, a.atthasdef,
 	pg_catalog.col_description(a.attrelid, a.attnum) AS comment
 FROM pg_attribute a LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
 WHERE a.attnum > 0 AND NOT a.attisdropped
@@ -186,7 +191,7 @@ EOD;
 			$c=$this->createColumn($column);
 			$table->columns[$c->name]=$c;
 
-			if(stripos($column['adsrc'],'nextval')===0 && preg_match('/nextval\([^\']*\'([^\']+)\'[^\)]*\)/i',$column['adsrc'],$matches))
+			if(stripos($column['column_def_value'],'nextval')===0 && preg_match('/nextval\([^\']*\'([^\']+)\'[^\)]*\)/i',$column['column_def_value'],$matches))
 			{
 				if(strpos($matches[1],'.')!==false || $table->schemaName===self::DEFAULT_SCHEMA)
 					$this->_sequences[$table->rawName.'.'.$c->name]=$matches[1];
@@ -213,7 +218,8 @@ EOD;
 		$c->isForeignKey=false;
 		$c->comment=$column['comment']===null ? '' : $column['comment'];
 
-		$c->init($column['type'],$column['atthasdef'] ? $column['adsrc'] : null);
+        $c->init($column['type'],$column['atthasdef']
+            ? $column['column_def_value'] : null);
 
 		return $c;
 	}
@@ -224,15 +230,19 @@ EOD;
 	 */
 	protected function findConstraints($table)
 	{
+        $serverVersion = $this->getDbConnection()->getServerVersion();
+        $checkExpr = version_compare($serverVersion, '12.0', '<')
+            ? 'consrc' : 'conbin';
+
 		$sql=<<<EOD
-SELECT conname, consrc, contype, indkey FROM (
+SELECT conname, check_constr_definition, contype, indkey FROM (
 	SELECT
 		conname,
 		CASE WHEN contype='f' THEN
 			pg_catalog.pg_get_constraintdef(oid)
 		ELSE
-			'CHECK (' || consrc || ')'
-		END AS consrc,
+			'CHECK (' || {$checkExpr} || ')'
+		END AS check_constr_definition,
 		contype,
 		conrelid AS relid,
 		NULL AS indkey
@@ -274,7 +284,7 @@ EOD;
 			if($row['contype']==='p') // primary key
 				$this->findPrimaryKey($table,$row['indkey']);
 			elseif($row['contype']==='f') // foreign key
-				$this->findForeignKey($table,$row['consrc']);
+				$this->findForeignKey($table,$row['check_constr_definition']);
 		}
 	}
 


### PR DESCRIPTION
Add PostgreSQL 12 support.

From PostgreSQL 12 [changelog](https://www.postgresql.org/docs/release/12.0/):
- Remove obsolete pg_constraint.consrc column (Peter Eisentraut)
- Remove obsolete pg_attrdef.adsrc column (Peter Eisentraut)

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #4294
