### PR TITLE
PHP 8.1 compatibility: Fix deprecation warning in CHtml::value 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ Version 1.1.28 under development
 - Bug #4499: PHP 8.1 compatibility: Fix deprecation warning in COciSchema (marcovtwout)
 - Bug #4500: PHP 8.1 compatibility: Fix deprecation warnings in CMysql classes (csears123)
 - Bug #4507: PHP 8.1 compatibility: Fix deprecation warning in CWebUser (marcovtwout, wtommyw)
+- Bug: PHP 8.1 compatibility: Fix deprecation warning in CHtml::value (papppeter)
 
 Version 1.1.27 November 21, 2022
 --------------------------------

--- a/framework/web/helpers/CHtml.php
+++ b/framework/web/helpers/CHtml.php
@@ -2369,7 +2369,11 @@ EOD;
 	 */
 	public static function value($model,$attribute,$defaultValue=null)
 	{
-		if(is_scalar($attribute) || $attribute===null)
+        if($attribute === null) {
+            return $defaultValue;
+        }
+		
+		if(is_scalar($attribute))
 			foreach(explode('.',(string)$attribute) as $name)
 			{
 				if(is_object($model))

--- a/framework/yiilite.php
+++ b/framework/yiilite.php
@@ -5914,6 +5914,10 @@ EOD;
 	}
 	public static function value($model,$attribute,$defaultValue=null)
 	{
+		if($attribute === null) {
+            return $defaultValue;
+        }
+		
 		if(is_scalar($attribute) || $attribute===null)
 			foreach(explode('.',$attribute) as $name)
 			{


### PR DESCRIPTION
<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | Explode cannot accept null.
