### PR TITLE
PHP 8 compatibility: Fix passing null to string parameter parameter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Version 1.1.30 under development
 - Bug #4547: PHP 8 compatibility: Fix deprecation in CCaptcha when using Imagick extension (apphp)
 - Bug #4541: PHP 8 compatibility: Fix deprecation in MarkdownParser (mdeweerd)
 - Bug #4544: PHP 8 compatibility: Fix deprecation in CLocale (apphp)
+- Bug #4566: PHP 8 compatibility: Fix passing null to string parameter parameter (apphp)
 - Enh #4552: Added support for PHP 8.3 (sandippingle, ThePepster, marcovtwout)
 
 Version 1.1.29 November 14, 2023

--- a/framework/console/CConsoleCommand.php
+++ b/framework/console/CConsoleCommand.php
@@ -229,8 +229,8 @@ abstract class CConsoleCommand extends CComponent
 		$params=array();	// unnamed parameters
 		foreach($args as $arg)
 		{
-            if (is_null($arg))
-                continue;
+			if (is_null($arg))
+				continue;
 
 			if(preg_match('/^--(\w+)(=(.*))?$/',$arg,$matches))  // an option
 			{

--- a/framework/console/CConsoleCommand.php
+++ b/framework/console/CConsoleCommand.php
@@ -229,6 +229,9 @@ abstract class CConsoleCommand extends CComponent
 		$params=array();	// unnamed parameters
 		foreach($args as $arg)
 		{
+            if (is_null($arg))
+                continue;
+
 			if(preg_match('/^--(\w+)(=(.*))?$/',$arg,$matches))  // an option
 			{
 				$name=$matches[1];


### PR DESCRIPTION
PHP8.1 compatibility fixed.
PHP Deprecated:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /opt/phishing/versions/5.3/web/protected/framework/console/CConsoleCommand.php on line 232


| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | 