### PR TITLE
Use `callable` as type name instead of `callback` in phpdoc

### DIFF
--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -652,7 +652,7 @@ class YiiBase
 	 * Registers a new class autoloader.
 	 * The new autoloader will be placed before {@link autoload} and after
 	 * any other existing autoloaders.
-	 * @param callback $callback a valid PHP callback (function name or array($className,$methodName)).
+	 * @param callable $callback a valid PHP callback (function name or array($className,$methodName)).
 	 * @param boolean $append whether to append the new autoloader after the default Yii autoloader.
 	 * Be careful using this option as it will disable {@link enableIncludePath autoloading via include path}
 	 * when set to true. After this the Yii autoloader can not rely on loading classes via simple include anymore

--- a/framework/base/CComponent.php
+++ b/framework/base/CComponent.php
@@ -507,7 +507,7 @@ class CComponent
 	 * makes the handler to be invoked first.
 	 *
 	 * @param string $name the event name
-	 * @param callback $handler the event handler
+	 * @param callable $handler the event handler
 	 * @throws CException if the event is not defined
 	 * @see detachEventHandler
 	 */
@@ -520,7 +520,7 @@ class CComponent
 	 * Detaches an existing event handler.
 	 * This method is the opposite of {@link attachEventHandler}.
 	 * @param string $name event name
-	 * @param callback $handler the event handler to be removed
+	 * @param callable $handler the event handler to be removed
 	 * @return boolean if the detachment process is successful
 	 * @see attachEventHandler
 	 */

--- a/framework/validators/CFilterValidator.php
+++ b/framework/validators/CFilterValidator.php
@@ -29,7 +29,7 @@
 class CFilterValidator extends CValidator
 {
 	/**
-	 * @var callback the filter method
+	 * @var callable the filter method
 	 */
 	public $filter;
 

--- a/framework/web/CController.php
+++ b/framework/web/CController.php
@@ -918,7 +918,7 @@ class CController extends CBaseController
 	 * Note, the callback and its parameter values will be serialized and saved in cache.
 	 * Make sure they are serializable.
 	 *
-	 * @param callback $callback a PHP callback which returns the needed dynamic content.
+	 * @param callable $callback a PHP callback which returns the needed dynamic content.
 	 * When the callback is specified as a string, it will be first assumed to be a method of the current
 	 * controller class. If the method does not exist, it is assumed to be a global PHP function.
 	 * Note, the callback should return the dynamic content instead of echoing it.
@@ -934,7 +934,7 @@ class CController extends CBaseController
 
 	/**
 	 * This method is internally used.
-	 * @param callback $callback a PHP callback which returns the needed dynamic content.
+	 * @param callable $callback a PHP callback which returns the needed dynamic content.
 	 * @param array $params parameters passed to the PHP callback
 	 * @see renderDynamic
 	 */

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -101,7 +101,7 @@ class CHtml
 	 */
 	public static $renderSpecialAttributesValue=true;
 	/**
-	 * @var callback the generator used in the {@link CHtml::modelName()} method.
+	 * @var callable the generator used in the {@link CHtml::modelName()} method.
 	 * @since 1.1.14
 	 */
 	private static $_modelNameConverter;
@@ -2439,7 +2439,7 @@ EOD;
 	 * Set generator used in the {@link CHtml::modelName()} method. You can use the `null` value to restore default
 	 * generator.
 	 *
-	 * @param callback|null $converter the new generator, the model or class name will be passed to the this callback
+	 * @param callable|null $converter the new generator, the model or class name will be passed to this callback
 	 * and result must be a valid value for HTML name attribute.
 	 * @throws CException if $converter isn't a valid callback
 	 * @since 1.1.14


### PR DESCRIPTION
`callback` is not recognized by some SCA tools (like psalm) and treated as class named "callback". `callable` is internal PHP type and it should not have such problems (at least it fixed some psalm complains).

https://www.php.net/manual/en/language.types.callable.php