### PR TITLE
4552 Update CVarDumper.php for PHP 8.3 changes to highlight_string

### DIFF
--- a/framework/utils/CVarDumper.php
+++ b/framework/utils/CVarDumper.php
@@ -60,7 +60,7 @@ class CVarDumper
 		if($highlight)
 		{
 			$result=highlight_string("<?php\n".self::$_output,true);
-			self::$_output=preg_replace('/&lt;\\?php<br \\/>/','',$result,1);
+			self::$_output=preg_replace('/&lt;\\?php(<br \\/>|'."\n".')/','',$result,1);
 		}
 		return self::$_output;
 	}


### PR DESCRIPTION
PHP 8.3.0 The resulting HTML of highlight_string has changed.

`'/&lt;\\?php<br \\/>/'` no longer removes the `"<?php\n"` added when using highlight_string().

