### PR TITLE
php 8.1 support

### DIFF
--- a/framework/collections/CList.php
+++ b/framework/collections/CList.php
@@ -85,7 +85,7 @@ class CList extends CComponent implements IteratorAggregate,ArrayAccess,Countabl
 	 * This method is required by the interface IteratorAggregate.
 	 * @return Iterator an iterator for traversing the items in the list.
 	 */
-	public function getIterator()
+	#[\ReturnTypeWillChange] public function getIterator()
 	{
 		return new CListIterator($this->_d);
 	}
@@ -95,7 +95,7 @@ class CList extends CComponent implements IteratorAggregate,ArrayAccess,Countabl
 	 * This method is required by Countable interface.
 	 * @return integer number of items in the list.
 	 */
-	public function count()
+	#[\ReturnTypeWillChange] public function count()
 	{
 		return $this->getCount();
 	}
@@ -298,19 +298,20 @@ class CList extends CComponent implements IteratorAggregate,ArrayAccess,Countabl
 	 * @param integer $offset the offset to check on
 	 * @return boolean
 	 */
-	public function offsetExists($offset)
+	#[\ReturnTypeWillChange] public function offsetExists($offset)
 	{
 		return ($offset>=0 && $offset<$this->_c);
 	}
 
 	/**
+	 * #[\ReturnTypeWillChange]
 	 * Returns the item at the specified offset.
 	 * This method is required by the interface ArrayAccess.
 	 * @param integer $offset the offset to retrieve item.
 	 * @return mixed the item at the offset
 	 * @throws CException if the offset is invalid
 	 */
-	public function offsetGet($offset)
+	#[\ReturnTypeWillChange] public function offsetGet($offset)
 	{
 		return $this->itemAt($offset);
 	}
@@ -321,7 +322,7 @@ class CList extends CComponent implements IteratorAggregate,ArrayAccess,Countabl
 	 * @param integer $offset the offset to set item
 	 * @param mixed $item the item value
 	 */
-	public function offsetSet($offset,$item)
+	#[\ReturnTypeWillChange] public function offsetSet($offset,$item)
 	{
 		if($offset===null || $offset===$this->_c)
 			$this->insertAt($this->_c,$item);
@@ -337,7 +338,7 @@ class CList extends CComponent implements IteratorAggregate,ArrayAccess,Countabl
 	 * This method is required by the interface ArrayAccess.
 	 * @param integer $offset the offset to unset item
 	 */
-	public function offsetUnset($offset)
+	#[\ReturnTypeWillChange] public function offsetUnset($offset)
 	{
 		$this->removeAt($offset);
 	}

--- a/framework/collections/CList.php
+++ b/framework/collections/CList.php
@@ -85,7 +85,8 @@ class CList extends CComponent implements IteratorAggregate,ArrayAccess,Countabl
 	 * This method is required by the interface IteratorAggregate.
 	 * @return Iterator an iterator for traversing the items in the list.
 	 */
-	#[\ReturnTypeWillChange] public function getIterator()
+	#[\ReturnTypeWillChange]
+    public function getIterator()
 	{
 		return new CListIterator($this->_d);
 	}
@@ -95,7 +96,8 @@ class CList extends CComponent implements IteratorAggregate,ArrayAccess,Countabl
 	 * This method is required by Countable interface.
 	 * @return integer number of items in the list.
 	 */
-	#[\ReturnTypeWillChange] public function count()
+	#[\ReturnTypeWillChange]
+    public function count()
 	{
 		return $this->getCount();
 	}
@@ -298,20 +300,21 @@ class CList extends CComponent implements IteratorAggregate,ArrayAccess,Countabl
 	 * @param integer $offset the offset to check on
 	 * @return boolean
 	 */
-	#[\ReturnTypeWillChange] public function offsetExists($offset)
+	#[\ReturnTypeWillChange]
+    public function offsetExists($offset)
 	{
 		return ($offset>=0 && $offset<$this->_c);
 	}
 
 	/**
-	 * #[\ReturnTypeWillChange]
 	 * Returns the item at the specified offset.
 	 * This method is required by the interface ArrayAccess.
 	 * @param integer $offset the offset to retrieve item.
 	 * @return mixed the item at the offset
 	 * @throws CException if the offset is invalid
 	 */
-	#[\ReturnTypeWillChange] public function offsetGet($offset)
+	#[\ReturnTypeWillChange]
+    public function offsetGet($offset)
 	{
 		return $this->itemAt($offset);
 	}
@@ -322,7 +325,8 @@ class CList extends CComponent implements IteratorAggregate,ArrayAccess,Countabl
 	 * @param integer $offset the offset to set item
 	 * @param mixed $item the item value
 	 */
-	#[\ReturnTypeWillChange] public function offsetSet($offset,$item)
+	#[\ReturnTypeWillChange]
+    public function offsetSet($offset,$item)
 	{
 		if($offset===null || $offset===$this->_c)
 			$this->insertAt($this->_c,$item);
@@ -338,7 +342,8 @@ class CList extends CComponent implements IteratorAggregate,ArrayAccess,Countabl
 	 * This method is required by the interface ArrayAccess.
 	 * @param integer $offset the offset to unset item
 	 */
-	#[\ReturnTypeWillChange] public function offsetUnset($offset)
+	#[\ReturnTypeWillChange]
+    public function offsetUnset($offset)
 	{
 		$this->removeAt($offset);
 	}

--- a/framework/collections/CListIterator.php
+++ b/framework/collections/CListIterator.php
@@ -42,7 +42,8 @@ class CListIterator implements Iterator
 	 * Rewinds internal array pointer.
 	 * This method is required by the interface Iterator.
 	 */
-	#[\ReturnTypeWillChange] public function rewind()
+	#[\ReturnTypeWillChange]
+    public function rewind()
 	{
 		$this->_i=0;
 	}
@@ -52,7 +53,8 @@ class CListIterator implements Iterator
 	 * This method is required by the interface Iterator.
 	 * @return integer the key of the current array item
 	 */
-	#[\ReturnTypeWillChange] public function key()
+	#[\ReturnTypeWillChange]
+    public function key()
 	{
 		return $this->_i;
 	}
@@ -62,7 +64,8 @@ class CListIterator implements Iterator
 	 * This method is required by the interface Iterator.
 	 * @return mixed the current array item
 	 */
-	#[\ReturnTypeWillChange] public function current()
+	#[\ReturnTypeWillChange]
+    public function current()
 	{
 		return $this->_d[$this->_i];
 	}
@@ -71,7 +74,8 @@ class CListIterator implements Iterator
 	 * Moves the internal pointer to the next array item.
 	 * This method is required by the interface Iterator.
 	 */
-	#[\ReturnTypeWillChange] public function next()
+	#[\ReturnTypeWillChange]
+    public function next()
 	{
 		$this->_i++;
 	}
@@ -81,7 +85,8 @@ class CListIterator implements Iterator
 	 * This method is required by the interface Iterator.
 	 * @return boolean
 	 */
-	#[\ReturnTypeWillChange] public function valid()
+	#[\ReturnTypeWillChange]
+    public function valid()
 	{
 		return $this->_i<count($this->_d);
 	}

--- a/framework/collections/CListIterator.php
+++ b/framework/collections/CListIterator.php
@@ -42,7 +42,7 @@ class CListIterator implements Iterator
 	 * Rewinds internal array pointer.
 	 * This method is required by the interface Iterator.
 	 */
-	public function rewind()
+	#[\ReturnTypeWillChange] public function rewind()
 	{
 		$this->_i=0;
 	}
@@ -52,7 +52,7 @@ class CListIterator implements Iterator
 	 * This method is required by the interface Iterator.
 	 * @return integer the key of the current array item
 	 */
-	public function key()
+	#[\ReturnTypeWillChange] public function key()
 	{
 		return $this->_i;
 	}
@@ -62,7 +62,7 @@ class CListIterator implements Iterator
 	 * This method is required by the interface Iterator.
 	 * @return mixed the current array item
 	 */
-	public function current()
+	#[\ReturnTypeWillChange] public function current()
 	{
 		return $this->_d[$this->_i];
 	}
@@ -71,7 +71,7 @@ class CListIterator implements Iterator
 	 * Moves the internal pointer to the next array item.
 	 * This method is required by the interface Iterator.
 	 */
-	public function next()
+	#[\ReturnTypeWillChange] public function next()
 	{
 		$this->_i++;
 	}
@@ -81,8 +81,9 @@ class CListIterator implements Iterator
 	 * This method is required by the interface Iterator.
 	 * @return boolean
 	 */
-	public function valid()
+	#[\ReturnTypeWillChange] public function valid()
 	{
 		return $this->_i<count($this->_d);
 	}
 }
+

--- a/framework/collections/CMap.php
+++ b/framework/collections/CMap.php
@@ -78,7 +78,7 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * This method is required by the interface IteratorAggregate.
 	 * @return CMapIterator an iterator for traversing the items in the list.
 	 */
-	public function getIterator()
+	#[\ReturnTypeWillChange] public function getIterator()
 	{
 		return new CMapIterator($this->_d);
 	}
@@ -88,7 +88,7 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * This method is required by Countable interface.
 	 * @return integer number of items in the map.
 	 */
-	public function count()
+	#[\ReturnTypeWillChange] public function count()
 	{
 		return $this->getCount();
 	}
@@ -97,7 +97,7 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * Returns the number of items in the map.
 	 * @return integer the number of items in the map
 	 */
-	public function getCount()
+	#[\ReturnTypeWillChange] public function getCount()
 	{
 		return count($this->_d);
 	}
@@ -105,7 +105,7 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	/**
 	 * @return array the key list
 	 */
-	public function getKeys()
+	#[\ReturnTypeWillChange] public function getKeys()
 	{
 		return array_keys($this->_d);
 	}
@@ -303,7 +303,7 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * @param mixed $offset the offset to check on
 	 * @return boolean
 	 */
-	public function offsetExists($offset)
+	#[\ReturnTypeWillChange] public function offsetExists($offset)
 	{
 		return $this->contains($offset);
 	}
@@ -314,7 +314,7 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * @param integer $offset the offset to retrieve element.
 	 * @return mixed the element at the offset, null if no element is found at the offset
 	 */
-	public function offsetGet($offset)
+	#[\ReturnTypeWillChange] public function offsetGet($offset)
 	{
 		return $this->itemAt($offset);
 	}
@@ -323,11 +323,11 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * Sets the element at the specified offset.
 	 * This method is required by the interface ArrayAccess.
 	 * @param integer $offset the offset to set element
-	 * @param mixed $item the element value
+	 * @param mixed $value the element value
 	 */
-	public function offsetSet($offset,$item)
+	#[\ReturnTypeWillChange] public function offsetSet($offset, $value)
 	{
-		$this->add($offset,$item);
+		$this->add($offset,$value);
 	}
 
 	/**
@@ -335,8 +335,9 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * This method is required by the interface ArrayAccess.
 	 * @param mixed $offset the offset to unset element
 	 */
-	public function offsetUnset($offset)
+	#[\ReturnTypeWillChange] public function offsetUnset($offset)
 	{
 		$this->remove($offset);
 	}
 }
+

--- a/framework/collections/CMap.php
+++ b/framework/collections/CMap.php
@@ -78,7 +78,8 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * This method is required by the interface IteratorAggregate.
 	 * @return CMapIterator an iterator for traversing the items in the list.
 	 */
-	#[\ReturnTypeWillChange] public function getIterator()
+	#[\ReturnTypeWillChange]
+    public function getIterator()
 	{
 		return new CMapIterator($this->_d);
 	}
@@ -88,7 +89,8 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * This method is required by Countable interface.
 	 * @return integer number of items in the map.
 	 */
-	#[\ReturnTypeWillChange] public function count()
+	#[\ReturnTypeWillChange]
+    public function count()
 	{
 		return $this->getCount();
 	}
@@ -97,7 +99,8 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * Returns the number of items in the map.
 	 * @return integer the number of items in the map
 	 */
-	#[\ReturnTypeWillChange] public function getCount()
+	#[\ReturnTypeWillChange]
+    public function getCount()
 	{
 		return count($this->_d);
 	}
@@ -105,7 +108,8 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	/**
 	 * @return array the key list
 	 */
-	#[\ReturnTypeWillChange] public function getKeys()
+	#[\ReturnTypeWillChange]
+    public function getKeys()
 	{
 		return array_keys($this->_d);
 	}
@@ -303,7 +307,8 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * @param mixed $offset the offset to check on
 	 * @return boolean
 	 */
-	#[\ReturnTypeWillChange] public function offsetExists($offset)
+	#[\ReturnTypeWillChange]
+    public function offsetExists($offset)
 	{
 		return $this->contains($offset);
 	}
@@ -314,7 +319,8 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * @param integer $offset the offset to retrieve element.
 	 * @return mixed the element at the offset, null if no element is found at the offset
 	 */
-	#[\ReturnTypeWillChange] public function offsetGet($offset)
+	#[\ReturnTypeWillChange]
+    public function offsetGet($offset)
 	{
 		return $this->itemAt($offset);
 	}
@@ -325,7 +331,8 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * @param integer $offset the offset to set element
 	 * @param mixed $value the element value
 	 */
-	#[\ReturnTypeWillChange] public function offsetSet($offset, $value)
+	#[\ReturnTypeWillChange]
+    public function offsetSet($offset, $value)
 	{
 		$this->add($offset,$value);
 	}
@@ -335,7 +342,8 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 	 * This method is required by the interface ArrayAccess.
 	 * @param mixed $offset the offset to unset element
 	 */
-	#[\ReturnTypeWillChange] public function offsetUnset($offset)
+	#[\ReturnTypeWillChange]
+    public function offsetUnset($offset)
 	{
 		$this->remove($offset);
 	}


### PR DESCRIPTION
PHP8.1 Fix
Fixes errors, like this one
`Return type of CListIterator::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
