### PR TITLE
Added special option 'encode' to `$htmlOptions` argument in `CHtml::errorSummary` and `CHtml::error`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,7 +11,7 @@ Version 1.1.23 under development
 - Bug #4306: Add PHP 8 support (samdark)
 - Enh #4308: PHP 7.3 compatibility: Add `samesite` as a session cookie option (tomfotherby)
 - Bug #4310: Items on memcache won't expire due to memcache difference in internal clock (nikolasr200)
-- Enh #4317: Added special option 'ignoreHtmlEncode' to `$htmlOptions` argument in `CHtml::errorSummary` and `CHtml::error` (shidenko97)
+- Enh #4317: Added special option 'encode' to `$htmlOptions` argument in `CHtml::errorSummary` and `CHtml::error` (shidenko97)
 
 Version 1.1.22 January 16, 2020
 -------------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,7 +11,7 @@ Version 1.1.23 under development
 - Bug #4306: Add PHP 8 support (samdark)
 - Enh #4308: PHP 7.3 compatibility: Add `samesite` as a session cookie option (tomfotherby)
 - Bug #4310: Items on memcache won't expire due to memcache difference in internal clock (nikolasr200)
-- Enh #4317: Rolled back model error escaping to output unescaped text (shidenko97)
+- Enh #4317: Added special option 'ignoreHtmlEncode' to `$htmlOptions` argument in `CHtml::errorSummary` and `CHtml::error` (shidenko97)
 
 Version 1.1.22 January 16, 2020
 -------------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ Version 1.1.23 under development
 - Bug #4306: Add PHP 8 support (samdark)
 - Enh #4308: PHP 7.3 compatibility: Add `samesite` as a session cookie option (tomfotherby)
 - Bug #4310: Items on memcache won't expire due to memcache difference in internal clock (nikolasr200)
+- Enh #4317: Rolled back model error escaping to output unescaped text (shidenko97)
 
 Version 1.1.22 January 16, 2020
 -------------------------------

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2220,7 +2220,7 @@ EOD;
 				foreach($errors as $error)
 				{
 					if($error!='')
-						$content.= '<li>'.self::encode($error)."</li>\n";
+						$content.= '<li>'.$error."</li>\n";
 					if($firstError)
 						break;
 				}
@@ -2251,7 +2251,7 @@ EOD;
 	public static function error($model,$attribute,$htmlOptions=array())
 	{
 		self::resolveName($model,$attribute); // turn [a][b]attr into attr
-		$error=self::encode($model->getError($attribute));
+		$error=$model->getError($attribute);
 		if($error!='')
 		{
 			if(!isset($htmlOptions['class']))

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2197,10 +2197,10 @@ EOD;
 	 * make the error summary to show only the first error message of each attribute.
 	 * If this is not set or is false, all error messages will be displayed.
 	 * This option has been available since version 1.1.3.
-     * Another special option named 'ignoreHtmlEncode' is recognized, which when set true, will
-     * disable the CHtml::encode encoding of all error messages.
-     * If this is not set or is false, all error messages will be encoded by CHtml::encode.
-     * This option has been available since version 1.1.23.
+	 * Another special option named 'encode' is recognized, which when set true, will
+	 * disable the CHtml::encode encoding of all error messages.
+	 * If this is not set or is false, all error messages will be encoded by CHtml::encode.
+	 * This option has been available since version 1.1.23.
 	 * @return string the error summary. Empty if no errors are found.
 	 * @see CModel::getErrors
 	 * @see errorSummaryCss
@@ -2225,10 +2225,10 @@ EOD;
 				{
 					if($error!='')
 					{
-                        if (!isset($htmlOptions['ignoreHtmlEncode']) || !$htmlOptions['ignoreHtmlEncode'])
-                            $error=self::encode($error);
-                        $content.= '<li>'.$error."</li>\n";
-                    }
+						if (!isset($htmlOptions['encode']) || !$htmlOptions['encode'])
+							$error=self::encode($error);
+						$content.= '<li>'.$error."</li>\n";
+					}
 					if($firstError)
 						break;
 				}
@@ -2260,8 +2260,8 @@ EOD;
 	{
 		self::resolveName($model,$attribute); // turn [a][b]attr into attr
 		$error=$model->getError($attribute);
-        if (!isset($htmlOptions['ignoreHtmlEncode']) || !$htmlOptions['ignoreHtmlEncode'])
-            $error=self::encode($error);
+		if (!isset($htmlOptions['encode']) || !$htmlOptions['encode'])
+			$error=self::encode($error);
 		if($error!='')
 		{
 			if(!isset($htmlOptions['class']))

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2197,6 +2197,10 @@ EOD;
 	 * make the error summary to show only the first error message of each attribute.
 	 * If this is not set or is false, all error messages will be displayed.
 	 * This option has been available since version 1.1.3.
+     * Another special option named 'ignoreHtmlEncode' is recognized, which when set true, will
+     * disable the CHtml::encode encoding of all error messages.
+     * If this is not set or is false, all error messages will be encoded by CHtml::encode.
+     * This option has been available since version 1.1.23.
 	 * @return string the error summary. Empty if no errors are found.
 	 * @see CModel::getErrors
 	 * @see errorSummaryCss
@@ -2220,7 +2224,11 @@ EOD;
 				foreach($errors as $error)
 				{
 					if($error!='')
-						$content.= '<li>'.$error."</li>\n";
+					{
+                        if (!isset($htmlOptions['ignoreHtmlEncode']) || !$htmlOptions['ignoreHtmlEncode'])
+                            $error=self::encode($error);
+                        $content.= '<li>'.$error."</li>\n";
+                    }
 					if($firstError)
 						break;
 				}
@@ -2252,6 +2260,8 @@ EOD;
 	{
 		self::resolveName($model,$attribute); // turn [a][b]attr into attr
 		$error=$model->getError($attribute);
+        if (!isset($htmlOptions['ignoreHtmlEncode']) || !$htmlOptions['ignoreHtmlEncode'])
+            $error=self::encode($error);
 		if($error!='')
 		{
 			if(!isset($htmlOptions['class']))

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2197,9 +2197,9 @@ EOD;
 	 * make the error summary to show only the first error message of each attribute.
 	 * If this is not set or is false, all error messages will be displayed.
 	 * This option has been available since version 1.1.3.
-	 * Another special option named 'encode' is recognized, which when set true, will
+	 * Another special option named 'encode' is recognized, which when set false, will
 	 * disable the CHtml::encode encoding of all error messages.
-	 * If this is not set or is false, all error messages will be encoded by CHtml::encode.
+	 * If this is not set or is true, all error messages will be encoded by CHtml::encode.
 	 * This option has been available since version 1.1.23.
 	 * @return string the error summary. Empty if no errors are found.
 	 * @see CModel::getErrors
@@ -2225,7 +2225,7 @@ EOD;
 				{
 					if($error!='')
 					{
-						if (!isset($htmlOptions['encode']) || !$htmlOptions['encode'])
+						if (!isset($htmlOptions['encode']) || $htmlOptions['encode'])
 							$error=self::encode($error);
 						$content.= '<li>'.$error."</li>\n";
 					}
@@ -2260,7 +2260,7 @@ EOD;
 	{
 		self::resolveName($model,$attribute); // turn [a][b]attr into attr
 		$error=$model->getError($attribute);
-		if (!isset($htmlOptions['encode']) || !$htmlOptions['encode'])
+		if (!isset($htmlOptions['encode']) || $htmlOptions['encode'])
 			$error=self::encode($error);
 		if($error!='')
 		{


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #4317
