### PR TITLE
Allow to instantiate the called class instead of the CActiveRecord class

### DIFF
--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -388,8 +388,12 @@ abstract class CActiveRecord extends CModel
 	 * @param string $className active record class name.
 	 * @return static active record model instance.
 	 */
-	public static function model($className=__CLASS__)
+	public static function model($className=null)
 	{
+		if($className === null){
+			$className = get_called_class();
+		}
+		
 		if(isset(self::$_models[$className]))
 			return self::$_models[$className];
 		else


### PR DESCRIPTION
The problem of this implementation is that this method needs to copied onto the children class to be instantiated correctly, since if the method is inherited _ _ CLASS _ _ will always point to CActiveRecord instead of the class calling this method, using get_called_class() fixes that, this function is present since php 5.3.0

Here's an example:

class A extends CActiveRecord {}

And we call A::model(), we will get an A instance instead of CActiveRecord

```php
<?php

class B
{
    public static function model($className = __CLASS__)
    {
        return new $className(null);
    }	
}

class A extends B
{
}

$b = new B();
$a = new A();

var_dump($b::model());
var_dump($a::model());
```

returns
```
object(B)#3 (0) { } 
object(B)#3 (0) { } 
```
but if we change that to get_called_class()

```php
<?php

class B
{
    public static function model($className = null)
    {
        if($className === null){
	     $className = get_called_class();
        }
        return new $className(null);
    }	
}

class A extends B
{
}

$b = new B();
$a = new A();

var_dump($b::model());
var_dump($a::model());
```
results in

```
object(B)#3 (0) { } 
object(A)#3 (0) { }
```

<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Tests pass?   | ✔️
