### PR TITLE
Fix #4627: Replace deprecated `is_integer()` calls with `is_int()` for PHP 8.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 Version 1.1.33 under development
 --------------------------------
 
+- Bug: Replace deprecated `is_integer()` calls with `is_int()` for PHP 8.6 (ac-dc)
 - Bug #4598: PHP 8.5 compatibility: Fix deprecated non-canonical casts to canonical forms (ac-dc)
 - Bug #4607: Fix loading CHttpSessionHandler when using yiilite on Yii 1.1.32 and PHP 7+ (tance77, marcovtwout)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 Version 1.1.33 under development
 --------------------------------
 
-- Bug: Replace deprecated `is_integer()` calls with `is_int()` for PHP 8.6 (ac-dc)
+- Bug #4627: Replace deprecated `is_integer()` calls with `is_int()` for PHP 8.6 (ac-dc)
 - Bug #4598: PHP 8.5 compatibility: Fix deprecated non-canonical casts to canonical forms (ac-dc)
 - Bug #4607: Fix loading CHttpSessionHandler when using yiilite on Yii 1.1.32 and PHP 7+ (tance77, marcovtwout)
 

--- a/framework/collections/CMap.php
+++ b/framework/collections/CMap.php
@@ -288,7 +288,7 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 			$next=array_shift($args);
 			foreach($next as $k => $v)
 			{
-				if(is_integer($k))
+				if(is_int($k))
 					isset($res[$k]) ? $res[]=$v : $res[$k]=$v;
 				elseif(is_array($v) && isset($res[$k]) && is_array($res[$k]))
 					$res[$k]=self::mergeArray($res[$k],$v);

--- a/framework/db/ar/CActiveRecord.php
+++ b/framework/db/ar/CActiveRecord.php
@@ -1164,7 +1164,7 @@ abstract class CActiveRecord extends CModel
 			$values=array();
 			foreach($attributes as $name=>$value)
 			{
-				if(is_integer($name))
+				if(is_int($name))
 					$values[$value]=$this->$value;
 				else
 					$values[$name]=$this->$name=$value;
@@ -1379,7 +1379,7 @@ abstract class CActiveRecord extends CModel
 			$c=$this->getDbCriteria();
 			foreach((array)$criteria->scopes as $k=>$v)
 			{
-				if(is_integer($k))
+				if(is_int($k))
 				{
 					if(is_string($v))
 					{

--- a/framework/db/schema/CDbCriteria.php
+++ b/framework/db/schema/CDbCriteria.php
@@ -590,7 +590,7 @@ class CDbCriteria extends CComponent
 			$scopes2=(array)$criteria->scopes;
 			foreach($scopes1 as $k=>$v)
 			{
-				if(is_integer($k))
+				if(is_int($k))
 					$scopes[]=$v;
 				elseif(isset($scopes2[$k]))
 					$scopes[]=array($k=>$v);
@@ -599,7 +599,7 @@ class CDbCriteria extends CComponent
 			}
 			foreach($scopes2 as $k=>$v)
 			{
-				if(is_integer($k))
+				if(is_int($k))
 					$scopes[]=$v;
 				elseif(isset($scopes1[$k]))
 					$scopes[]=array($k=>$v);
@@ -616,7 +616,7 @@ class CDbCriteria extends CComponent
 			$this->with=(array)$this->with;
 			foreach((array)$criteria->with as $k=>$v)
 			{
-				if(is_integer($k))
+				if(is_int($k))
 					$this->with[]=$v;
 				elseif(isset($this->with[$k]))
 				{

--- a/framework/web/helpers/CJavaScript.php
+++ b/framework/web/helpers/CJavaScript.php
@@ -73,7 +73,7 @@ class CJavaScript
 			return 'null';
 		elseif(is_bool($value))
 			return $value?'true':'false';
-		elseif(is_integer($value))
+		elseif(is_int($value))
 			return "$value";
 		elseif(is_float($value))
 		{

--- a/framework/yiilite.php
+++ b/framework/yiilite.php
@@ -2097,7 +2097,7 @@ class CMap extends CComponent implements IteratorAggregate,ArrayAccess,Countable
 			$next=array_shift($args);
 			foreach($next as $k => $v)
 			{
-				if(is_integer($k))
+				if(is_int($k))
 					isset($res[$k]) ? $res[]=$v : $res[$k]=$v;
 				elseif(is_array($v) && isset($res[$k]) && is_array($res[$k]))
 					$res[$k]=self::mergeArray($res[$k],$v);
@@ -8110,7 +8110,7 @@ abstract class CActiveRecord extends CModel
 			$values=array();
 			foreach($attributes as $name=>$value)
 			{
-				if(is_integer($name))
+				if(is_int($name))
 					$values[$value]=$this->$value;
 				else
 					$values[$name]=$this->$name=$value;
@@ -8241,7 +8241,7 @@ abstract class CActiveRecord extends CModel
 			$c=$this->getDbCriteria();
 			foreach((array)$criteria->scopes as $k=>$v)
 			{
-				if(is_integer($k))
+				if(is_int($k))
 				{
 					if(is_string($v))
 					{

--- a/framework/zii/widgets/CListView.php
+++ b/framework/zii/widgets/CListView.php
@@ -312,7 +312,7 @@ class CListView extends CBaseListView
 		foreach($this->sortableAttributes as $name=>$label)
 		{
 			echo "<li>";
-			if(is_integer($name))
+			if(is_int($name))
 				echo $sort->link($label);
 			else
 				echo $sort->link($name,$label);


### PR DESCRIPTION
## Summary

Replace all framework calls to `is_integer()` with the canonical `is_int()` alias.

## Motivation

PHP 8.6 deprecates `is_integer()` and recommends `is_int()` instead.

RFC:
https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_is_integer

## Tests

Relevant framework tests: 19 tests, 47 assertions.