### PR TITLE
Method CDbCommandBuilder:: createMultipleInsertCommandWithIgnore added

### DIFF
--- a/framework/db/schema/CDbCommandBuilder.php
+++ b/framework/db/schema/CDbCommandBuilder.php
@@ -264,7 +264,18 @@ class CDbCommandBuilder extends CComponent
 		return $this->composeMultipleInsertCommand($table,$data);
 	}
 
-	/**
+    /**
+     * Creates a conflict ignorant multiple INSERT command (should be overridden).
+     * @param mixed $table the table schema ({@link CDbTableSchema}) or the table name (string).
+     * @param array[] $data list data to be inserted, each value should be an array in format (column name=>column value).
+     * @return CDbCommand multiple insert command
+     * @since 1.1.30
+     */
+    public function createMultipleInsertCommandWithIgnore($table, array $data) {
+        return $this->createMultipleInsertCommand($table, $data);
+    }
+
+    /**
 	 * Creates a multiple INSERT command.
 	 * This method compose the SQL expression via given part templates, providing ability to adjust
 	 * command for different SQL syntax.

--- a/framework/db/schema/mysql/CMysqlCommandBuilder.php
+++ b/framework/db/schema/mysql/CMysqlCommandBuilder.php
@@ -65,8 +65,8 @@ class CMysqlCommandBuilder extends CDbCommandBuilder
      * @since 1.1.30
      */
     public function createMultipleInsertCommandWithIgnore($table, array $data) {
-        return $this->composeMultipleInsertCommand($table, $data, [
+        return $this->composeMultipleInsertCommand($table, $data, array(
             "main" => "INSERT INTO {{tableName}} ({{columnInsertNames}}) VALUES {{rowInsertValues}} ON DUPLICATE KEY DO NOTHING",
-        ]);
+        ));
     }
 }

--- a/framework/db/schema/mysql/CMysqlCommandBuilder.php
+++ b/framework/db/schema/mysql/CMysqlCommandBuilder.php
@@ -55,4 +55,18 @@ class CMysqlCommandBuilder extends CDbCommandBuilder
 			$limit=PHP_INT_MAX;
 		return parent::applyLimit($sql,$limit,$offset);
 	}
+
+    /**
+     * Creates a conflict ignorant multiple INSERT command.
+     * @param mixed $table the table schema ({@link CDbTableSchema}) or the table name (string).
+     * @param array[] $data list data to be inserted, each value should be an array in format (column name=>column value).
+     * @return CDbCommand multiple insert command
+     * @throws CDbException
+     * @since 1.1.30
+     */
+    public function createMultipleInsertCommandWithIgnore($table, array $data) {
+        return $this->composeMultipleInsertCommand($table, $data, [
+            "main" => "INSERT INTO {{tableName}} ({{columnInsertNames}}) VALUES {{rowInsertValues}} ON DUPLICATE KEY DO NOTHING ",
+        ]);
+    }
 }

--- a/framework/db/schema/mysql/CMysqlCommandBuilder.php
+++ b/framework/db/schema/mysql/CMysqlCommandBuilder.php
@@ -66,7 +66,7 @@ class CMysqlCommandBuilder extends CDbCommandBuilder
      */
     public function createMultipleInsertCommandWithIgnore($table, array $data) {
         return $this->composeMultipleInsertCommand($table, $data, [
-            "main" => "INSERT INTO {{tableName}} ({{columnInsertNames}}) VALUES {{rowInsertValues}} ON DUPLICATE KEY DO NOTHING ",
+            "main" => "INSERT INTO {{tableName}} ({{columnInsertNames}}) VALUES {{rowInsertValues}} ON DUPLICATE KEY DO NOTHING",
         ]);
     }
 }

--- a/framework/db/schema/pgsql/CPgsqlCommandBuilder.php
+++ b/framework/db/schema/pgsql/CPgsqlCommandBuilder.php
@@ -27,4 +27,18 @@ class CPgsqlCommandBuilder extends CDbCommandBuilder
 	{
 		return 'DEFAULT';
 	}
+
+    /**
+     * Creates a conflict ignorant multiple INSERT command.
+     * @param mixed $table the table schema ({@link CDbTableSchema}) or the table name (string).
+     * @param array[] $data list data to be inserted, each value should be an array in format (column name=>column value).
+     * @return CDbCommand multiple insert command
+     * @throws CDbException
+     * @since 1.1.30
+     */
+    public function createMultipleInsertCommandWithIgnore($table, array $data) {
+        return $this->composeMultipleInsertCommand($table, $data, [
+            "main" => "INSERT INTO {{tableName}} ({{columnInsertNames}}) VALUES {{rowInsertValues}} ON CONFLICT DO NOTHING",
+        ]);
+    }
 }

--- a/framework/db/schema/pgsql/CPgsqlCommandBuilder.php
+++ b/framework/db/schema/pgsql/CPgsqlCommandBuilder.php
@@ -37,8 +37,8 @@ class CPgsqlCommandBuilder extends CDbCommandBuilder
      * @since 1.1.30
      */
     public function createMultipleInsertCommandWithIgnore($table, array $data) {
-        return $this->composeMultipleInsertCommand($table, $data, [
+        return $this->composeMultipleInsertCommand($table, $data, array(
             "main" => "INSERT INTO {{tableName}} ({{columnInsertNames}}) VALUES {{rowInsertValues}} ON CONFLICT DO NOTHING",
-        ]);
+        ));
     }
 }


### PR DESCRIPTION
Added method CDbCommandBuilder:: createMultipleInsertCommandWithIgnore and implemented for MySQL and Postgres