### PR TITLE
add session_set_cookie_params samesite option for PHP 7.3 compatibility

### DIFF
--- a/framework/web/CHttpSession.php
+++ b/framework/web/CHttpSession.php
@@ -241,7 +241,7 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 	 * The effect of this method only lasts for the duration of the script.
 	 * Call this method before the session starts.
 	 * @param array $value cookie parameters, valid keys include: lifetime, path,
-	 * domain, secure, httponly. Note that httponly is all lowercase.
+	 * domain, secure, httponly, samesite. Note that httponly and samesite is all lowercase.
 	 * @see http://us2.php.net/manual/en/function.session-set-cookie-params.php
 	 */
 	public function setCookieParams($value)
@@ -250,7 +250,17 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 		extract($data);
 		extract($value);
 		$this->freeze();
-		if(isset($httponly))
+		if(isset($httponly) && isset($sameSite))
+		if(version_compare(PHP_VERSION,'7.3.0','>='))
+			session_set_cookie_params(['lifetime'=>$lifetime,'path'=>$path,'domain'=>$domain,'secure'=>$secure,'httponly'=>$httponly,'samesite'=>$samesite]);
+		else
+		{
+			// Work around for setting sameSite cookie prior PHP 7.3
+			// https://stackoverflow.com/questions/39750906/php-setcookie-samesite-strict/46971326#46971326
+			$path .= '; samesite=' . $sameSite;
+			session_set_cookie_params($lifetime,$path,$domain,$secure,$httponly);
+		}
+		else if(isset($httponly))
 			session_set_cookie_params($lifetime,$path,$domain,$secure,$httponly);
 		else
 			session_set_cookie_params($lifetime,$path,$domain,$secure);


### PR DESCRIPTION

In PHP 7.3 the [session_set_cookie_params](https://www.php.net/manual/en/function.session-set-cookie-params.php) function had the following change:

> 7.3.0 | An alternative signature supporting an options array has been added. **This signature supports also setting of the `SameSite` cookie attribute**.

This PR bring Yii up to date for PHP 7.3. This PR is a follow-up to https://github.com/yiisoft/yii/pull/4275 (_add setcookie $options for PHP 7.3 compatibility_)


| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️

