### PR TITLE
Add postgresql 12 support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 Version 1.1.23 under development
 --------------------------------
 
+- Enh #4323: Add PostgreSQL 12 support (bio, d4rkstar, marcovtwout)
 - Bug #4291: The scheme (protocol) is deleted when validateIDN is enabled after validation (Argevollen)
 
 Version 1.1.22 January 16, 2020

--- a/framework/db/schema/pgsql/CPgsqlSchema.php
+++ b/framework/db/schema/pgsql/CPgsqlSchema.php
@@ -169,7 +169,7 @@ class CPgsqlSchema extends CDbSchema
 SELECT
 	a.attname,
 	LOWER(format_type(a.atttypid, a.atttypmod)) AS type,
-	pg_get_expr(adbin, adrelid) AS default_value_text,
+	pg_get_expr(adbin, adrelid) AS adsrc,
 	a.attnotnull,
 	a.atthasdef,
 	pg_catalog.col_description(a.attrelid, a.attnum) AS comment
@@ -191,7 +191,7 @@ EOD;
 			$c=$this->createColumn($column);
 			$table->columns[$c->name]=$c;
 
-			if(stripos($column['default_value_text'],'nextval')===0 && preg_match('/nextval\([^\']*\'([^\']+)\'[^\)]*\)/i',$column['default_value_text'],$matches))
+			if(stripos($column['adsrc'],'nextval')===0 && preg_match('/nextval\([^\']*\'([^\']+)\'[^\)]*\)/i',$column['adsrc'],$matches))
 			{
 				if(strpos($matches[1],'.')!==false || $table->schemaName===self::DEFAULT_SCHEMA)
 					$this->_sequences[$table->rawName.'.'.$c->name]=$matches[1];
@@ -218,7 +218,7 @@ EOD;
 		$c->isForeignKey=false;
 		$c->comment=$column['comment']===null ? '' : $column['comment'];
 
-		$c->init($column['type'],$column['atthasdef'] ? $column['default_value_text'] : null);
+		$c->init($column['type'],$column['atthasdef'] ? $column['adsrc'] : null);
 
 		return $c;
 	}

--- a/framework/db/schema/pgsql/CPgsqlSchema.php
+++ b/framework/db/schema/pgsql/CPgsqlSchema.php
@@ -166,7 +166,12 @@ class CPgsqlSchema extends CDbSchema
 	protected function findColumns($table)
 	{
 		$sql=<<<EOD
-SELECT a.attname, LOWER(format_type(a.atttypid, a.atttypmod)) AS type, d.adsrc, a.attnotnull, a.atthasdef,
+SELECT
+	a.attname,
+	LOWER(format_type(a.atttypid, a.atttypmod)) AS type,
+	d.adsrc,
+	a.attnotnull,
+	a.atthasdef,
 	pg_catalog.col_description(a.attrelid, a.attnum) AS comment
 FROM pg_attribute a LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
 WHERE a.attnum > 0 AND NOT a.attisdropped
@@ -225,7 +230,12 @@ EOD;
 	protected function findConstraints($table)
 	{
 		$sql=<<<EOD
-SELECT conname, consrc, contype, indkey FROM (
+SELECT
+	conname,
+	consrc,
+	contype,
+	indkey
+FROM (
 	SELECT
 		conname,
 		CASE WHEN contype='f' THEN

--- a/framework/db/schema/pgsql/CPgsqlSchema.php
+++ b/framework/db/schema/pgsql/CPgsqlSchema.php
@@ -238,11 +238,7 @@ SELECT
 FROM (
 	SELECT
 		conname,
-		CASE WHEN contype='f' THEN
-			pg_catalog.pg_get_constraintdef(oid)
-		ELSE
-			'CHECK (' || consrc || ')'
-		END AS consrc,
+		pg_catalog.pg_get_constraintdef(oid) AS consrc,
 		contype,
 		conrelid AS relid,
 		NULL AS indkey

--- a/framework/db/schema/pgsql/CPgsqlSchema.php
+++ b/framework/db/schema/pgsql/CPgsqlSchema.php
@@ -169,7 +169,7 @@ class CPgsqlSchema extends CDbSchema
 SELECT
 	a.attname,
 	LOWER(format_type(a.atttypid, a.atttypmod)) AS type,
-	d.adsrc,
+	pg_get_expr(adbin, adrelid) AS default_value_text,
 	a.attnotnull,
 	a.atthasdef,
 	pg_catalog.col_description(a.attrelid, a.attnum) AS comment
@@ -191,7 +191,7 @@ EOD;
 			$c=$this->createColumn($column);
 			$table->columns[$c->name]=$c;
 
-			if(stripos($column['adsrc'],'nextval')===0 && preg_match('/nextval\([^\']*\'([^\']+)\'[^\)]*\)/i',$column['adsrc'],$matches))
+			if(stripos($column['default_value_text'],'nextval')===0 && preg_match('/nextval\([^\']*\'([^\']+)\'[^\)]*\)/i',$column['default_value_text'],$matches))
 			{
 				if(strpos($matches[1],'.')!==false || $table->schemaName===self::DEFAULT_SCHEMA)
 					$this->_sequences[$table->rawName.'.'.$c->name]=$matches[1];
@@ -218,7 +218,7 @@ EOD;
 		$c->isForeignKey=false;
 		$c->comment=$column['comment']===null ? '' : $column['comment'];
 
-		$c->init($column['type'],$column['atthasdef'] ? $column['adsrc'] : null);
+		$c->init($column['type'],$column['atthasdef'] ? $column['default_value_text'] : null);
 
 		return $c;
 	}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | **requires confirmation**
| Fixed issues  | https://github.com/yiisoft/yii/issues/4294, https://github.com/yiisoft/yii/issues/4302

This PR replaces the implementation in https://github.com/yiisoft/yii/issues/4297 with an improved implementation according to the notes in https://www.postgresql.org/docs/12/release-12.html:

> - Remove obsolete pg_constraint.consrc column (Peter Eisentraut)
> This column has been deprecated for a long time, because it did not update in response to other catalog changes (such as column renamings). The recommended way to get a text version of a check constraint's expression from pg_constraint is pg_get_expr(conbin, conrelid). pg_get_constraintdef() is also a useful alternative.

> - Remove obsolete pg_attrdef.adsrc column (Peter Eisentraut)
> This column has been deprecated for a long time, because it did not update in response to other catalog changes (such as column renamings). The recommended way to get a text version of a default-value expression from pg_attrdef is pg_get_expr(adbin, adrelid).

The new implementation should be fully backwards compatible on older versions of PostgreSQL down to the oldest supported version 9.5 according to https://www.postgresql.org/support/versioning/