### PR TITLE
Preserve previous behavior which silently discards errors when fopen fails on PHP 8.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ Version 1.1.25 under development
 - Bug #4369: PHP 8.0 compatibility: Fix warning "Only the first byte will be assigned to the string offset" when generating code with Gii (marcovtwout)
 - Bug #4374: Fix for createUpdateCommand which did not accept just a table name when using MSSQL (c-schmitz)
 - Bug #4380: Prevent fatal errors while validating CSRF token of malformed requests (rob006)
+- Bug #4382: PHP 8.0 compatibility: Fix CFileLogRoute throwing TypeError when logfile cannot be opened (marcovtwout)
 
 Version 1.1.24 June 7, 2021
 --------------------------------

--- a/framework/logging/CFileLogRoute.php
+++ b/framework/logging/CFileLogRoute.php
@@ -154,6 +154,9 @@ class CFileLogRoute extends CLogRoute
 
 		$logFile=$this->getLogPath().DIRECTORY_SEPARATOR.$this->getLogFile();
 		$fp=@fopen($logFile,'a');
+		if($fp===false)
+			return;
+
 		@flock($fp,LOCK_EX);
 		if(@filesize($logFile)>$this->getMaxFileSize()*1024)
 		{


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues |  #4382

I don't really like silencing these errors, but this PR keeps the behavior exactly backward compatible.
(Yii 2 would throw an InvalidConfigException in this case: https://github.com/yiisoft/yii2/blob/master/framework/log/FileTarget.php#L111)