### PR TITLE
Update basics.component.txt

### DIFF
--- a/docs/guide/pt/basics.component.txt
+++ b/docs/guide/pt/basics.component.txt
@@ -128,7 +128,7 @@ e, portanto, ganharam a possibilidade de receber um ou mais comportamentos. Um *
 coleta de funcionalidades em vez de especialização (por exemplo, a herança normal de classes). 
 Um componente pode receber diversos comportamentos e, assim, utilizar a "herança múltipla".
 
-Classes de comportamento devem implema interface [IBehavior]. A maioria dos comportamentos
+Classes de comportamento devem implementar a interface [IBehavior]. A maioria dos comportamentos
 podem utilizar a classe [CBehavior] como base, estendendo-a. Se um comportamento precisar ser atribuído 
 a um [modelo](/doc/guide/basics.model), ele deve estender as classes [CModelBehavior] ou 
 [CActiveRecordBehavior], que implementam características específicas para modelos.
@@ -168,7 +168,7 @@ $component->enableBehavior($name);
 // agora funciona
 $component->test();
 ~~~
-entar
+
 É possível que dois comportamentos atribuídos ao mesmo componente tenham métodos com o mesmo nome. 
 Nesse caso, o método do comportamento atribuído primeiro terá precedência.
 


### PR DESCRIPTION
Correção de erros de português implema (implement ) e entar.

Classes de comportamento devem implema interface IBehavior.
Behavior classes must implement the IBehavior interface.

entar É possível que dois comportamentos atribuídos ao mesmo componente tenham métodos com o mesmo nome.
It is possible that two behaviors attached to the same component have methods of the same name.

<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
