### PR TITLE
#[\AllowDynamicProperties] in ActiveRecord Models

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -37,6 +37,7 @@
  * @package system.db.ar
  * @since 1.0
  */
+#[\AllowDynamicProperties]
 abstract class CActiveRecord extends CModel
 {
 	const BELONGS_TO='CBelongsToRelation';


### PR DESCRIPTION
Set this class to Allow Dynamic Properties, this will allow all child classes to allow dynamic properties

https://www.php.net/manual/en/migration82.deprecated.php

This will prevent getting a warning trying to set a dynamic property in CActiveRecord objects

This can be fixed in userland code, but since this is the expected behaviour, I would expect not getting a warning when using dynamic properties.

<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
