### PR TITLE
Fix type checking on union and intersection types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 Version 1.1.29 under development
 --------------------------------
 
-- No changes yet
+- Bug #4516: PHP 8 compatibility: Allow union types and intersection types in action declarations (wtommyw)
 
 Version 1.1.28 February 28, 2023
 --------------------------------

--- a/framework/console/CConsoleCommand.php
+++ b/framework/console/CConsoleCommand.php
@@ -129,12 +129,19 @@ abstract class CConsoleCommand extends CComponent
 			$name=$param->getName();
 			if(isset($options[$name]))
 			{
-				if(version_compare(PHP_VERSION,'8.0','>=')) {
-					$isArray=$param->getType() && $param->getType()->getName()==='array';
+				if(PHP_VERSION_ID >= 80000) {
+					$type = $param->getType();
+					if ((PHP_VERSION_ID >= 80100 && $type instanceof \ReflectionIntersectionType)
+						|| $type instanceof  \ReflectionUnionType) {
+						foreach($type->getTypes() as $complexType) {
+							$isArray=$complexType->getName()==='array';
+						}
+					} else {
+						$isArray=$type && $type->getName()==='array';
+					}
 				} else {
-					$isArray = $param->isArray();
+					$isArray=$param->isArray();
 				}
-
 				if($isArray)
 					$params[]=is_array($options[$name]) ? $options[$name] : array($options[$name]);
 				elseif(!is_array($options[$name]))

--- a/framework/console/CConsoleCommand.php
+++ b/framework/console/CConsoleCommand.php
@@ -129,19 +129,11 @@ abstract class CConsoleCommand extends CComponent
 			$name=$param->getName();
 			if(isset($options[$name]))
 			{
-				if(PHP_VERSION_ID >= 80000) {
-					$type = $param->getType();
-					if ((PHP_VERSION_ID >= 80100 && $type instanceof \ReflectionIntersectionType)
-						|| $type instanceof  \ReflectionUnionType) {
-						foreach($type->getTypes() as $complexType) {
-							$isArray=$complexType->getName()==='array';
-						}
-					} else {
-						$isArray=$type && $type->getName()==='array';
-					}
-				} else {
+				if(version_compare(PHP_VERSION,'8.0','>='))
+					$isArray=($type=$param->getType()) instanceof \ReflectionNamedType && $type->getName()==='array';
+				else
 					$isArray=$param->isArray();
-				}
+
 				if($isArray)
 					$params[]=is_array($options[$name]) ? $options[$name] : array($options[$name]);
 				elseif(!is_array($options[$name]))

--- a/framework/web/actions/CAction.php
+++ b/framework/web/actions/CAction.php
@@ -94,19 +94,11 @@ abstract class CAction extends CComponent implements IAction
 			$name=$param->getName();
 			if(isset($params[$name]))
 			{
-				if(PHP_VERSION_ID >= 80000) {
-					$type = $param->getType();
-					if ((PHP_VERSION_ID >= 80100 && $type instanceof \ReflectionIntersectionType)
-						|| $type instanceof  \ReflectionUnionType) {
-						foreach($type->getTypes() as $complexType) {
-							$isArray=$complexType->getName()==='array';
-						}
-					} else {
-						$isArray=$type && $type->getName()==='array';
-					}
-				} else {
+				if(version_compare(PHP_VERSION,'8.0','>='))
+					$isArray=($type=$param->getType()) instanceof \ReflectionNamedType && $type->getName()==='array';
+				else
 					$isArray=$param->isArray();
-                }
+
 				if($isArray)
 					$ps[]=is_array($params[$name]) ? $params[$name] : array($params[$name]);
 				elseif(!is_array($params[$name]))

--- a/framework/web/actions/CAction.php
+++ b/framework/web/actions/CAction.php
@@ -94,12 +94,19 @@ abstract class CAction extends CComponent implements IAction
 			$name=$param->getName();
 			if(isset($params[$name]))
 			{
-				if(version_compare(PHP_VERSION,'8.0','>=')) {
-					$isArray=$param->getType() && $param->getType()->getName()==='array';
+				if(PHP_VERSION_ID >= 80000) {
+					$type = $param->getType();
+					if ((PHP_VERSION_ID >= 80100 && $type instanceof \ReflectionIntersectionType)
+						|| $type instanceof  \ReflectionUnionType) {
+						foreach($type->getTypes() as $complexType) {
+							$isArray=$complexType->getName()==='array';
+						}
+					} else {
+						$isArray=$type && $type->getName()==='array';
+					}
 				} else {
 					$isArray=$param->isArray();
                 }
-
 				if($isArray)
 					$ps[]=is_array($params[$name]) ? $params[$name] : array($params[$name]);
 				elseif(!is_array($params[$name]))


### PR DESCRIPTION
<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #4516, #4518

Fixes type checking on union and intersection types in `CAction`  and `CConsoleCommand` 
