### PR TITLE
Update CSysLogRoute.php

### DIFF
--- a/framework/logging/CSysLogRoute.php
+++ b/framework/logging/CSysLogRoute.php
@@ -47,4 +47,14 @@ class CSysLogRoute extends CLogRoute
 			syslog($syslogLevels[$log[1]],$this->formatLogMessage(str_replace("\n",', ',$log[0]),$log[1],$log[2],$log[3]));
 		closelog();
 	}
+	
+	/**
+         *  Syslog formatting is different than file-logging:
+         *    no trailing newline, no date-time, no level, no newline.
+         *  The above meta-data is handled in the syslog() call and by subsystem
+         */
+        protected function formatLogMessage($message,$level,$category,$time)
+        {
+                return "[$category] $message";
+        }
 }


### PR DESCRIPTION
logging with syslog facility does not use the same default format. While this might interfere with some custom-made filters to handle the problems originally introduced here, I sincerely doubt it. Syslog messages do not need a time, date, level or newline. Anyone who used syslog probably quickly realized it was FUBAR'd.

<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
