### PR TITLE
Set default value to None on sameSite

### DIFF
--- a/framework/web/CHttpCookie.php
+++ b/framework/web/CHttpCookie.php
@@ -80,9 +80,10 @@ class CHttpCookie extends CComponent
 	 * @var array Cookie attribute "SameSite".
 	 * @see https://www.owasp.org/index.php/SameSite
 	 * This property only works for PHP 7.3.0 or above.
+	 * Set this value to None because there might be breaking changes on different default value.
 	 * @since 1.1.22
 	 */
-	public $sameSite=self::SAME_SITE_LAX;
+	public $sameSite=self::SAME_SITE_NONE;
 
 	/**
 	 * Constructor.


### PR DESCRIPTION
<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

According to PHP manual https://www.php.net/manual/en/function.session-set-cookie-params.php
"If any of the allowed options are not given, their default values are the same as the default values of the explicit parameters. If the samesite element is omitted, no SameSite cookie attribute is set." I believe although i was greate feature to be added, it is more consistent to use default value None rather than Lax. However this may have some impact, on upgrading from 1.1.22 to 1.1.23 as it will be by default a more loose rule

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
