### PR TITLE
fix/static methods of HTMLPurifier should not be called dynamically

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Version 1.1.30 under development
 - Bug #4547: PHP 8 compatibility: Fix deprecation in CCaptcha when using Imagick extension (apphp)
 - Bug #4541: PHP 8 compatibility: Fix deprecation in MarkdownParser (mdeweerd)
 - Bug #4544: PHP 8 compatibility: Fix deprecation in CLocale (apphp)
+- Bug #4548: PHP 8 compatibility: Fix deprecation in HTMLPurifier (apphp)
 
 Version 1.1.29 November 14, 2023
 --------------------------------

--- a/framework/vendors/htmlpurifier/HTMLPurifier.standalone.php
+++ b/framework/vendors/htmlpurifier/HTMLPurifier.standalone.php
@@ -7958,13 +7958,13 @@ class HTMLPurifier_Lexer
 
         if ($config->get('HTML.Trusted')) {
             // escape convoluted CDATA
-            $html = $this->escapeCommentedCDATA($html);
+            $html = self::escapeCommentedCDATA($html);
         }
 
         // escape CDATA
-        $html = $this->escapeCDATA($html);
+        $html = self::escapeCDATA($html);
 
-        $html = $this->removeIEConditional($html);
+        $html = self::removeIEConditional($html);
 
         // extract body from document if applicable
         if ($config->get('Core.ConvertDocumentToFragment')) {


### PR DESCRIPTION
Static methods of HTMLPurifier: escapeCommentedCDATA, escapeCDATA and removeIEConditional should not be called dynamically