### PR TITLE
PHP 7.4 CClientScript.php fail when is baseUrl not an array

### DIFF
--- a/framework/web/CClientScript.php
+++ b/framework/web/CClientScript.php
@@ -538,9 +538,18 @@ class CClientScript extends CApplicationComponent
 		if(isset($package['baseUrl']))
 		{
 			$baseUrl=$package['baseUrl'];
-			if($baseUrl==='' || $baseUrl[0]!=='/' && strpos($baseUrl,'://')===false)
-				$baseUrl=Yii::app()->getRequest()->getBaseUrl().'/'.$baseUrl;
-			$baseUrl=rtrim($baseUrl,'/');
+			if(is_array($baseUrl))
+			{
+				if($baseUrl==='' || $baseUrl[0]!=='/' && strpos($baseUrl,'://')===false)
+					$baseUrl=Yii::app()->getRequest()->getBaseUrl().'/'.$baseUrl;
+				$baseUrl=rtrim($baseUrl,'/');
+			}
+			else
+			{
+				if($baseUrl==='' && strpos($baseUrl,'://')===false)
+					$baseUrl=Yii::app()->getRequest()->getBaseUrl().'/'.$baseUrl;
+				$baseUrl=rtrim($baseUrl,'/');
+			}
 		}
 		elseif(isset($package['basePath']))
 			$baseUrl=Yii::app()->getAssetManager()->publish(Yii::getPathOfAlias($package['basePath']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | #4329
