### PR TITLE
Set composer branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,9 @@
 		"pear/archive_tar": "~1.4.6"
 	},
 	"extra": {
+		"branch-alias": {
+			"dev-master": "1.1.x-dev"
+		},
 		"composer-exit-on-patch-failure": true,
 		"patches": {
 			"phpunit/phpunit-mock-objects": {


### PR DESCRIPTION
This allows you to do: `composer require yiisoft/yii ~1.1@dev`

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
