### PR TITLE
Fixed issue: createUpdateCommand does not accept just a table name when using MSSQL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,8 +5,7 @@ Version 1.1.25 under development
 --------------------------------
 
 - Bug #4369: PHP 8.0 compatibility: Fix warning "Only the first byte will be assigned to the string offset" when generating code with Gii (marcovtwout)
-- Bug: createUpdateCommand does not accept just a table name when using MSSQL (c-schmitz)
-
+- Bug #4374: Fix for createUpdateCommand which did not accept just a table name when using MSSQL (c-schmitz)
 
 Version 1.1.24 June 7, 2021
 --------------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@ Version 1.1.25 under development
 --------------------------------
 
 - Bug #4369: PHP 8.0 compatibility: Fix warning "Only the first byte will be assigned to the string offset" when generating code with Gii (marcovtwout)
+- Bug: createUpdateCommand does not accept just a table name when using MSSQL (c-schmitz)
+
 
 Version 1.1.24 June 7, 2021
 --------------------------------

--- a/framework/db/schema/mssql/CMssqlCommandBuilder.php
+++ b/framework/db/schema/mssql/CMssqlCommandBuilder.php
@@ -60,6 +60,7 @@ class CMssqlCommandBuilder extends CDbCommandBuilder
 	 */
 	public function createUpdateCommand($table,$data,$criteria)
 	{
+		$this->ensureTable($table);
 		$criteria=$this->checkCriteria($table,$criteria);
 		$fields=array();
 		$values=array();


### PR DESCRIPTION
If a tablename as string is given the following error occurs: 
Error: Call to a member function getColumn() on string 

Normal CDBCommand (Mysql) does this just fine.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  |❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️


