### PR TITLE
PHP 8.5 compatibility fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,9 +4,9 @@
 Version 1.1.33 under development
 --------------------------------
 
-- Bug #4627: Replace deprecated `is_integer()` calls with `is_int()` for PHP 8.6 (ac-dc)
-- Bug #4598: PHP 8.5 compatibility: Fix deprecated non-canonical casts to canonical forms (ac-dc)
 - Bug #4607: Fix loading CHttpSessionHandler when using yiilite on Yii 1.1.32 and PHP 7+ (tance77, marcovtwout)
+- Enh #4598: Added support for PHP 8.5 (marcovtwout, ac-dc)
+- Enh #4627: Replace deprecated `is_integer()` calls with `is_int()` for PHP 8.6 (ac-dc)
 
 Version 1.1.32 December 23, 2025
 --------------------------------

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Thank you for choosing Yii - a high-performance component-based PHP framework.
   and will only receive necessary security fixes and fixes to adjust the code for compatibility with PHP 7 and 8 if they do not cause breaking changes.
   This allows you to keep your servers PHP version up to date in the environments where old Yii 1.1 applications are hosted and stay within the [version ranges supported by the PHP team](https://php.net/supported-versions.php).
 > 
-> Currently tested and supported [up to PHP 8.4](https://github.com/yiisoft/yii/blob/master/.github/workflows/build.yml#L36).
+> Currently tested and supported [up to PHP 8.5](https://github.com/yiisoft/yii/blob/master/.github/workflows/build.yml#L29).
 
 INSTALLATION
 ------------

--- a/framework/db/ar/CActiveFinder.php
+++ b/framework/db/ar/CActiveFinder.php
@@ -463,7 +463,7 @@ class CJoinElement
 	public function lazyFind($baseRecord)
 	{
 		if(is_string($this->_table->primaryKey))
-			$this->records[$baseRecord->{$this->_table->primaryKey}]=$baseRecord;
+			$this->records[(string)$baseRecord->{$this->_table->primaryKey}]=$baseRecord;
 		else
 		{
 			$pk=array();
@@ -697,7 +697,7 @@ class CJoinElement
 		if(is_string($this->_table->primaryKey))
 		{
 			foreach($baseRecords as $baseRecord)
-				$this->records[$baseRecord->{$this->_table->primaryKey}]=$baseRecord;
+				$this->records[(string)$baseRecord->{$this->_table->primaryKey}]=$baseRecord;
 		}
 		else
 		{

--- a/framework/web/auth/CPhpAuthManager.php
+++ b/framework/web/auth/CPhpAuthManager.php
@@ -75,9 +75,9 @@ class CPhpAuthManager extends CAuthManager
 		{
 			if(in_array($itemName,$this->defaultRoles))
 				return true;
-			if(isset($this->_assignments[$userId][$itemName]))
+			if(isset($this->_assignments[(string)$userId][$itemName]))
 			{
-				$assignment=$this->_assignments[$userId][$itemName];
+				$assignment=$this->_assignments[(string)$userId][$itemName];
 				if($this->executeBizRule($assignment->getBizRule(),$params,$assignment->getData()))
 					return true;
 			}
@@ -177,11 +177,11 @@ class CPhpAuthManager extends CAuthManager
 	{
 		if(!isset($this->_items[$itemName]))
 			throw new CException(Yii::t('yii','Unknown authorization item "{name}".',array('{name}'=>$itemName)));
-		elseif(isset($this->_assignments[$userId][$itemName]))
+		elseif(isset($this->_assignments[(string)$userId][$itemName]))
 			throw new CException(Yii::t('yii','Authorization item "{item}" has already been assigned to user "{user}".',
 				array('{item}'=>$itemName,'{user}'=>$userId)));
 		else
-			return $this->_assignments[$userId][$itemName]=new CAuthAssignment($this,$itemName,$userId,$bizRule,$data);
+			return $this->_assignments[(string)$userId][$itemName]=new CAuthAssignment($this,$itemName,$userId,$bizRule,$data);
 	}
 
 	/**
@@ -192,9 +192,9 @@ class CPhpAuthManager extends CAuthManager
 	 */
 	public function revoke($itemName,$userId)
 	{
-		if(isset($this->_assignments[$userId][$itemName]))
+		if(isset($this->_assignments[(string)$userId][$itemName]))
 		{
-			unset($this->_assignments[$userId][$itemName]);
+			unset($this->_assignments[(string)$userId][$itemName]);
 			return true;
 		}
 		else
@@ -209,7 +209,7 @@ class CPhpAuthManager extends CAuthManager
 	 */
 	public function isAssigned($itemName,$userId)
 	{
-		return isset($this->_assignments[$userId][$itemName]);
+		return isset($this->_assignments[(string)$userId][$itemName]);
 	}
 
 	/**
@@ -221,7 +221,7 @@ class CPhpAuthManager extends CAuthManager
 	 */
 	public function getAuthAssignment($itemName,$userId)
 	{
-		return isset($this->_assignments[$userId][$itemName])?$this->_assignments[$userId][$itemName]:null;
+		return isset($this->_assignments[(string)$userId][$itemName])?$this->_assignments[(string)$userId][$itemName]:null;
 	}
 
 	/**
@@ -232,7 +232,7 @@ class CPhpAuthManager extends CAuthManager
 	 */
 	public function getAuthAssignments($userId)
 	{
-		return isset($this->_assignments[$userId])?$this->_assignments[$userId]:array();
+		return isset($this->_assignments[(string)$userId])?$this->_assignments[(string)$userId]:array();
 	}
 
 	/**

--- a/framework/web/widgets/captcha/CCaptchaAction.php
+++ b/framework/web/widgets/captcha/CCaptchaAction.php
@@ -286,7 +286,6 @@ class CCaptchaAction extends CAction
 		header('Content-Transfer-Encoding: binary');
 		header("Content-Type: image/png");
 		imagepng($image);
-		imagedestroy($image);
 	}
 
 	/**

--- a/tests/framework/db/ar/CActiveRecordTest.php
+++ b/tests/framework/db/ar/CActiveRecordTest.php
@@ -588,6 +588,22 @@ class CActiveRecordTest extends CTestCase
 		$this->assertNull($author);
 	}
 
+	public function testLazyRelationWithoutPrimaryKeyInSelect()
+	{
+		$post=Post::model()->find(array('select'=>'author_id','condition'=>'id=1'));
+		$this->assertNull($post->id);
+		$this->assertEquals('user1',$post->author->username);
+	}
+
+	public function testEagerRelationWithoutPrimaryKeyInSql()
+	{
+		$posts=Post::model()->with('author')->findAllBySql('SELECT title, author_id FROM posts ORDER BY id');
+		$this->assertEquals(5,count($posts));
+		$this->assertNull($posts[0]->id);
+		$this->assertEquals('user1',$posts[0]->author->username);
+		$this->assertEquals('user2',$posts[1]->author->username);
+	}
+
 	public function testRelationWithDynamicCondition()
 	{
 		$user=User::model()->with('posts')->findByPk(2);

--- a/tests/framework/web/CHttpRequestTest.php
+++ b/tests/framework/web/CHttpRequestTest.php
@@ -177,7 +177,7 @@ class CHttpRequestTest extends CTestCase
 					'subType'=>'html',
 					'baseType'=>null,
 					'params'=>array(
-						'q'=>(double)1,
+						'q'=>(float)1,
 					),
 				),
 				1,

--- a/tests/framework/web/auth/CWebUserTest.php
+++ b/tests/framework/web/auth/CWebUserTest.php
@@ -76,4 +76,15 @@ class CWebUserTest extends CTestCase
 		$this->assertFalse(Yii::app()->user->checkAccess('createPost'));
 		$this->assertFalse(Yii::app()->user->checkAccess('deletePost'));
 	}
+
+	public function testCheckAccessForGuestWithDefaultRole()
+	{
+		$auth = Yii::app()->authManager;
+		$auth->createOperation('readPost');
+		$auth->createRole('reader')->addChild('readPost');
+		$auth->defaultRoles = array('reader');
+
+		$this->assertTrue(Yii::app()->user->getIsGuest());
+		$this->assertTrue(Yii::app()->user->checkAccess('readPost'));
+	}
 }

--- a/tests/framework/web/helpers/CHtmlTest.php
+++ b/tests/framework/web/helpers/CHtmlTest.php
@@ -644,12 +644,10 @@ class CHtmlTest extends CTestCase
 			array(array('v1'),0,'defaultValue','v1'),
 			array(array('v1'),0.0,'defaultValue','v1'),
 
-			// Test $model as an array, with null as a key, see: https://github.com/yiisoft/yii/pull/4503#discussion_r1054516859
-			array(array(null=>'v1','k2'=>'v2'),null,'defaultValue','v1'),
-			array(array(null=>'v1','k2'=>'v2'),'','defaultValue','v1'),
+			// A null $attribute must not blindly return the default, see: https://github.com/yiisoft/yii/pull/4503#discussion_r1054516859
 			array(array(''=>'v1','k2'=>'v2'),null,'defaultValue','v1'),
 			array(array(''=>'v1','k2'=>'v2'),'','defaultValue','v1'),
-			array(array(null=>'v1','k2'=>'v2'),'k2','defaultValue','v2'),
+			array(array(''=>'v1','k2'=>'v2'),'k2','defaultValue','v2'),
 		);
 
 		// create_function is not supported by CHtml::value(), we're just testing this feature/property


### PR DESCRIPTION
<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | https://github.com/yiisoft/yii/issues/4598

Depends on https://github.com/yiisoft/yii/pull/4631 which adds 8.5 support for HTMLPurifier
