### PR TITLE
Update README.md show support for php 8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Thank you for choosing Yii - a high-performance component-based PHP framework.
   and will only receive necessary security fixes and fixes to adjust the code for compatibility with PHP 7 and 8 if they do not cause breaking changes.
   This allows you to keep your servers PHP version up to date in the environments where old Yii 1.1 applications are hosted and stay within the [version ranges supported by the PHP team](https://php.net/supported-versions.php).
 > 
-> Currently tested and supported [up to PHP 8.4](https://github.com/yiisoft/yii/blob/master/.github/workflows/build.yml#L36).
+> Currently tested and supported [up to PHP 8.5](https://github.com/yiisoft/yii/blob/master/.github/workflows/build.yml#L36).
 
 INSTALLATION
 ------------


### PR DESCRIPTION
Currently there are tests for php 8.5 but in the readme we show only support for php 8.4

<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | updated readme to indicate support for php8.5