### PR TITLE
PDO_OCI returns NULL on INSERT...RETURNING operations in PHP 8.2

### DIFF
--- a/framework/db/schema/oci/COciCommandBuilder.php
+++ b/framework/db/schema/oci/COciCommandBuilder.php
@@ -113,12 +113,7 @@ EOD;
 
 		$sql="INSERT INTO {$table->rawName} (".implode(', ',$fields).') VALUES ('.implode(', ',$placeholders).')';
 
-		if(is_string($table->primaryKey) && ($column=$table->getColumn($table->primaryKey))!==null && $column->type!=='string')
-		{
-			$command=$this->getDbConnection()->createCommand($sql);
-		}
-		else
-			$command=$this->getDbConnection()->createCommand($sql);
+		$command=$this->getDbConnection()->createCommand($sql);
 
 		foreach($values as $name=>$value)
 			$command->bindValue($name,$value);

--- a/framework/db/schema/oci/COciCommandBuilder.php
+++ b/framework/db/schema/oci/COciCommandBuilder.php
@@ -109,6 +109,7 @@ EOD;
 		{
 			$sql.=' RETURNING '.$column->rawName.' INTO :RETURN_ID';
 			$command=$this->getDbConnection()->createCommand($sql);
+			$this->returnID = 0;
 			$command->bindParam(':RETURN_ID', $this->returnID, PDO::PARAM_INT, 12);
 			$table->sequenceName='RETURN_ID';
 		}

--- a/framework/db/schema/oci/COciCommandBuilder.php
+++ b/framework/db/schema/oci/COciCommandBuilder.php
@@ -28,7 +28,15 @@ class COciCommandBuilder extends CDbCommandBuilder
 	 */
 	public function getLastInsertID($table)
 	{
-		return $this->returnID;
+		if($table !== null && $table->sequenceName !== null) {
+            $sql = "SELECT " . $table->sequenceName . ".CURRVAL FROM DUAL";
+            try {
+                return $this->getDbConnection()->createCommand($sql)->queryScalar();
+            } catch(Exception $e) {
+                return $this->returnID;
+            }
+        }
+        return $this->returnID;
 	}
 
 	/**
@@ -107,11 +115,7 @@ EOD;
 
 		if(is_string($table->primaryKey) && ($column=$table->getColumn($table->primaryKey))!==null && $column->type!=='string')
 		{
-			$sql.=' RETURNING '.$column->rawName.' INTO :RETURN_ID';
 			$command=$this->getDbConnection()->createCommand($sql);
-			$this->returnID = 0;
-			$command->bindParam(':RETURN_ID', $this->returnID, PDO::PARAM_INT, 12);
-			$table->sequenceName='RETURN_ID';
 		}
 		else
 			$command=$this->getDbConnection()->createCommand($sql);

--- a/framework/db/schema/oci/COciSchema.php
+++ b/framework/db/schema/oci/COciSchema.php
@@ -213,12 +213,34 @@ EOD;
 					$table->primaryKey=array($table->primaryKey,$c->name);
 				else
 					$table->primaryKey[]=$c->name;
-				$table->sequenceName='';
+				$table->sequenceName=$this->getTableSequenceName($table->name);
 				$c->autoIncrement=true;
 			}
 		}
 		return true;
 	}
+
+	/**
+     * Sequence name of table.
+     * @param string $tableName table name
+     * @return string Whether the sequence exists.
+     */
+    protected function getTableSequenceName($tableName)
+    {
+        $sequenceNameSql = <<<EOD
+SELECT
+    UD.REFERENCED_NAME AS SEQUENCE_NAME
+    FROM USER_DEPENDENCIES UD
+    JOIN USER_TRIGGERS UT ON (UT.TRIGGER_NAME = UD.NAME)
+    WHERE
+    UT.TABLE_NAME = '{$tableName}'
+    AND UD.TYPE = 'TRIGGER'
+    AND UD.REFERENCED_TYPE = 'SEQUENCE'
+EOD;
+
+        $sequenceName = $this->getDbConnection()->createCommand($sequenceNameSql)->queryScalar();
+        return $sequenceName === false ? '' : $sequenceName;
+    }
 
 	/**
 	 * Creates a table column.


### PR DESCRIPTION
A critical issue encountered when migrating from PHP 7.3 to PHP 8.2 using the PDO_OCI driver with Oracle database.

After migrating from PHP 7.3.20, the application stopped functioning correctly. Whenever a new record was created in Oracle, the RETURNING INTO clause failed to populate the ID reference, returning NULL instead. I fixed this by explicitly casting the variable to an integer to ensure proper binding in the PHP 8 environment.

Forced $this->returnID = 0; immediately before bindParam to ensure a clean integer memory buffer is allocated.
Tested with php 8.2.28 and work fine, backward compatibility maintained.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️