### PR TITLE
Provided a "username" property for Redis cache configurations

### DIFF
--- a/framework/caching/CRedisCache.php
+++ b/framework/caching/CRedisCache.php
@@ -52,6 +52,10 @@ class CRedisCache extends CCache
 	 * @var int the port to use for connecting to the redis server. Default port is 6379.
 	 */
 	public $port=6379;
+	 /**
+  	  * @var string the username to use to authenticate with the redis server. If not set, default username will be sent.
+	  */
+	public $username = 'default';
 	/**
 	 * @var string the password to use to authenticate with the redis server. If not set, no AUTH command will be sent.
 	 */
@@ -97,7 +101,7 @@ class CRedisCache extends CCache
 			if($this->ssl)
 				stream_socket_enable_crypto($this->_socket,true,STREAM_CRYPTO_METHOD_TLS_CLIENT);
 			if($this->password!==null)
-				$this->executeCommand('AUTH',array($this->password));
+				$this->executeCommand('AUTH',array($this->username, $this->password));
 			$this->executeCommand('SELECT',array($this->database));
 		}
 		else


### PR DESCRIPTION
Added a "username" property for the Redis connection authentication. A username may be used other then "default".

<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | 
