### PR TITLE
FIX: incorrectly translated messages for Greek in requirements view

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Version 1.1.29 under development
 --------------------------------
 
 - Bug #4516: PHP 8 compatibility: Allow union types and intersection types in action declarations (wtommyw)
+- Bug #4523: Fixed translated in Greek class messages in framework requirements view, which they should not be translated.
 
 Version 1.1.28 February 28, 2023
 --------------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ Version 1.1.29 under development
 --------------------------------
 
 - Bug #4516: PHP 8 compatibility: Allow union types and intersection types in action declarations (wtommyw)
-- Bug #4523: Fixed translated in Greek class messages in framework requirements view, which they should not be translated.
+- Bug #4523: Fixed translated in Greek class messages in framework requirements view, which they should not be translated (lourdas)
 
 Version 1.1.28 February 28, 2023
 --------------------------------

--- a/requirements/views/el/index.php
+++ b/requirements/views/el/index.php
@@ -43,7 +43,7 @@
 	<td>
 	<?php echo $requirement[0]; ?>
 	</td>
-	<td class="<?php echo $requirement[2] ? 'πέρασε' : ($requirement[1] ? 'απέτυχε' : 'προειδοποίηση'); ?>">
+	<td class="<?php echo $requirement[2] ? 'passed' : ($requirement[1] ? 'failed' : 'warning'); ?>">
 	<?php echo $requirement[2] ? 'Πέρασε' : ($requirement[1] ? 'Απέτυχε' : 'Προειδοποίηση'); ?>
 	</td>
 	<td>


### PR DESCRIPTION
<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️

The requirements view file for Greek had a few class strings translated, which was wrong. This pull request fixes this.