### PR TITLE
Increase validation string length size for decimal values

### DIFF
--- a/framework/db/schema/CDbColumnSchema.php
+++ b/framework/db/schema/CDbColumnSchema.php
@@ -115,8 +115,10 @@ class CDbColumnSchema extends CComponent
 		{
 			$values=explode(',',$matches[1]);
 			$this->size=$this->precision=(int)$values[0];
-			if(isset($values[1]))
+			if(isset($values[1])) {
 				$this->scale=(int)$values[1];
+				$this->size++; // account for '.'
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

When validating decimal fields e.g. currency, the string length is one character short of what can fit in the database. So need to add one to take the '.' into account

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 