### PR TITLE
Getter methods available for attributes property

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -133,7 +133,10 @@ abstract class CActiveRecord extends CModel
 	 */
 	public function __get($name)
 	{
-		if(isset($this->_attributes[$name]))
+	 	$getter = 'get'.$name;
+            	if(method_exists($this, $getter))
+                	return $this->$getter();
+		elseif(isset($this->_attributes[$name]))
 			return $this->_attributes[$name];
 		elseif(isset($this->getMetaData()->columns[$name]))
 			return null;


### PR DESCRIPTION
It must be possible to override, in a child class, the value of an attribute property, to give developers more flexibility.
Now it's possible to define a new getter method in an ActiveRecord extended class, even for attributes property, in order to process original values saved in db and modify its values.

<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌


