### PR TITLE
PHP 8.1 deprecation error, add return type for CMssql-classes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 Version 1.1.28 under development
 --------------------------------
 
-- No changes yet
+- Bug #4500: PHP 8.1 compatibility: Fix deprecation warnings in CMysql classes (csears123)
 
 Version 1.1.27 November 21, 2022
 --------------------------------

--- a/framework/db/schema/mssql/CMssqlPdoAdapter.php
+++ b/framework/db/schema/mssql/CMssqlPdoAdapter.php
@@ -37,6 +37,7 @@ class CMssqlPdoAdapter extends PDO
 	 *
 	 * @return boolean
 	 */
+	#[ReturnTypeWillChange]
 	public function beginTransaction ()
 	{
 		$this->exec('BEGIN TRANSACTION');
@@ -51,6 +52,7 @@ class CMssqlPdoAdapter extends PDO
 	 *
 	 * @return boolean
 	 */
+	#[ReturnTypeWillChange]
 	public function commit ()
 	{
 		$this->exec('COMMIT TRANSACTION');
@@ -65,6 +67,7 @@ class CMssqlPdoAdapter extends PDO
 	 *
 	 * @return boolean
 	 */
+	#[ReturnTypeWillChange]
 	public function rollBack ()
 	{
 		$this->exec('ROLLBACK TRANSACTION');

--- a/framework/db/schema/mssql/CMssqlPdoAdapter.php
+++ b/framework/db/schema/mssql/CMssqlPdoAdapter.php
@@ -23,6 +23,7 @@ class CMssqlPdoAdapter extends PDO
 	 * @param string|null sequence name. Defaults to null
 	 * @return integer last inserted id
 	 */
+	#[ReturnTypeWillChange]
 	public function lastInsertId ($sequence=NULL)
 	{
 		return $this->query('SELECT CAST(COALESCE(SCOPE_IDENTITY(), @@IDENTITY) AS bigint)')->fetchColumn();

--- a/framework/db/schema/mssql/CMssqlSqlsrvPdoAdapter.php
+++ b/framework/db/schema/mssql/CMssqlSqlsrvPdoAdapter.php
@@ -30,7 +30,7 @@ class CMssqlSqlsrvPdoAdapter extends PDO
 	 * @param string|null $sequence the sequence/table name. Defaults to null.
 	 * @return integer last inserted ID value.
 	 */
-	public function lastInsertId($sequence=null)
+	public function lastInsertId($sequence=null): string|false
 	{
 		$parts = explode('.', phpversion('pdo_sqlsrv'));
 		$sqlsrvVer = phpversion('pdo_sqlsrv') ? intval(array_shift($parts)) : 0;

--- a/framework/db/schema/mssql/CMssqlSqlsrvPdoAdapter.php
+++ b/framework/db/schema/mssql/CMssqlSqlsrvPdoAdapter.php
@@ -30,7 +30,8 @@ class CMssqlSqlsrvPdoAdapter extends PDO
 	 * @param string|null $sequence the sequence/table name. Defaults to null.
 	 * @return integer last inserted ID value.
 	 */
-	public function lastInsertId($sequence=null): string|false
+	#[ReturnTypeWillChange]
+	public function lastInsertId($sequence=null)
 	{
 		$parts = explode('.', phpversion('pdo_sqlsrv'));
 		$sqlsrvVer = phpversion('pdo_sqlsrv') ? intval(array_shift($parts)) : 0;


### PR DESCRIPTION
The return type for lastInsertId() method needs to be compatible with PDO::lastInsertId().  Adding the return type for stiring|false resolves the compatibility issue encountered in PHP 8.1

<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
