### PR TITLE
fix: invalid path to /CHttpSessionHandler.php

### DIFF
--- a/framework/yiilite.php
+++ b/framework/yiilite.php
@@ -4665,7 +4665,7 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 			// where SessionHandlerInterface doesn't exist.
 			if(version_compare(PHP_VERSION, '7.0', '>='))
 			{
-				require_once(dirname(__FILE__) . '/CHttpSessionHandler.php');
+				require_once(dirname(__FILE__) . '/web/CHttpSessionHandler.php');
 				@session_set_save_handler(new CHttpSessionHandler($this), true);
 			}
 			else


### PR DESCRIPTION
<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any



This fixes version `1.1.32` if you are using Yii lite the path mapping was wrong.
