### PR TITLE
Apply proper refactor for deprecated each(), broken since https://git…

### DIFF
--- a/framework/gii/components/Pear/Text/Diff/Engine/native.php
+++ b/framework/gii/components/Pear/Text/Diff/Engine/native.php
@@ -191,10 +191,7 @@ class Text_Diff_Engine_native {
                     continue;
                 }
                 $matches = $ymatches[$line];
-                reset($matches);
-                foreach($matches as $match) {
-                    reset($match);
-                    $y = next($match);
+                foreach($matches as $y) {
                     if (empty($this->in_seq[$y])) {
                         $k = $this->_lcsPos($y);
                         assert($k > 0);
@@ -202,9 +199,7 @@ class Text_Diff_Engine_native {
                         break;
                     }
                 }
-                foreach($matches as $match) {
-                    reset($match);
-                    $y = next($match);
+                foreach($matches as $y) {
                     if ($y > $this->seq[$k - 1]) {
                         assert($y <= $this->seq[$k]);
                         /* Optimization: this is a common case: next match is


### PR DESCRIPTION
Fix "reset() expects parameter 1 to be array" raised by Gii diff, issue #4226
Replaces https://github.com/yiisoft/yii/pull/4373

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️/❌
| Fixed issues  | #4226