### PR TITLE
fix/static method getCanonicalID should not be called dynamically

### DIFF
--- a/framework/i18n/CLocale.php
+++ b/framework/i18n/CLocale.php
@@ -330,7 +330,7 @@ class CLocale extends CComponent
 	public function getLanguageID($id)
 	{
 		// normalize id
-		$id = $this->getCanonicalID($id);
+		$id = self::getCanonicalID($id);
 		// remove sub tags
 		if(($underscorePosition=strpos($id, '_'))!== false)
 		{
@@ -349,7 +349,7 @@ class CLocale extends CComponent
 	public function getScriptID($id)
 	{
 		// normalize id
-		$id = $this->getCanonicalID($id);
+		$id = self::getCanonicalID($id);
 		// find sub tags
 		if(($underscorePosition=strpos($id, '_'))!==false)
 		{
@@ -381,7 +381,7 @@ class CLocale extends CComponent
 	public function getTerritoryID($id)
 	{
 		// normalize id
-		$id = $this->getCanonicalID($id);
+		$id = self::getCanonicalID($id);
 		// find sub tags
 		if (($underscorePosition=strpos($id, '_'))!== false)
 		{
@@ -417,7 +417,7 @@ class CLocale extends CComponent
 	 */
 	public function getLocaleDisplayName($id=null, $category='languages')
 	{
-		$id = $this->getCanonicalID((string)$id);
+		$id = self::getCanonicalID((string)$id);
 		if (($category == 'languages') && (isset($this->_data[$category][$id])))
 		{
 			return $this->_data[$category][$id];


### PR DESCRIPTION
<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
