### PR TITLE
Update YiiBase.php to fix autoload to handle null includePaths

### DIFF
--- a/framework/YiiBase.php
+++ b/framework/YiiBase.php
@@ -444,7 +444,7 @@ class YiiBase
 			{
 				if(self::$enableIncludePath===false)
 				{
-					foreach(self::$_includePaths as $path)
+					foreach(self::$_includePaths ?: [] as $path)
 					{
 						$classFile=$path.DIRECTORY_SEPARATOR.$className.'.php';
 						if(is_file($classFile))


### PR DESCRIPTION
Fix static autoload to handle case where _includePaths isn't set yet (so isn't an array)

<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
