### PR TITLE
PHP 8.1 support for active checkbox list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 Version 1.1.26 under development
 --------------------------------
 
-- Enh #4386: Added support for PHP 8.1 (marcovtwout, JonathanArgentao, ivany4)
+- Enh #4386: Added support for PHP 8.1 (marcovtwout, JonathanArgentao, ivany4, csears123)
 - Enh #4386: Updated HTMLPurifier to version 4.14.0-master-1dd3e52 for PHP 8.1 support (https://github.com/ezyang/htmlpurifier/blob/v4.14.0/NEWS) (marcovtwout)
 - Enh #4392: Added support for SSL to CRedisCache (andres101)
 - Bug #4453: Alpine Linux compatibility: Avoid using `GLOB_BRACE` in `CFileHelper::removeDirectory` (ivany4)

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -1168,7 +1168,7 @@ class CHtml
 
 		foreach($data as $value=>$labelTitle)
 		{
-			$checked=!is_array($select) && !strcmp($value, (string)$select) || is_array($select) && in_array($value,$select);
+			$checked=!is_array($select) && !strcmp($value,(string)$select) || is_array($select) && in_array($value,$select);
 			$checkAll=$checkAll && $checked;
 			$htmlOptions['value']=$value;
 			$htmlOptions['id']=$baseID.'_'.$id++;
@@ -1280,7 +1280,7 @@ EOD;
 		$id=0;
 		foreach($data as $value=>$labelTitle)
 		{
-			$checked=!strcmp($value, (string)$select);
+			$checked=!strcmp($value,(string)$select);
 			$htmlOptions['value']=$value;
 			$htmlOptions['id']=$baseID.'_'.$id++;
 			$option=self::radioButton($name,$checked,$htmlOptions);

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -1168,7 +1168,7 @@ class CHtml
 
 		foreach($data as $value=>$labelTitle)
 		{
-			$checked=!empty($select) && !is_array($select) && !strcmp($value,$select) || is_array($select) && in_array($value,$select);
+			$checked=!is_array($select) && !strcmp($value, (string)$select) || is_array($select) && in_array($value,$select);
 			$checkAll=$checkAll && $checked;
 			$htmlOptions['value']=$value;
 			$htmlOptions['id']=$baseID.'_'.$id++;
@@ -1280,7 +1280,7 @@ EOD;
 		$id=0;
 		foreach($data as $value=>$labelTitle)
 		{
-			$checked=!strcmp($value,$select);
+			$checked=!strcmp($value, (string)$select);
 			$htmlOptions['value']=$value;
 			$htmlOptions['id']=$baseID.'_'.$id++;
 			$option=self::radioButton($name,$checked,$htmlOptions);

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -1168,7 +1168,7 @@ class CHtml
 
 		foreach($data as $value=>$labelTitle)
 		{
-			$checked=!is_array($select) && !strcmp($value,$select) || is_array($select) && in_array($value,$select);
+			$checked=!empty($select) && !is_array($select) && !strcmp($value,$select) || is_array($select) && in_array($value,$select);
 			$checkAll=$checkAll && $checked;
 			$htmlOptions['value']=$value;
 			$htmlOptions['id']=$baseID.'_'.$id++;


### PR DESCRIPTION
In PHP 8.1 I am receiving the error below when using CActiveForm checkbox field, when the CFormModel model attribute has a default 'null' value as defined. 

"strcmp(): Passing null to parameter #2 ($string2) of type string is deprecated"

The 'null' value is passed to the checkBoxList() method as the second argument variable $select.  A null value is not allowed in PHP 8.1 in strcmp().  An additional condition check for !empty() on the $select variable will prevent this error, as well as support the remaining variable types for a string or array.

<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
