### PR TITLE
refactor(security): add pure-PHP HMAC fallback

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 Version 1.1.32 under development
 --------------------------------
 
+- Bug #4590: CSecurityManager: add fallback for dropped hash_hmac algorithms (PHP7.2.0)
 - Enh #4587: Add socket connection support to `CRedisCache` (mateusmetzker)
 
 Version 1.1.31 April 10, 2025

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 Version 1.1.32 under development
 --------------------------------
 
-- Bug #4590: CSecurityManager: add fallback for dropped hash_hmac algorithms (PHP7.2.0)
+- Bug #4590: CSecurityManager: add fallback for dropped hash_hmac algorithms in PHP 7.2 (mdeweerd)
 - Enh #4587: Add socket connection support to `CRedisCache` (mateusmetzker)
 
 Version 1.1.31 April 10, 2025


### PR DESCRIPTION
This fixes issues with deprecations in hash_hamac by adding a pure-PHP HMAC fallback implementation to handle cases where the native `hash_hmac` function for the algorithm is not available.

- Added `my_hash_hmac` function for pure-PHP HMAC calculation
- Added `hash_hmac_fallback` wrapper to use native `hash_hmac` if available, otherwise falls back to `my_hash_hmac`
- Updated `computeHMAC` to use the new fallback mechanism

After a PHP upgrade some feature relying on a specific hash_hmac algorithm did not work any more because it is removed from PHP.


| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
