### PR TITLE
Remove GLOB_BRACE for Alpine

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Version 1.1.26 under development
 - Enh #4386: Added support for PHP 8.1 (marcovtwout)
 - Enh #4386: Updated HTMLPurifier to version 4.14.0-master-1dd3e52 for PHP 8.1 support (https://github.com/ezyang/htmlpurifier/blob/v4.14.0/NEWS) (marcovtwout)
 - Enh #4392: Added support for SSL to CRedisCache (andres101)
+- Bug #4453: Alpine Linux compatibility: Avoid using `GLOB_BRACE` in `CFileHelper::removeDirectory` (ivany4)
 
 Version 1.1.25 December 13, 2021
 --------------------------------

--- a/framework/utils/CFileHelper.php
+++ b/framework/utils/CFileHelper.php
@@ -79,7 +79,10 @@ class CFileHelper
 	{
 		if(!isset($options['traverseSymlinks']))
 			$options['traverseSymlinks']=false;
-		$items=glob($directory.DIRECTORY_SEPARATOR.'{,.}*',GLOB_MARK | GLOB_BRACE);
+		$items=array_merge(
+			glob($directory.DIRECTORY_SEPARATOR.'*',GLOB_MARK),
+			glob($directory.DIRECTORY_SEPARATOR.'.*',GLOB_MARK)
+		);
 		foreach($items as $item)
 		{
 			if(basename($item)=='.' || basename($item)=='..')


### PR DESCRIPTION
`GLOB_BRACE` constant is not supported on Alpine Linux. See https://github.com/docker-library/php/issues/719

Fortunately, this is the only place in the codebase, where `GLOB_BRACE` is being used. The other one being in tests:
https://github.com/yiisoft/yii/search?q=GLOB_BRACE

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
