### PR TITLE
PHP 8.1 compatibility fix for CFileCache

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 Version 1.1.27 under development
 --------------------------------
 
-- No changes yet
+- Bug: PHP 8.1 compatibility: Fix CFileCache call of file_get_contents (Bregi)
 
 Version 1.1.26 September 30, 2022
 --------------------------------

--- a/framework/caching/CFileCache.php
+++ b/framework/caching/CFileCache.php
@@ -130,7 +130,7 @@ class CFileCache extends CCache
 	{
 		$cacheFile=$this->getCacheFile($key);
 		if(($time=$this->filemtime($cacheFile))>time())
-			return @file_get_contents($cacheFile,false,null,$this->embedExpiry ? 10 : null);
+			return @file_get_contents($cacheFile,false,null,$this->embedExpiry ? 10 : 0);
 		elseif($time>0)
 			@unlink($cacheFile);
 		return false;


### PR DESCRIPTION
<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
