### PR TITLE
Allow "cweagans/composer-patches" in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,5 +107,10 @@
 				"Fix PHP 8 compatibility": "https://yiisoft.github.io/phpunit-patches/phpunit_php8.patch"
 			}
 		}
+	},
+	"config": {
+		"allow-plugins": {
+			"cweagans/composer-patches": true
+		}
 	}
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  |

This prevents blocking of generating API documentation for site:

- https://github.com/yiisoft-contrib/yiiframework.com/blob/798f4197c4700749ce37eb8a95f648bab59f0b5c/Makefile#L76

```
  - Installing cweagans/composer-patches (1.7.1): Extracting archive
cweagans/composer-patches contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "cweagans/composer-patches" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?]
```

