### PR TITLE
Bug fixed: «mkdir(): File exists» in «framework/utils/CFileHelper.php»

### DIFF
--- a/framework/utils/CFileHelper.php
+++ b/framework/utils/CFileHelper.php
@@ -360,9 +360,16 @@ class CFileHelper
 	{
 		if($mode===null)
 			$mode=0777;
+		
+		if(is_dir($dst))
+	        {
+	        	@chmod($dst,$mode);
+	        	return true;
+	        }
+		
 		$prevDir=dirname($dst);
-		if($recursive && !is_dir($dst) && !is_dir($prevDir))
-			self::createDirectory(dirname($dst),$mode,true);
+		if($recursive && !is_dir($prevDir))
+			self::createDirectory($prevDir,$mode,true);
 		$res=mkdir($dst, $mode);
 		@chmod($dst,$mode);
 		return $res;


### PR DESCRIPTION
В некоторых случаях функция «mkdir()» внутри статического метода «createDirectory()» класса «framework/utils/CFileHelper.php» возвращает ошибку «mkdir(): File exists». Я так понимаю, эта ошибка возникает, если существует каталог со значением переменной $dst. Чтобы исправить эту ошибку, я написал проверку для переменной «$dst». Если каталог «$dst» уже существует, мы устанавливаем для него необходимые права доступа и возвращаем «true».


| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
