### PR TITLE
Allow setting samesite correctly when calling setCookieParams()

### DIFF
--- a/framework/web/CHttpSession.php
+++ b/framework/web/CHttpSession.php
@@ -251,14 +251,16 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 		extract($value);
 		$this->freeze();
 		if(isset($httponly) && isset($samesite))
-		if(version_compare(PHP_VERSION,'7.3.0','>='))
-			session_set_cookie_params(array('lifetime'=>$lifetime,'path'=>$path,'domain'=>$domain,'secure'=>$secure,'httponly'=>$httponly,'samesite'=>$samesite));
-		else
 		{
-			// Work around for setting sameSite cookie prior PHP 7.3
-			// https://stackoverflow.com/questions/39750906/php-setcookie-samesite-strict/46971326#46971326
-			$path .= '; samesite=' . $samesite;
-			session_set_cookie_params($lifetime,$path,$domain,$secure,$httponly);
+			if(version_compare(PHP_VERSION,'7.3.0','>='))
+				session_set_cookie_params(array('lifetime'=>$lifetime,'path'=>$path,'domain'=>$domain,'secure'=>$secure,'httponly'=>$httponly,'samesite'=>$samesite));
+			else
+			{
+				// Work around for setting sameSite cookie prior PHP 7.3
+				// https://stackoverflow.com/questions/39750906/php-setcookie-samesite-strict/46971326#46971326
+				$path .= '; samesite=' . $samesite;
+				session_set_cookie_params($lifetime,$path,$domain,$secure,$httponly);
+			}
 		}
 		else if(isset($httponly))
 			session_set_cookie_params($lifetime,$path,$domain,$secure,$httponly);

--- a/framework/web/CHttpSession.php
+++ b/framework/web/CHttpSession.php
@@ -250,14 +250,14 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 		extract($data);
 		extract($value);
 		$this->freeze();
-		if(isset($httponly) && isset($sameSite))
+		if(isset($httponly) && isset($samesite))
 		if(version_compare(PHP_VERSION,'7.3.0','>='))
 			session_set_cookie_params(array('lifetime'=>$lifetime,'path'=>$path,'domain'=>$domain,'secure'=>$secure,'httponly'=>$httponly,'samesite'=>$samesite));
 		else
 		{
 			// Work around for setting sameSite cookie prior PHP 7.3
 			// https://stackoverflow.com/questions/39750906/php-setcookie-samesite-strict/46971326#46971326
-			$path .= '; samesite=' . $sameSite;
+			$path .= '; samesite=' . $samesite;
 			session_set_cookie_params($lifetime,$path,$domain,$secure,$httponly);
 		}
 		else if(isset($httponly))


### PR DESCRIPTION
Fixes bug introduced in #4308 (https://github.com/yiisoft/yii/pull/4308#pullrequestreview-479712334)

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️