### PR TITLE
PHP8.1 Compatibility: Fix passing null to parameter in preg_match

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Version 1.1.30 under development
 - Bug #4547: PHP 8 compatibility: Fix deprecation in CCaptcha when using Imagick extension (apphp)
 - Bug #4541: PHP 8 compatibility: Fix deprecation in MarkdownParser (mdeweerd)
 - Bug #4544: PHP 8 compatibility: Fix deprecation in CLocale (apphp)
+- Bug #4548: PHP 8 compatibility: Fix deprecation in HTMLPurifier (apphp)
 
 Version 1.1.29 November 14, 2023
 --------------------------------

--- a/framework/console/CConsoleCommand.php
+++ b/framework/console/CConsoleCommand.php
@@ -229,6 +229,9 @@ abstract class CConsoleCommand extends CComponent
 		$params=array();	// unnamed parameters
 		foreach($args as $arg)
 		{
+            if (is_null($arg))
+                continue;
+
 			if(preg_match('/^--(\w+)(=(.*))?$/',$arg,$matches))  // an option
 			{
 				$name=$matches[1];

--- a/framework/vendors/htmlpurifier/HTMLPurifier.standalone.php
+++ b/framework/vendors/htmlpurifier/HTMLPurifier.standalone.php
@@ -7958,13 +7958,13 @@ class HTMLPurifier_Lexer
 
         if ($config->get('HTML.Trusted')) {
             // escape convoluted CDATA
-            $html = $this->escapeCommentedCDATA($html);
+            $html = self::escapeCommentedCDATA($html);
         }
 
         // escape CDATA
-        $html = $this->escapeCDATA($html);
+        $html = self::escapeCDATA($html);
 
-        $html = $this->removeIEConditional($html);
+        $html = self::removeIEConditional($html);
 
         // extract body from document if applicable
         if ($config->get('Core.ConvertDocumentToFragment')) {


### PR DESCRIPTION
PHP8.1 compatibility fixed.
PHP Deprecated:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /opt/phishing/versions/5.3/web/protected/framework/console/CConsoleCommand.php on line 232


| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | 