### PR TITLE
Update PHP supported version from 8.1 to 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Thank you for choosing Yii - a high-performance component-based PHP framework.
   and will only receive necessary security fixes and fixes to adjust the code for compatibility with PHP 7 and 8 if they do not cause breaking changes.
   This allows you to keep your servers PHP version up to date in the environments where old Yii 1.1 applications are hosted and stay within the [version ranges supported by the PHP team](http://php.net/supported-versions.php).
 > 
-> Currently tested and supported [up to PHP 8.1](https://github.com/yiisoft/yii/blob/master/.github/workflows/build.yml#L33).
+> Currently tested and supported [up to PHP 8.2](https://github.com/yiisoft/yii/blob/master/.github/workflows/build.yml#L34).
 
 INSTALLATION
 ------------


### PR DESCRIPTION
Update the docs to show that the current php version 8.2 is supported, showing 8.1 it might give the impression that yii does not support current versions of php.

<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
