### PR TITLE
port code from yii2 handling memcached issue, related to use of unix timestamp

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@ Version 1.1.23 under development
 - Bug #4291: The scheme (protocol) is deleted when validateIDN is enabled after validation (Argevollen)
 - Bug: Fix CFileHelper::findFiles() to use correct directory separator under Windows (samdark)
 - Bug #4306: Add PHP 8 support (samdark)
-- Bug #4310: Items on memcache won't expire due to memcache difference in internal clock. Port code from yii2 (nikolasr200)
+- Bug #4310: Items on memcache won't expire due to memcache difference in internal clock (nikolasr200)
 
 Version 1.1.22 January 16, 2020
 -------------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ Version 1.1.23 under development
 - Bug #4291: The scheme (protocol) is deleted when validateIDN is enabled after validation (Argevollen)
 - Bug: Fix CFileHelper::findFiles() to use correct directory separator under Windows (samdark)
 - Bug #4306: Add PHP 8 support (samdark)
+- Bug #4310: Items on memcache won't expire due to memcache difference in internal clock. Port code from yii2 (nikolasr200)
 
 Version 1.1.22 January 16, 2020
 -------------------------------


### PR DESCRIPTION
There is an issue with Yii1 and memcached that has already been addressed in yii2. The issue is related to internal memcached clock and how the use of unix timestamp in small expiration examples, doesn't expire the cached items as expected.

<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
