### PR TITLE
Add PHP 8.6 session handler methods

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 Version 1.1.33 under development
 --------------------------------
 
-- Bug: Add PHP 8.6-compatible custom session ID handling (ac-dc)
+- Bug #4626: Add PHP 8.6-compatible custom session ID handling (ac-dc)
 - Bug #4627: Replace deprecated `is_integer()` calls with `is_int()` for PHP 8.6 (ac-dc)
 - Bug #4598: PHP 8.5 compatibility: Fix deprecated non-canonical casts to canonical forms (ac-dc)
 - Bug #4607: Fix loading CHttpSessionHandler when using yiilite on Yii 1.1.32 and PHP 7+ (tance77, marcovtwout)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 Version 1.1.33 under development
 --------------------------------
 
+- Bug: Add PHP 8.6-compatible custom session ID handling (ac-dc)
 - Bug #4627: Replace deprecated `is_integer()` calls with `is_int()` for PHP 8.6 (ac-dc)
 - Bug #4598: PHP 8.5 compatibility: Fix deprecated non-canonical casts to canonical forms (ac-dc)
 - Bug #4607: Fix loading CHttpSessionHandler when using yiilite on Yii 1.1.32 and PHP 7+ (tance77, marcovtwout)

--- a/framework/web/CCacheHttpSession.php
+++ b/framework/web/CCacheHttpSession.php
@@ -78,6 +78,16 @@ class CCacheHttpSession extends CHttpSession
 	}
 
 	/**
+	 * Session ID validation handler.
+	 * @param string $id session ID
+	 * @return boolean whether the session ID exists
+	 */
+	public function validateSession($id)
+	{
+		return $this->_cache->get($this->calculateKey($id))!==false;
+	}
+
+	/**
 	 * Session write handler.
 	 * Do not call this method directly.
 	 * @param string $id session ID

--- a/framework/web/CDbHttpSession.php
+++ b/framework/web/CDbHttpSession.php
@@ -232,6 +232,20 @@ class CDbHttpSession extends CHttpSession
 	}
 
 	/**
+	 * Session ID validation handler.
+	 * @param string $id session ID
+	 * @return boolean whether the session ID exists
+	 */
+	public function validateSession($id)
+	{
+		return $this->getDbConnection()->createCommand()
+			->select('id')
+			->from($this->sessionTableName)
+			->where('expire>:expire AND id=:id',array(':expire'=>time(),':id'=>$id))
+			->queryScalar()!==false;
+	}
+
+	/**
 	 * Session write handler.
 	 * Do not call this method directly.
 	 * @param string $id session ID

--- a/framework/web/CHttpSession.php
+++ b/framework/web/CHttpSession.php
@@ -433,6 +433,19 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 	}
 
 	/**
+	 * Session ID validation handler.
+	 * This method should be overridden if {@link useCustomStorage} is set true
+	 * and the storage can distinguish an empty session from a missing one.
+	 * @param string $id session ID
+	 * @return boolean whether the session ID exists
+	 */
+	public function validateSession($id)
+	{
+		$data=$this->readSession($id);
+		return $data!=='' && $data!==false;
+	}
+
+	/**
 	 * Session write handler.
 	 * This method should be overridden if {@link useCustomStorage} is set true.
 	 * Do not call this method directly.

--- a/framework/web/CHttpSessionHandler.php
+++ b/framework/web/CHttpSessionHandler.php
@@ -106,7 +106,21 @@ class CHttpSessionHandler implements SessionHandlerInterface
 	 */
 	public function create_sid()
 	{
-		return bin2hex(random_bytes(16));
+		$length=(int)ini_get('session.sid_length');
+		$bitsPerCharacter=(int)ini_get('session.sid_bits_per_character');
+		if($length<1)
+			$length=32;
+		if($bitsPerCharacter<4 || $bitsPerCharacter>6)
+			$bitsPerCharacter=4;
+
+		$alphabet=substr('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ,-',0,1 << $bitsPerCharacter);
+		$mask=(1 << $bitsPerCharacter)-1;
+		$bytes=random_bytes($length);
+		$id='';
+		for($i=0;$i<$length;++$i)
+			$id.=$alphabet[ord($bytes[$i]) & $mask];
+
+		return $id;
 	}
 
 	/**

--- a/framework/web/CHttpSessionHandler.php
+++ b/framework/web/CHttpSessionHandler.php
@@ -106,9 +106,6 @@ class CHttpSessionHandler implements SessionHandlerInterface
 	 */
 	public function create_sid()
 	{
-		if(function_exists('session_create_id'))
-			return session_create_id();
-
 		return bin2hex(random_bytes(16));
 	}
 
@@ -119,8 +116,6 @@ class CHttpSessionHandler implements SessionHandlerInterface
 	 */
 	public function validateId($id)
 	{
-		// Preserve legacy acceptance of the current client-supplied ID while
-		// reporting newly generated collision candidates as unused.
-		return $id===session_id();
+		return $this->_session->validateSession($id);
 	}
 }

--- a/framework/web/CHttpSessionHandler.php
+++ b/framework/web/CHttpSessionHandler.php
@@ -114,13 +114,13 @@ class CHttpSessionHandler implements SessionHandlerInterface
 
 	/**
 	 * Validates a session ID.
-	 * Returning true preserves the behavior of the legacy callback-based handler,
-	 * which accepted externally supplied session IDs.
 	 * @param string $id the session ID
 	 * @return bool whether the session ID is valid
 	 */
 	public function validateId($id)
 	{
-		return true;
+		// Preserve legacy acceptance of the current client-supplied ID while
+		// reporting newly generated collision candidates as unused.
+		return $id===session_id();
 	}
 }

--- a/framework/web/CHttpSessionHandler.php
+++ b/framework/web/CHttpSessionHandler.php
@@ -99,4 +99,28 @@ class CHttpSessionHandler implements SessionHandlerInterface
 	{
 		return $this->_session->gcSession($max_lifetime) ? 0 : false;
 	}
+
+	/**
+	 * Creates a new session ID.
+	 * @return string the new session ID
+	 */
+	public function create_sid()
+	{
+		if(function_exists('session_create_id'))
+			return session_create_id();
+
+		return bin2hex(random_bytes(16));
+	}
+
+	/**
+	 * Validates a session ID.
+	 * Returning true preserves the behavior of the legacy callback-based handler,
+	 * which accepted externally supplied session IDs.
+	 * @param string $id the session ID
+	 * @return bool whether the session ID is valid
+	 */
+	public function validateId($id)
+	{
+		return true;
+	}
 }

--- a/framework/yiilite.php
+++ b/framework/yiilite.php
@@ -4857,6 +4857,11 @@ class CHttpSession extends CApplicationComponent implements IteratorAggregate,Ar
 	{
 		return '';
 	}
+	public function validateSession($id)
+	{
+		$data=$this->readSession($id);
+		return $data!=='' && $data!==false;
+	}
 	public function writeSession($id,$data)
 	{
 		return true;

--- a/tests/framework/web/CCacheHttpSessionTest.php
+++ b/tests/framework/web/CCacheHttpSessionTest.php
@@ -24,12 +24,18 @@ class CCacheHttpSessionTest extends CTestCase
 
 		$this->assertTrue($session->destroySession('test'));
 		$this->assertEquals('',$session->readSession('test'));
+		$this->assertFalse($session->validateSession('test'));
 
 		$this->assertTrue($session->writeSession('test','any value'));
 		$this->assertEquals('any value',$session->readSession('test'));
+		$this->assertTrue($session->validateSession('test'));
+
+		$this->assertTrue($session->writeSession('test',''));
+		$this->assertTrue($session->validateSession('test'));
 
 		$this->assertTrue($session->destroySession('test'));
 		$this->assertEquals('',$session->readSession('test'));
+		$this->assertFalse($session->validateSession('test'));
 	}
 
 	/**

--- a/tests/framework/web/CHttpSessionTest.php
+++ b/tests/framework/web/CHttpSessionTest.php
@@ -123,6 +123,24 @@ class CHttpSessionTest extends CTestCase {
 		restore_error_handler();
 	}
 
+	public function testCustomStorageHandlerCreatesConfiguredSessionId()
+	{
+		if(version_compare(PHP_VERSION, '7.0', '<'))
+		{
+			$this->markTestSkipped('Object-style session handlers are used on PHP 7.0+ only.');
+		}
+
+		Yii::import('system.web.CHttpSessionHandler');
+
+		$handler=new CHttpSessionHandler(new CustomStorageSession());
+		$sessionId=$handler->create_sid();
+		$bitsPerCharacter=(int)ini_get('session.sid_bits_per_character');
+		$alphabet=substr('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ,-',0,1 << $bitsPerCharacter);
+
+		$this->assertSame((int)ini_get('session.sid_length'),strlen($sessionId));
+		$this->assertSame(strlen($sessionId),strspn($sessionId,$alphabet));
+	}
+
 	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled

--- a/tests/framework/web/CHttpSessionTest.php
+++ b/tests/framework/web/CHttpSessionTest.php
@@ -104,4 +104,21 @@ class CHttpSessionTest extends CTestCase {
 		}
 		restore_error_handler();
 	}
+
+	public function testCustomStorageHandlerSupportsSessionIdValidation()
+	{
+		if(version_compare(PHP_VERSION, '7.0', '<'))
+		{
+			$this->markTestSkipped('Object-style session handlers are used on PHP 7.0+ only.');
+		}
+
+		Yii::import('system.web.CHttpSessionHandler');
+
+		$handler=new CHttpSessionHandler(new CustomStorageSession());
+		$sessionId=$handler->create_sid();
+
+		$this->assertInternalType('string', $sessionId);
+		$this->assertNotSame('', $sessionId);
+		$this->assertTrue($handler->validateId($sessionId));
+	}
 }

--- a/tests/framework/web/CHttpSessionTest.php
+++ b/tests/framework/web/CHttpSessionTest.php
@@ -7,8 +7,26 @@ Yii::import('system.web.CHttpSession');
  */
 class CustomStorageSession extends CHttpSession
 {
+	private $_data=array();
+
 	public function getUseCustomStorage()
 	{
+		return true;
+	}
+
+	public function readSession($id)
+	{
+		return isset($this->_data[$id]) ? $this->_data[$id] : '';
+	}
+
+	public function validateSession($id)
+	{
+		return isset($this->_data[$id]);
+	}
+
+	public function writeSession($id,$data)
+	{
+		$this->_data[$id]=$data;
 		return true;
 	}
 }
@@ -111,9 +129,9 @@ class CHttpSessionTest extends CTestCase {
 	 */
 	public function testCustomStorageHandlerSupportsSessionIdCreation()
 	{
-		if(version_compare(PHP_VERSION, '7.0', '<'))
+		if(version_compare(PHP_VERSION, '7.4', '<'))
 		{
-			$this->markTestSkipped('Object-style session handlers are used on PHP 7.0+ only.');
+			$this->markTestSkipped('Custom session ID validation is not reliable before PHP 7.4.');
 		}
 
 		Yii::import('system.web.CHttpSessionHandler');
@@ -122,10 +140,15 @@ class CHttpSessionTest extends CTestCase {
 		session_set_save_handler($handler, true);
 
 		$this->assertTrue(session_start());
+		$currentSessionId=session_id();
 		$sessionId=session_create_id();
 
 		$this->assertInternalType('string', $sessionId);
 		$this->assertNotSame('', $sessionId);
+		$this->assertFalse($handler->validateId($sessionId));
+
+		$_SESSION['stored']=true;
 		session_write_close();
+		$this->assertTrue($handler->validateId($currentSessionId));
 	}
 }

--- a/tests/framework/web/CHttpSessionTest.php
+++ b/tests/framework/web/CHttpSessionTest.php
@@ -105,7 +105,11 @@ class CHttpSessionTest extends CTestCase {
 		restore_error_handler();
 	}
 
-	public function testCustomStorageHandlerSupportsSessionIdValidation()
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testCustomStorageHandlerSupportsSessionIdCreation()
 	{
 		if(version_compare(PHP_VERSION, '7.0', '<'))
 		{
@@ -115,10 +119,13 @@ class CHttpSessionTest extends CTestCase {
 		Yii::import('system.web.CHttpSessionHandler');
 
 		$handler=new CHttpSessionHandler(new CustomStorageSession());
-		$sessionId=$handler->create_sid();
+		session_set_save_handler($handler, true);
+
+		$this->assertTrue(session_start());
+		$sessionId=session_create_id();
 
 		$this->assertInternalType('string', $sessionId);
 		$this->assertNotSame('', $sessionId);
-		$this->assertTrue($handler->validateId($sessionId));
+		session_write_close();
 	}
 }

--- a/tests/framework/web/CHttpSessionTest.php
+++ b/tests/framework/web/CHttpSessionTest.php
@@ -134,10 +134,15 @@ class CHttpSessionTest extends CTestCase {
 
 		$handler=new CHttpSessionHandler(new CustomStorageSession());
 		$sessionId=$handler->create_sid();
+		$length=(int)ini_get('session.sid_length');
 		$bitsPerCharacter=(int)ini_get('session.sid_bits_per_character');
+		if($length<1)
+			$length=32;
+		if($bitsPerCharacter<4 || $bitsPerCharacter>6)
+			$bitsPerCharacter=4;
 		$alphabet=substr('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ,-',0,1 << $bitsPerCharacter);
 
-		$this->assertSame((int)ini_get('session.sid_length'),strlen($sessionId));
+		$this->assertSame($length,strlen($sessionId));
 		$this->assertSame(strlen($sessionId),strspn($sessionId,$alphabet));
 	}
 


### PR DESCRIPTION
## Summary

- add `create_sid()` and `validateId()` to `CHttpSessionHandler`
- avoid the PHP 8.6 deprecation emitted when an object passed to `session_set_save_handler()` does not provide these methods
- generate session IDs directly using the configured `session.sid_length` and `session.sid_bits_per_character`, without recursively calling `session_create_id()`
- validate IDs against the configured storage backend so strict mode rejects unknown client-supplied IDs

## Motivation

PHP 8.6 deprecates passing a session handler object without `create_sid()` and `validateId()`. PHP 9 will require these methods as part of `SessionHandlerInterface`.

RFC:
https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_passing_a_sessionhandler_object_to_session_set_save_handler_which_does_not_contain_the_create_sid_and_validateid_methods

## Behavior

With `session.use_strict_mode=1`, externally supplied IDs that do not exist in storage are replaced. Existing IDs are accepted, including sessions whose stored payload is empty. This preserves strict-mode session fixation protection and provides meaningful collision detection.

## Tests

- current PHP: 4 tests, 93 assertions
- current PHP with `session.use_strict_mode=1`: 4 tests, 93 assertions
- PHP 7.4: 4 tests, 91 assertions, 1 expected skip
- PHP 7.1: 4 tests, 86 assertions, 2 expected skips
- configured 48-character, 6-bit session IDs verified separately on PHP 7.1 and 7.4
- the full `session_create_id()` lifecycle test is skipped below PHP 7.4 because of known bugs in older PHP session-handler behavior