### PR TITLE
Fix PHP 8.1 deprecation errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 Version 1.1.28 under development
 --------------------------------
 
+- Enh 4503: Update tests and code for PHP 8.1 compatibility, stop suppressing deprecation warnings in tests (wtommyw)
 - Bug #4491: Fixed limit and Offset not working correctly with MSSQL version 11 (2012) and newer (shnoulle, wtommyw)
 - Bug #4497: PHP 8.1 compatibility: Fix unserialize null in CRedisCache (kenguest, wtommyw)
 - Bug #4500: PHP 8.1 compatibility: Fix deprecation warnings in CMysql classes (csears123)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 Version 1.1.28 under development
 --------------------------------
 
-- Enh 4503: Update tests and code for PHP 8.1 compatibility, stop suppressing deprecation warnings in tests (wtommyw)
+- Enh #4503: Update tests and code for PHP 8.1 compatibility, stop suppressing deprecation warnings in tests (wtommyw)
 - Bug #4491: Fixed limit and Offset not working correctly with MSSQL version 11 (2012) and newer (shnoulle, wtommyw)
 - Bug #4497: PHP 8.1 compatibility: Fix unserialize null in CRedisCache (kenguest, wtommyw)
 - Bug #4500: PHP 8.1 compatibility: Fix deprecation warnings in CMysql classes (csears123)

--- a/framework/i18n/CLocale.php
+++ b/framework/i18n/CLocale.php
@@ -113,7 +113,7 @@ class CLocale extends CComponent
 	 */
 	public static function getCanonicalID($id)
 	{
-		return strtolower(str_replace('-','_',(string)$id));
+		return strtolower(str_replace('-','_',$id));
 	}
 
 	/**
@@ -417,7 +417,7 @@ class CLocale extends CComponent
 	 */
 	public function getLocaleDisplayName($id=null, $category='languages')
 	{
-		$id = $this->getCanonicalID($id);
+		$id = $this->getCanonicalID((string)$id);
 		if (($category == 'languages') && (isset($this->_data[$category][$id])))
 		{
 			return $this->_data[$category][$id];

--- a/framework/i18n/CLocale.php
+++ b/framework/i18n/CLocale.php
@@ -113,7 +113,7 @@ class CLocale extends CComponent
 	 */
 	public static function getCanonicalID($id)
 	{
-		return strtolower(str_replace('-','_',$id));
+		return strtolower(str_replace('-','_',(string)$id));
 	}
 
 	/**

--- a/framework/utils/CDateTimeParser.php
+++ b/framework/utils/CDateTimeParser.php
@@ -83,9 +83,6 @@ class CDateTimeParser
 		if(self::$_mbstringAvailable===null)
 			self::$_mbstringAvailable=extension_loaded('mbstring');
 
-		if($value===null)
-			return false;
-
 		$tokens=self::tokenize($pattern);
 		$i=0;
 		$n=self::$_mbstringAvailable ? mb_strlen($value,Yii::app()->charset) : strlen($value);

--- a/framework/utils/CDateTimeParser.php
+++ b/framework/utils/CDateTimeParser.php
@@ -83,6 +83,9 @@ class CDateTimeParser
 		if(self::$_mbstringAvailable===null)
 			self::$_mbstringAvailable=extension_loaded('mbstring');
 
+		if($value===null)
+			return false;
+
 		$tokens=self::tokenize($pattern);
 		$i=0;
 		$n=self::$_mbstringAvailable ? mb_strlen($value,Yii::app()->charset) : strlen($value);

--- a/framework/utils/CFormatter.php
+++ b/framework/utils/CFormatter.php
@@ -73,7 +73,7 @@ class CFormatter extends CApplicationComponent
 	 * They correspond to the number of digits after the decimal point, the character displayed as the decimal point
 	 * and the thousands separator character.
 	 */
-	public $numberFormat=array('decimals'=>null, 'decimalSeparator'=>null, 'thousandSeparator'=>null);
+	public $numberFormat=array('decimals'=>0, 'decimalSeparator'=>null, 'thousandSeparator'=>null);
 	/**
 	 * @var array the text to be displayed when formatting a boolean value. The first element corresponds
 	 * to the text display for false, the second element for true. Defaults to <code>array('No', 'Yes')</code>.

--- a/framework/validators/CDateValidator.php
+++ b/framework/validators/CDateValidator.php
@@ -55,7 +55,8 @@ class CDateValidator extends CValidator
 		$valid=false;
 
 		// reason of array checking is explained here: https://github.com/yiisoft/yii/issues/1955
-		if(!is_array($value))
+        // checking for `null` as passing `null` to CDateTimeParser::parse will throw a deprecation error in PHP >= 8.1
+		if(!is_array($value) && $value !== null)
 		{
 			$formats=is_string($this->format) ? array($this->format) : $this->format;
 			foreach($formats as $format)

--- a/framework/validators/CDateValidator.php
+++ b/framework/validators/CDateValidator.php
@@ -55,7 +55,7 @@ class CDateValidator extends CValidator
 		$valid=false;
 
 		// reason of array checking is explained here: https://github.com/yiisoft/yii/issues/1955
-        // checking for `null` as passing `null` to CDateTimeParser::parse will throw a deprecation error in PHP >= 8.1
+		// checking for `null` as passing `null` to CDateTimeParser::parse will throw a deprecation error in PHP >= 8.1
 		if(!is_array($value) && $value !== null)
 		{
 			$formats=is_string($this->format) ? array($this->format) : $this->format;

--- a/framework/validators/CStringValidator.php
+++ b/framework/validators/CStringValidator.php
@@ -88,9 +88,9 @@ class CStringValidator extends CValidator
 		}
 
 		if(function_exists('mb_strlen') && $this->encoding!==false)
-			$length=mb_strlen($value, $this->encoding ? $this->encoding : Yii::app()->charset);
+			$length=mb_strlen((string)$value, $this->encoding ? $this->encoding : Yii::app()->charset);
 		else
-			$length=strlen($value);
+			$length=strlen((string)$value);
 
 		if($this->min!==null && $length<$this->min)
 		{

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2370,7 +2370,7 @@ EOD;
 	public static function value($model,$attribute,$defaultValue=null)
 	{
 		if(is_scalar($attribute) || $attribute===null)
-			foreach(explode('.',$attribute) as $name)
+			foreach(explode('.',(string)$attribute) as $name)
 			{
 				if(is_object($model))
 				{

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2369,8 +2369,10 @@ EOD;
 	 */
 	public static function value($model,$attribute,$defaultValue=null)
 	{
-		if(is_scalar($attribute) || $attribute===null)
-			foreach(explode('.',(string)$attribute) as $name)
+		if($attribute===null)
+			return $defaultValue;
+		elseif(is_scalar($attribute))
+			foreach(explode('.',$attribute) as $name)
 			{
 				if(is_object($model))
 				{

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2369,10 +2369,8 @@ EOD;
 	 */
 	public static function value($model,$attribute,$defaultValue=null)
 	{
-		if($attribute===null)
-			return $defaultValue;
-		elseif(is_scalar($attribute))
-			foreach(explode('.',$attribute) as $name)
+		if(is_scalar($attribute) || $attribute===null)
+			foreach(explode('.',(string)$attribute) as $name)
 			{
 				if(is_object($model))
 				{

--- a/framework/web/widgets/CStarRating.php
+++ b/framework/web/widgets/CStarRating.php
@@ -170,7 +170,7 @@ class CStarRating extends CInputWidget
 				$options['title']=$this->titles[$value];
 			else
 				unset($options['title']);
-			echo CHtml::radioButton($name,!strcmp($value,$selection),$options) . "\n";
+			echo CHtml::radioButton($name,!strcmp($value,(string)$selection),$options) . "\n";
 		}
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 
 if (PHP_MAJOR_VERSION>=7 && PHP_MINOR_VERSION>=1) {
 	// skip deprecation errors in PHP 7.1 and above
-	error_reporting(E_ALL & ~E_DEPRECATED);
+	error_reporting(E_ALL);
 }
 
 defined('YII_ENABLE_EXCEPTION_HANDLER') or define('YII_ENABLE_EXCEPTION_HANDLER',false);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,10 +1,5 @@
 <?php
 
-if (PHP_MAJOR_VERSION>=7 && PHP_MINOR_VERSION>=1) {
-	// skip deprecation errors in PHP 7.1 and above
-	error_reporting(E_ALL);
-}
-
 defined('YII_ENABLE_EXCEPTION_HANDLER') or define('YII_ENABLE_EXCEPTION_HANDLER',false);
 defined('YII_ENABLE_ERROR_HANDLER') or define('YII_ENABLE_ERROR_HANDLER',false);
 defined('YII_DEBUG') or define('YII_DEBUG',true);

--- a/tests/framework/base/CSecurityManagerTest.php
+++ b/tests/framework/base/CSecurityManagerTest.php
@@ -246,7 +246,7 @@ class CSecurityManagerTest extends CTestCase
 	public function testCompareStrings($expected, $actual)
 	{
 		$sm=new CSecurityManager;
-		$this->assertEquals(strcmp($expected,$actual)===0,$sm->compareString($expected,$actual));
+		$this->assertEquals(strcmp((string)$expected,(string)$actual)===0,$sm->compareString((string)$expected,(string)$actual));
 	}
 
 	/**

--- a/tests/framework/i18n/CLocaleTest.php
+++ b/tests/framework/i18n/CLocaleTest.php
@@ -176,7 +176,7 @@ class CLocaleTest extends CTestCase
 	public function testGetLanguage($ctorLocale,$methodLocale,$assertion)
 	{
 		$locale=CLocale::getInstance($ctorLocale);
-		$this->assertEquals(mb_strtolower((string)$assertion),mb_strtolower((string)$locale->getLanguage($methodLocale)));
+		$this->assertEquals(mb_strtolower((string)$assertion),mb_strtolower((string)$locale->getLanguage((string)$methodLocale)));
 	}
 
 	public function providerGetScript()

--- a/tests/framework/i18n/CLocaleTest.php
+++ b/tests/framework/i18n/CLocaleTest.php
@@ -123,7 +123,7 @@ class CLocaleTest extends CTestCase
 	public function testGetLocaleDisplayName($ctorLocale,$methodLocale,$assertion)
 	{
 		$locale=CLocale::getInstance($ctorLocale);
-		$this->assertEquals(mb_strtolower($assertion),mb_strtolower($locale->getLocaleDisplayName($methodLocale)));
+		$this->assertEquals(mb_strtolower((string)$assertion),mb_strtolower((string)$locale->getLocaleDisplayName((string)$methodLocale)));
 	}
 
 	public function providerGetLanguage()
@@ -176,7 +176,7 @@ class CLocaleTest extends CTestCase
 	public function testGetLanguage($ctorLocale,$methodLocale,$assertion)
 	{
 		$locale=CLocale::getInstance($ctorLocale);
-		$this->assertEquals(mb_strtolower($assertion),mb_strtolower($locale->getLanguage($methodLocale)));
+		$this->assertEquals(mb_strtolower((string)$assertion),mb_strtolower((string)$locale->getLanguage($methodLocale)));
 	}
 
 	public function providerGetScript()
@@ -217,7 +217,7 @@ class CLocaleTest extends CTestCase
 	public function testGetScript($ctorLocale,$methodLocale,$assertion)
 	{
 		$locale=CLocale::getInstance($ctorLocale);
-		$this->assertEquals($assertion,$locale->getScript($methodLocale));
+		$this->assertEquals((string)$assertion,$locale->getScript((string)$methodLocale));
 	}
 
 	public function providerGetTerritory()
@@ -264,6 +264,6 @@ class CLocaleTest extends CTestCase
 	public function testGetTerritory($ctorLocale,$methodLocale,$assertion)
 	{
 		$locale=CLocale::getInstance($ctorLocale);
-		$this->assertEquals($assertion,$locale->getTerritory($methodLocale));
+		$this->assertEquals((string)$assertion,$locale->getTerritory((string)$methodLocale));
 	}
 }

--- a/tests/framework/utils/CDateTimeParserTest.php
+++ b/tests/framework/utils/CDateTimeParserTest.php
@@ -193,8 +193,6 @@ class CDateTimeParserTest extends CTestCase
 	{
 		// empty parsed string
 		$this->assertFalse(CDateTimeParser::parse('', 'dd MMMM, yyyy, HH:mm'));
-		$this->assertFalse(CDateTimeParser::parse(false, 'dd MMMM, yyyy, HH:mm'));
-		$this->assertFalse(CDateTimeParser::parse(null, 'dd MMMM, yyyy, HH:mm'));
 
 		// accidently mixed up arguments
 		$this->assertFalse(CDateTimeParser::parse('dd/MM/yyyy, ???, hh:m:s', '02/08/2010, yyy, 05:9:7'));

--- a/tests/framework/utils/CFormatterTest.php
+++ b/tests/framework/utils/CFormatterTest.php
@@ -123,4 +123,57 @@ class CFormatterTest extends CTestCase
 		$formatter = new CFormatter();
 		$this->assertEquals($assertion, $formatter->formatNtext($value, $paragraphs, $removeEmptyParagraphs));
 	}
+
+	/**
+	 * @dataProvider providerFormatNumber()
+	 * @param string $value
+	 * @param string $decimals
+	 * @param string $decimalSeparator
+	 * @param string $thousandSeparator
+	 * @param string $assertion
+	 */
+	public function testFormatNumber($value,$decimals,$decimalSeparator,$thousandSeparator,$assertion)
+	{
+		$formatter = new CFormatter();
+
+		if ($decimals!==null)
+			$formatter->numberFormat['decimals']=$decimals;
+
+		if ($decimalSeparator!==null)
+			$formatter->numberFormat['decimalSeparator']=$decimalSeparator;
+
+		if ($thousandSeparator!==null)
+			$formatter->numberFormat['thousandSeparator']=$thousandSeparator;
+
+		$this->assertEquals($assertion,$formatter->formatNumber($value));
+	}
+
+	public function providerFormatNumber()
+	{
+		return array(
+			// Tests decimals
+			array('1.5',null,null,null,'2'),
+			array('1.5',1,null,null,'1.5'),
+			array('1.55',1,null,null,'1.6'),
+			array('1.44',1,null,null,'1.4'),
+			array('1.01',2,null,null,'1.01'),
+
+			// Test decimal separator
+			array('1.5',null, ',', null,'2'),
+			array('1.5',1,',',null,'1,5'),
+			array('1.55',1,',',null,'1,6'),
+			array('1.44',1,',',null,'1,4'),
+			array('1.01',2,',',null,'1,01'),
+
+			// Test thousands seperator
+			array('1000',null,null,'.','1.000'),
+			array('10000',null,null,'.','10.000'),
+			array('100000',null,null,'.','100.000'),
+			array('1000000',null,null,'.','1.000.000'),
+
+			// Test all at once
+			array('1000.05',2,'D','T','1T000D05'),
+			array('10000.005',2,'D','T','10T000D01'),
+		);
+	}
 }

--- a/tests/framework/validators/CFileValidatorTest.php
+++ b/tests/framework/validators/CFileValidatorTest.php
@@ -34,7 +34,7 @@ class CFileValidatorTest extends CTestCase
 	public function testSizeToBytes($sizeString, $assertion)
 	{
 		$fileValidator=new CFileValidator();
-		$this->assertEquals($assertion, $fileValidator->sizeToBytes((string)$sizeString));
+		$this->assertSame($assertion, $fileValidator->sizeToBytes((string)$sizeString));
 	}
 
 	public function testValidate()

--- a/tests/framework/validators/CFileValidatorTest.php
+++ b/tests/framework/validators/CFileValidatorTest.php
@@ -20,8 +20,8 @@ class CFileValidatorTest extends CTestCase
 			array('1.2G', 1*1024*1024*1024),
 			array('100500', 100500),
 			array('9000', 9000),
-			array(null, null),
-			array('', null),
+			array(null, 0),
+			array('', 0),
 		);
 	}
 
@@ -34,7 +34,7 @@ class CFileValidatorTest extends CTestCase
 	public function testSizeToBytes($sizeString, $assertion)
 	{
 		$fileValidator=new CFileValidator();
-		$this->assertEquals($assertion, $fileValidator->sizeToBytes($sizeString));
+		$this->assertEquals($assertion, $fileValidator->sizeToBytes((string)$sizeString));
 	}
 
 	public function testValidate()

--- a/tests/framework/web/helpers/CHtmlTest.php
+++ b/tests/framework/web/helpers/CHtmlTest.php
@@ -1128,17 +1128,17 @@ class CHtmlTest extends CTestCase
 		$out=CHtml::ajax(array(
 			'success'=>'js:function() { /* callback */ }',
 		));
-		$this->assertTrue(mb_strpos($out,"'success':function() { /* callback */ }", null, Yii::app()->charset)!==false, "Unexpected JavaScript: ".$out);
+		$this->assertTrue(mb_strpos($out,"'success':function() { /* callback */ }", 0, Yii::app()->charset)!==false, "Unexpected JavaScript: ".$out);
 
 		$out=CHtml::ajax(array(
 			'success'=>'function() { /* callback */ }',
 		));
-		$this->assertTrue(mb_strpos($out,"'success':function() { /* callback */ }", null, Yii::app()->charset)!==false, "Unexpected JavaScript: ".$out);
+		$this->assertTrue(mb_strpos($out,"'success':function() { /* callback */ }", 0, Yii::app()->charset)!==false, "Unexpected JavaScript: ".$out);
 
 		$out=CHtml::ajax(array(
 			'success'=>new CJavaScriptExpression('function() { /* callback */ }'),
 		));
-		$this->assertTrue(mb_strpos($out,"'success':function() { /* callback */ }", null, Yii::app()->charset)!==false, "Unexpected JavaScript: ".$out);
+		$this->assertTrue(mb_strpos($out,"'success':function() { /* callback */ }", 0, Yii::app()->charset)!==false, "Unexpected JavaScript: ".$out);
 	}
 }
 

--- a/tests/framework/web/helpers/CHtmlTest.php
+++ b/tests/framework/web/helpers/CHtmlTest.php
@@ -671,7 +671,7 @@ class CHtmlTest extends CTestCase
 	 */
 	public function testValue($model, $attribute, $defaultValue, $assertion)
 	{
-		$this->assertEquals($assertion, CHtml::value($model, $attribute, $defaultValue));
+		$this->assertEquals($assertion, CHtml::value($model, $attribute, (string)$defaultValue));
 	}
 
 	/**

--- a/tests/framework/web/helpers/CHtmlTest.php
+++ b/tests/framework/web/helpers/CHtmlTest.php
@@ -643,6 +643,13 @@ class CHtmlTest extends CTestCase
 			array(array('v1'),"0",'defaultValue','v1'),
 			array(array('v1'),0,'defaultValue','v1'),
 			array(array('v1'),0.0,'defaultValue','v1'),
+
+            // Test $model as an array, with null as a key, see: https://github.com/yiisoft/yii/pull/4503#discussion_r1054516859
+            array(array(null=>'v1','k2'=>'v2'),null,'defaultValue','v1'),
+            array(array(null=>'v1','k2'=>'v2'),'','defaultValue','v1'),
+            array(array(''=>'v1','k2'=>'v2'),null,'defaultValue','v1'),
+            array(array(''=>'v1','k2'=>'v2'),'','defaultValue','v1'),
+            array(array(null=>'v1','k2'=>'v2'),'k2','defaultValue','v2'),
 		);
 
 		// create_function is not supported by CHtml::value(), we're just testing this feature/property

--- a/tests/framework/web/helpers/CHtmlTest.php
+++ b/tests/framework/web/helpers/CHtmlTest.php
@@ -178,7 +178,7 @@ class CHtmlTest extends CTestCase
 		);
 	}
 
-    /**
+	/**
 	 * @dataProvider providerCloseTag
 	 *
 	 * @param string $tag
@@ -402,11 +402,11 @@ class CHtmlTest extends CTestCase
 				array('async'=>true),
 				"<script type=\"text/javascript\" async=\"async\">\n/*<![CDATA[*/\nvar a = 10;\n/*]]>*/\n</script>"
 			),
-            array(
-                'var a = 10;',
-                array('async'=>false),
-                "<script type=\"text/javascript\" async=\"false\">\n/*<![CDATA[*/\nvar a = 10;\n/*]]>*/\n</script>"
-            ),
+			array(
+				'var a = 10;',
+				array('async'=>false),
+				"<script type=\"text/javascript\" async=\"false\">\n/*<![CDATA[*/\nvar a = 10;\n/*]]>*/\n</script>"
+			),
 		);
 	}
 
@@ -644,12 +644,12 @@ class CHtmlTest extends CTestCase
 			array(array('v1'),0,'defaultValue','v1'),
 			array(array('v1'),0.0,'defaultValue','v1'),
 
-            // Test $model as an array, with null as a key, see: https://github.com/yiisoft/yii/pull/4503#discussion_r1054516859
-            array(array(null=>'v1','k2'=>'v2'),null,'defaultValue','v1'),
-            array(array(null=>'v1','k2'=>'v2'),'','defaultValue','v1'),
-            array(array(''=>'v1','k2'=>'v2'),null,'defaultValue','v1'),
-            array(array(''=>'v1','k2'=>'v2'),'','defaultValue','v1'),
-            array(array(null=>'v1','k2'=>'v2'),'k2','defaultValue','v2'),
+			// Test $model as an array, with null as a key, see: https://github.com/yiisoft/yii/pull/4503#discussion_r1054516859
+			array(array(null=>'v1','k2'=>'v2'),null,'defaultValue','v1'),
+			array(array(null=>'v1','k2'=>'v2'),'','defaultValue','v1'),
+			array(array(''=>'v1','k2'=>'v2'),null,'defaultValue','v1'),
+			array(array(''=>'v1','k2'=>'v2'),'','defaultValue','v1'),
+			array(array(null=>'v1','k2'=>'v2'),'k2','defaultValue','v2'),
 		);
 
 		// create_function is not supported by CHtml::value(), we're just testing this feature/property
@@ -1175,7 +1175,7 @@ class CHtmlTestModel extends CModel
 	 */
 	public $attr4;
 
-    /**
+	/**
 	 * Returns the list of attribute names.
 	 * @return array list of attribute names. Defaults to all public properties of the class.
 	 */

--- a/tests/framework/web/widgets/CAutoCompleteTest.php
+++ b/tests/framework/web/widgets/CAutoCompleteTest.php
@@ -9,13 +9,13 @@ class CAutoCompleteTest extends CTestCase
 		$expected = "'highlight':function() { /* callback */ }";
 
 		$out=$this->getWidgetScript('js:function() { /* callback */ }');
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
 
 		$out=$this->getWidgetScript('function() { /* callback */ }');
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
 
 		$out=$this->getWidgetScript(new CJavaScriptExpression('function() { /* callback */ }'));
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
 	}
 
 	private function getWidgetScript($callback)

--- a/tests/framework/web/widgets/CAutoCompleteTest.php
+++ b/tests/framework/web/widgets/CAutoCompleteTest.php
@@ -28,6 +28,7 @@ class CAutoCompleteTest extends CTestCase
 		$widget->data = array(1, 2, 3);
 		$widget->init();
 		$widget->run();
+		$out = '';
 		Yii::app()->clientScript->render($out);
 		ob_end_clean();
 		return $out;

--- a/tests/framework/web/widgets/CMaskedTextFieldTest.php
+++ b/tests/framework/web/widgets/CMaskedTextFieldTest.php
@@ -9,13 +9,13 @@ class CMaskedTextFieldTest extends CTestCase
 		$expected = "'completed':function() { /* callback */ }";
 
 		$out=$this->getWidgetScript('js:function() { /* callback */ }');
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
 
 		$out=$this->getWidgetScript('function() { /* callback */ }');
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
 
 		$out=$this->getWidgetScript(new CJavaScriptExpression('function() { /* callback */ }'));
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
 	}
 
 	private function getWidgetScript($callback)

--- a/tests/framework/web/widgets/CMaskedTextFieldTest.php
+++ b/tests/framework/web/widgets/CMaskedTextFieldTest.php
@@ -28,6 +28,7 @@ class CMaskedTextFieldTest extends CTestCase
 		$widget->mask = '99/99/9999';
 		$widget->init();
 		$widget->run();
+		$out = '';
 		Yii::app()->clientScript->render($out);
 		ob_end_clean();
 		return $out;

--- a/tests/framework/web/widgets/CMultiFileUploadTest.php
+++ b/tests/framework/web/widgets/CMultiFileUploadTest.php
@@ -9,13 +9,13 @@ class CMultiFileUploadTest extends CTestCase
 		$expected = "'onFileSelect':function() { /* callback */ }";
 
 		$out=$this->getWidgetScript('js:function() { /* callback */ }');
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
 
 		$out=$this->getWidgetScript('function() { /* callback */ }');
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
 
 		$out=$this->getWidgetScript(new CJavaScriptExpression('function() { /* callback */ }'));
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
 	}
 
 	private function getWidgetScript($callback)

--- a/tests/framework/web/widgets/CMultiFileUploadTest.php
+++ b/tests/framework/web/widgets/CMultiFileUploadTest.php
@@ -27,6 +27,7 @@ class CMultiFileUploadTest extends CTestCase
 		$widget->options['onFileSelect'] = $callback;
 		$widget->init();
 		$widget->run();
+		$out = '';
 		Yii::app()->clientScript->render($out);
 		ob_end_clean();
 		return $out;

--- a/tests/framework/web/widgets/CStarRatingTest.php
+++ b/tests/framework/web/widgets/CStarRatingTest.php
@@ -9,13 +9,13 @@ class CStarRatingTest extends CTestCase
 		$expected = "'callback':function() { /* callback */ }";
 
 		$out=$this->getWidgetScript('js:function() { /* callback */ }');
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
 
 		$out=$this->getWidgetScript('function() { /* callback */ }');
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
 
 		$out=$this->getWidgetScript(new CJavaScriptExpression('function() { /* callback */ }'));
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
 	}
 
 	private function getWidgetScript($callback)

--- a/tests/framework/web/widgets/CStarRatingTest.php
+++ b/tests/framework/web/widgets/CStarRatingTest.php
@@ -27,6 +27,7 @@ class CStarRatingTest extends CTestCase
 		$widget->callback = $callback;
 		$widget->init();
 		$widget->run();
+		$out = '';
 		Yii::app()->clientScript->render($out);
 		ob_end_clean();
 		return $out;

--- a/tests/framework/zii/widgets/CGridViewTest.php
+++ b/tests/framework/zii/widgets/CGridViewTest.php
@@ -46,6 +46,7 @@ class CGridViewTest extends CTestCase
 		$widget->dataProvider = new CArrayDataProvider(array(1, 2, 3));
 		$widget->init();
 		$widget->registerClientScript();
+		$out = '';
 		Yii::app()->clientScript->render($out);
 		ob_end_clean();
 		return $out;

--- a/tests/framework/zii/widgets/CGridViewTest.php
+++ b/tests/framework/zii/widgets/CGridViewTest.php
@@ -14,7 +14,7 @@ class CGridViewTest extends CTestCase
 			'js:function() { /* callback3 */ }',
 			'js:function() { /* callback4 */ }'
 		);
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
 
 		$out=$this->getWidgetScript(
 			'function() { /* callback1 */ }',
@@ -22,7 +22,7 @@ class CGridViewTest extends CTestCase
 			'function() { /* callback3 */ }',
 			'function() { /* callback4 */ }'
 		);
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
 
 		$out=$this->getWidgetScript(
 			new CJavaScriptExpression('function() { /* callback1 */ }'),
@@ -30,7 +30,7 @@ class CGridViewTest extends CTestCase
 			new CJavaScriptExpression('function() { /* callback3 */ }'),
 			new CJavaScriptExpression('function() { /* callback4 */ }')
 		);
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
 	}
 
 	private function getWidgetScript($callback1, $callback2, $callback3, $callback4)

--- a/tests/framework/zii/widgets/CListViewTest.php
+++ b/tests/framework/zii/widgets/CListViewTest.php
@@ -9,13 +9,13 @@ class CListViewTest extends CTestCase
 		$expected = "'beforeAjaxUpdate':function() { /* callback1 */ },'afterAjaxUpdate':function() { /* callback2 */ }";
 
 		$out=$this->getWidgetScript('js:function() { /* callback1 */ }', 'js:function() { /* callback2 */ }');
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
 
 		$out=$this->getWidgetScript('function() { /* callback1 */ }', 'function() { /* callback2 */ }');
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
 
 		$out=$this->getWidgetScript(new CJavaScriptExpression('function() { /* callback1 */ }'), new CJavaScriptExpression('function() { /* callback2 */ }'));
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
 	}
 
 	private function getWidgetScript($callback1, $callback2)

--- a/tests/framework/zii/widgets/CListViewTest.php
+++ b/tests/framework/zii/widgets/CListViewTest.php
@@ -30,6 +30,7 @@ class CListViewTest extends CTestCase
 		$widget->dataProvider = new CArrayDataProvider(array(1, 2, 3));
 		$widget->init();
 		$widget->registerClientScript();
+		$out = '';
 		Yii::app()->clientScript->render($out);
 		ob_end_clean();
 		return $out;

--- a/tests/framework/zii/widgets/grid/CButtonColumnTest.php
+++ b/tests/framework/zii/widgets/grid/CButtonColumnTest.php
@@ -32,6 +32,7 @@ class CButtonColumnTest extends CTestCase
 			),
 		);
 		$widget->init();
+		$out = '';
 		Yii::app()->clientScript->render($out);
 		ob_end_clean();
 		return $out;

--- a/tests/framework/zii/widgets/grid/CButtonColumnTest.php
+++ b/tests/framework/zii/widgets/grid/CButtonColumnTest.php
@@ -9,13 +9,13 @@ class CButtonColumnTest extends CTestCase
 		$expected = "jQuery(document).on('click','#grid1 a.view',function() { /* callback */ });";
 
 		$out=$this->getWidgetScript('js:function() { /* callback */ }');
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
 
 		$out=$this->getWidgetScript('function() { /* callback */ }');
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
 
 		$out=$this->getWidgetScript(new CJavaScriptExpression('function() { /* callback */ }'));
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
 	}
 
 	private function getWidgetScript($callback)

--- a/tests/framework/zii/widgets/jui/CJuiButtonTest.php
+++ b/tests/framework/zii/widgets/jui/CJuiButtonTest.php
@@ -28,6 +28,7 @@ class CJuiButtonTest extends CTestCase
 		$widget->onclick = $callback;
 		$widget->init();
 		$widget->run();
+		$out = '';
 		Yii::app()->clientScript->render($out);
 		ob_end_clean();
 		return $out;

--- a/tests/framework/zii/widgets/jui/CJuiButtonTest.php
+++ b/tests/framework/zii/widgets/jui/CJuiButtonTest.php
@@ -9,13 +9,13 @@ class CJuiButtonTest extends CTestCase
 		$expected = ".click(function() { /* callback */ });";
 
 		$out=$this->getWidgetScript('js:function() { /* callback */ }');
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (js:): ".$out);
 
 		$out=$this->getWidgetScript('function() { /* callback */ }');
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (w/o js:): ".$out);
 
 		$out=$this->getWidgetScript(new CJavaScriptExpression('function() { /* callback */ }'));
-		$this->assertTrue(mb_strpos($out,$expected, null, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
+		$this->assertTrue(mb_strpos($out,$expected, 0, Yii::app()->charset)!==false, "Unexpected JavaScript (wrap): ".$out);
 	}
 
 	private function getWidgetScript($callback)


### PR DESCRIPTION
Re-enabled deprecation errors in tests and fixed them.

Main fixes:
- CStarRating widget throwing a deprecation error if it is initalized without `value`;
- `strcmp`, `strtolower`, `mb_stringtolower`, `mb_strpos` and other built in functions being passed  `null` in tests;
- CFileValidatorTest testing for the wrong value, it returns 0 as the outcome is always cased to an int. The test never failed because `assertEquals` uses `==` and performs type coercion;
- CStringValidator treating `null` as an empty string, `strlen(null)` is deprecated so a cast is needed;
- ClientScript tests using a reference to an uninitialised variable, for example: https://github.com/yiisoft/yii/blob/1c6f6fe221404de9afeb32059e6671676237482c/tests/framework/web/widgets/CAutoCompleteTest.php#L31 causing a deprecation error in: https://github.com/yiisoft/yii/blob/1c6f6fe221404de9afeb32059e6671676237482c/framework/web/CClientScript.php#L414 as `$output` would be `null`.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #4506 
