### PR TITLE
minor Fix deprecations: curly string access

### DIFF
--- a/build/commands/markdown/MarkdownParser.php
+++ b/build/commands/markdown/MarkdownParser.php
@@ -17,7 +17,7 @@ class MarkdownParser extends CMarkdownParser
 	{
 		if ($matches[3] == '-' && preg_match('{^- }', $matches[1]))
 			return $matches[0];
-		$level = $matches[3]{0} == '=' ? 1 : 2;
+		$level = $matches[3][0] == '=' ? 1 : 2;
 		$text = $this->runSpanGamut($matches[1]);
 		$attr = $this->doHeaderId($text);
 		$block = "<h$level$attr>".$text."</h$level>";

--- a/docs/viewer/components/MarkdownParser.php
+++ b/docs/viewer/components/MarkdownParser.php
@@ -24,7 +24,7 @@ class MarkdownParser extends CMarkdownParser
 	{
 		if ($matches[3] == '-' && preg_match('{^- }', $matches[1]))
 			return $matches[0];
-		$level = $matches[3]{0} == '=' ? 1 : 2;
+		$level = $matches[3][0] == '=' ? 1 : 2;
 		$text = $this->runSpanGamut($matches[1]);
 		$attr = $this->doHeaderId($text);
 		$block = "<h$level$attr>".$text."</h$level>";


### PR DESCRIPTION
Fix use of access to string using curly brackets https://www.php.net/manual/en/migration74.deprecated.php

Replaces with square brackets.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | 
