### PR TITLE
Fixes #4484: send cacheControlHeader earlier

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ Version 1.1.26 under development
 - Enh #4386: Updated HTMLPurifier to version 4.14.0-master-1dd3e52 for PHP 8.1 support (https://github.com/ezyang/htmlpurifier/blob/v4.14.0/NEWS) (marcovtwout)
 - Enh #4392: Added support for SSL to CRedisCache (andres101)
 - Bug #4453: Alpine Linux compatibility: Avoid using `GLOB_BRACE` in `CFileHelper::removeDirectory` (ivany4)
+- Bug #4484: Fixed cache control headers (jannis701)
 
 Version 1.1.25 December 13, 2021
 --------------------------------

--- a/framework/web/filters/CHttpCacheFilter.php
+++ b/framework/web/filters/CHttpCacheFilter.php
@@ -104,10 +104,11 @@ class CHttpCacheFilter extends CFilter
 
 		}
 
+		$this->sendCacheControlHeader();
+
 		if($lastModified)
 			header('Last-Modified: '.gmdate('D, d M Y H:i:s', $lastModified).' GMT');
 
-		$this->sendCacheControlHeader();
 		return true;
 	}
 


### PR DESCRIPTION
call CHttpCacheFilter::sendCacheControlHeader before setting last-modified

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | 
| Fixed issues  | #4484