### PR TITLE
Set Last-Modified after sending cache control headers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 Version 1.1.28 under development
 --------------------------------
 
+- Bug #4484: Set Last-Modified after sending cache control headers (jannis701, wtommyw)
 - Bug #4491: Fixed limit and Offset not working correctly with MSSQL version 11 (2012) and newer (shnoulle, wtommyw)
 - Bug #4497: PHP 8.1 compatibility: Fix unserialize null in CRedisCache (kenguest, wtommyw)
 - Bug #4500: PHP 8.1 compatibility: Fix deprecation warnings in CMysql classes (csears123)

--- a/framework/web/filters/CHttpCacheFilter.php
+++ b/framework/web/filters/CHttpCacheFilter.php
@@ -82,21 +82,21 @@ class CHttpCacheFilter extends CFilter
 		{
 			if($this->checkLastModified($lastModified)&&$this->checkEtag($etag))
 			{
-				$cacheValid = true;
+				$cacheValid=true;
 			}
 		}
 		elseif(isset($_SERVER['HTTP_IF_MODIFIED_SINCE']))
 		{
 			if($this->checkLastModified($lastModified))
 			{
-				$cacheValid = true;
+				$cacheValid=true;
 			}
 		}
 		elseif(isset($_SERVER['HTTP_IF_NONE_MATCH']))
 		{
 			if($this->checkEtag($etag))
 			{
-				$cacheValid = true;
+				$cacheValid=true;
 			}
 		}
 

--- a/framework/web/filters/CHttpCacheFilter.php
+++ b/framework/web/filters/CHttpCacheFilter.php
@@ -75,39 +75,39 @@ class CHttpCacheFilter extends CFilter
 		if($etag)
 			header('ETag: '.$etag);
 
+		$this->sendCacheControlHeader();
+
+		$cacheValid = false;
 		if(isset($_SERVER['HTTP_IF_MODIFIED_SINCE'])&&isset($_SERVER['HTTP_IF_NONE_MATCH']))
 		{
 			if($this->checkLastModified($lastModified)&&$this->checkEtag($etag))
 			{
-				$this->send304Header();
-				$this->sendCacheControlHeader();
-				return false;
+				$cacheValid = true;
 			}
 		}
 		elseif(isset($_SERVER['HTTP_IF_MODIFIED_SINCE']))
 		{
 			if($this->checkLastModified($lastModified))
 			{
-				$this->send304Header();
-				$this->sendCacheControlHeader();
-				return false;
+				$cacheValid = true;
 			}
 		}
 		elseif(isset($_SERVER['HTTP_IF_NONE_MATCH']))
 		{
 			if($this->checkEtag($etag))
 			{
-				$this->send304Header();
-				$this->sendCacheControlHeader();
-				return false;
+				$cacheValid = true;
 			}
-
 		}
 
 		if($lastModified)
 			header('Last-Modified: '.gmdate('D, d M Y H:i:s', $lastModified).' GMT');
 
-		$this->sendCacheControlHeader();
+		if ($cacheValid) {
+			$this->send304Header();
+			return false;
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
 Fixes #4484 Set lastModified after setting cache control header,refactor duplicate code in CHttpCacheFilter::prefiler().

<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #4484 
